### PR TITLE
[Feat] Add command catalog discovery

### DIFF
--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -1,0 +1,149 @@
+package lathe
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/samzong/lathe/pkg/config"
+	"github.com/samzong/lathe/pkg/runtime"
+)
+
+func commandsCmd(m *config.Manifest) *cobra.Command {
+	var jsonOut bool
+	var includeHidden bool
+	cmd := &cobra.Command{
+		Use:   "commands",
+		Short: "List generated commands",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			catalog := runtime.BuildCatalog(cmd.Root(), catalogOptions(m, includeHidden))
+			if jsonOut {
+				return writeJSON(cmd, catalog)
+			}
+			for i, entry := range catalog.Commands {
+				if i > 0 {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+				writeCommandSummary(cmd, entry)
+			}
+			return nil
+		},
+	}
+	addJSONFlag(cmd, &jsonOut, "Emit catalog JSON")
+	cmd.Flags().BoolVar(&includeHidden, "include-hidden", false, "Include hidden commands")
+	cmd.AddCommand(commandsShowCmd(m), commandsSchemaCmd())
+	return cmd
+}
+
+func commandsShowCmd(m *config.Manifest) *cobra.Command {
+	var jsonOut bool
+	var includeHidden bool
+	cmd := &cobra.Command{
+		Use:   "show <path...>",
+		Short: "Show one generated command",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			entry, ok := runtime.FindCatalogCommand(cmd.Root(), args, catalogOptions(m, includeHidden))
+			if !ok {
+				return fmt.Errorf("generated command not found: %s", strings.Join(args, " "))
+			}
+			if jsonOut {
+				return writeJSON(cmd, entry)
+			}
+			writeCommandSummary(cmd, entry)
+			if len(entry.Flags) > 0 {
+				fmt.Fprintln(cmd.OutOrStdout())
+				fmt.Fprintln(cmd.OutOrStdout(), "Flags:")
+				for _, flag := range entry.Flags {
+					required := ""
+					if flag.Required {
+						required = " required"
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "  --%s %s%s  %s\n", flag.Flag, flag.Type, required, flag.Help)
+				}
+			}
+			return nil
+		},
+	}
+	addJSONFlag(cmd, &jsonOut, "Emit command JSON")
+	cmd.Flags().BoolVar(&includeHidden, "include-hidden", false, "Include hidden commands")
+	return cmd
+}
+
+func commandsSchemaCmd() *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Print command catalog schema version",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			data := map[string]int{"catalog_schema_version": runtime.CatalogSchemaVersion}
+			if jsonOut {
+				return writeJSON(cmd, data)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "catalog schema %d\n", runtime.CatalogSchemaVersion)
+			return nil
+		},
+	}
+	addJSONFlag(cmd, &jsonOut, "Emit schema JSON")
+	return cmd
+}
+
+func searchCmd(m *config.Manifest) *cobra.Command {
+	var jsonOut bool
+	var limit int
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search generated commands",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.Join(args, " ")
+			results := runtime.SearchCatalog(cmd.Root(), query, runtime.SearchOptions{
+				CatalogOptions: catalogOptions(m, false),
+				Limit:          limit,
+			})
+			if jsonOut {
+				return writeJSON(cmd, results)
+			}
+			for i, result := range results {
+				if i > 0 {
+					fmt.Fprintln(cmd.OutOrStdout())
+				}
+				writeCommandSummary(cmd, result.Command)
+			}
+			return nil
+		},
+	}
+	addJSONFlag(cmd, &jsonOut, "Emit search results JSON")
+	cmd.Flags().IntVar(&limit, "limit", runtime.DefaultSearchLimit, "Maximum number of results")
+	return cmd
+}
+
+func catalogOptions(m *config.Manifest, includeHidden bool) runtime.CatalogOptions {
+	return runtime.CatalogOptions{
+		CLIName:       m.CLI.Name,
+		CLIVersion:    Version,
+		IncludeHidden: includeHidden,
+	}
+}
+
+func writeCommandSummary(cmd *cobra.Command, entry runtime.CatalogCommand) {
+	fmt.Fprintln(cmd.OutOrStdout(), strings.Join(entry.Path, " "))
+	if entry.Summary != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", entry.Summary)
+	}
+	if entry.HTTP.Method != "" || entry.HTTP.PathTemplate != "" {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s %s\n", entry.HTTP.Method, entry.HTTP.PathTemplate)
+	}
+}
+
+func writeJSON(cmd *cobra.Command, v any) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func addJSONFlag(cmd *cobra.Command, target *bool, usage string) {
+	cmd.Flags().BoolVar(target, "json", false, usage)
+}

--- a/pkg/lathe/catalog_test.go
+++ b/pkg/lathe/catalog_test.go
@@ -1,0 +1,130 @@
+package lathe
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/samzong/lathe/pkg/config"
+	"github.com/samzong/lathe/pkg/runtime"
+)
+
+func TestCommandsJSON_EmptyCatalog(t *testing.T) {
+	root := NewApp(testManifest())
+	out, err := execute(root, "commands", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, `"commands": []`) {
+		t.Fatalf("output missing empty commands array:\n%s", out)
+	}
+	var catalog runtime.Catalog
+	if err := json.Unmarshal([]byte(out), &catalog); err != nil {
+		t.Fatal(err)
+	}
+	if catalog.Commands == nil || len(catalog.Commands) != 0 {
+		t.Fatalf("commands = %#v", catalog.Commands)
+	}
+}
+
+func TestCommandsShowAndSearchJSON(t *testing.T) {
+	root := NewApp(testManifest())
+	runtime.Build(root, "demo", []runtime.CommandSpec{{
+		Group:       "Users",
+		Use:         "get-user",
+		Short:       "Get a user",
+		OperationID: "getUser",
+		Method:      "GET",
+		PathTpl:     "/users/{id}",
+		Params: []runtime.ParamSpec{
+			{Name: "id", Flag: "id", In: runtime.InPath, GoType: "string", Required: true, Help: "User id"},
+		},
+	}})
+
+	out, err := execute(root, "commands", "show", "demo", "users", "get-user", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry runtime.CatalogCommand
+	if err := json.Unmarshal([]byte(out), &entry); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(entry.Path, " ") != "demo users get-user" || entry.Group != "Users" {
+		t.Fatalf("entry = %+v", entry)
+	}
+
+	out, err = execute(root, "search", "getUser", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var results []runtime.SearchResult
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Command.Use != "get-user" {
+		t.Fatalf("results = %+v", results)
+	}
+}
+
+func TestCommandsShow_NotFound(t *testing.T) {
+	root := NewApp(testManifest())
+	_, err := execute(root, "commands", "show", "demo", "users", "missing")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCommandsSchemaJSON(t *testing.T) {
+	root := NewApp(testManifest())
+	out, err := execute(root, "commands", "schema", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var data map[string]int
+	if err := json.Unmarshal([]byte(out), &data); err != nil {
+		t.Fatal(err)
+	}
+	if data["catalog_schema_version"] != runtime.CatalogSchemaVersion {
+		t.Fatalf("schema = %d", data["catalog_schema_version"])
+	}
+}
+
+func TestSearchExcludesHiddenCommands(t *testing.T) {
+	root := NewApp(testManifest())
+	runtime.Build(root, "demo", []runtime.CommandSpec{{
+		Group:   "Users",
+		Use:     "delete-user",
+		Short:   "Delete a user",
+		Method:  "DELETE",
+		PathTpl: "/users/{id}",
+		Hidden:  true,
+	}})
+
+	out, err := execute(root, "search", "delete", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var results []runtime.SearchResult
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results = %+v", results)
+	}
+}
+
+func testManifest() *config.Manifest {
+	return &config.Manifest{CLI: config.CLIInfo{Name: "myctl", Short: "test cli", HostEnv: "MYCTL_HOST"}}
+}
+
+func execute(root *cobra.Command, args ...string) (string, error) {
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs(args)
+	err := root.Execute()
+	return buf.String(), err
+}

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -38,6 +38,8 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	authCmd := auth.NewCommand(m)
 	authCmd.GroupID = authGroupID
 	cmd.AddCommand(authCmd)
+	cmd.AddCommand(commandsCmd(m))
+	cmd.AddCommand(searchCmd(m))
 	cmd.AddCommand(versionCmd())
 	return cmd
 }

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -39,6 +39,7 @@ func Build(root *cobra.Command, service string, specs []CommandSpec) {
 			svc.AddCommand(g)
 		}
 		c := buildCmd(s)
+		AttachCatalogCommand(c, service, s)
 		g.AddCommand(c)
 	}
 	root.AddCommand(svc)

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -1,0 +1,404 @@
+package runtime
+
+import (
+	"encoding/json"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const CatalogSchemaVersion = 1
+const DefaultSearchLimit = 20
+
+const catalogCommandAnnotation = "lathe.catalog.command"
+
+type CatalogOptions struct {
+	CLIName       string
+	CLIVersion    string
+	IncludeHidden bool
+}
+
+type SearchOptions struct {
+	CatalogOptions
+	Limit int
+}
+
+type Catalog struct {
+	CatalogSchemaVersion int                  `json:"catalog_schema_version"`
+	CLI                  CatalogCLI           `json:"cli"`
+	Output               CatalogOutputFormats `json:"output"`
+	Commands             []CatalogCommand     `json:"commands"`
+}
+
+type CatalogCLI struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+type CatalogOutputFormats struct {
+	DefaultFormat string   `json:"default_format"`
+	Formats       []string `json:"formats"`
+}
+
+type CatalogCommand struct {
+	Path        []string      `json:"path"`
+	Service     string        `json:"service"`
+	Group       string        `json:"group"`
+	Use         string        `json:"use"`
+	Aliases     []string      `json:"aliases,omitempty"`
+	Summary     string        `json:"summary,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Example     string        `json:"example,omitempty"`
+	OperationID string        `json:"operation_id,omitempty"`
+	HTTP        CatalogHTTP   `json:"http"`
+	Auth        CatalogAuth   `json:"auth"`
+	Body        *CatalogBody  `json:"body,omitempty"`
+	Flags       []CatalogFlag `json:"flags"`
+	Output      CatalogOutput `json:"output"`
+	Hidden      bool          `json:"hidden"`
+	Deprecated  bool          `json:"deprecated"`
+}
+
+type CatalogHTTP struct {
+	Method       string `json:"method"`
+	PathTemplate string `json:"path_template"`
+}
+
+type CatalogAuth struct {
+	Required bool     `json:"required"`
+	Scopes   []string `json:"scopes,omitempty"`
+}
+
+type CatalogBody struct {
+	Required  bool   `json:"required"`
+	MediaType string `json:"media_type,omitempty"`
+}
+
+type CatalogFlag struct {
+	Name       string   `json:"name"`
+	Flag       string   `json:"flag"`
+	Location   string   `json:"location"`
+	Type       string   `json:"type"`
+	Required   bool     `json:"required"`
+	Default    string   `json:"default,omitempty"`
+	Enum       []string `json:"enum,omitempty"`
+	Format     string   `json:"format,omitempty"`
+	Deprecated bool     `json:"deprecated"`
+	Help       string   `json:"help,omitempty"`
+}
+
+type CatalogOutput struct {
+	ListPath          string             `json:"list_path,omitempty"`
+	DefaultColumns    []string           `json:"default_columns,omitempty"`
+	ResponseMediaType string             `json:"response_media_type,omitempty"`
+	Pagination        *CatalogPagination `json:"pagination,omitempty"`
+	Streaming         *CatalogStreaming  `json:"streaming,omitempty"`
+}
+
+type CatalogPagination struct {
+	Strategy   string `json:"strategy"`
+	TokenParam string `json:"token_param,omitempty"`
+	TokenField string `json:"token_field,omitempty"`
+	LimitParam string `json:"limit_param,omitempty"`
+}
+
+type CatalogStreaming struct {
+	Strategy string `json:"strategy"`
+}
+
+type SearchResult struct {
+	Score   int            `json:"score"`
+	Command CatalogCommand `json:"command"`
+}
+
+func AttachCatalogCommand(cmd *cobra.Command, service string, spec CommandSpec) {
+	entry := catalogCommand(service, spec, nil)
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		panic(err)
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[catalogCommandAnnotation] = string(raw)
+}
+
+func BuildCatalog(root *cobra.Command, opts CatalogOptions) Catalog {
+	if opts.CLIName == "" {
+		opts.CLIName = root.Use
+	}
+	commands := make([]CatalogCommand, 0)
+	walkCatalog(root, nil, opts, &commands)
+	sort.Slice(commands, func(i, j int) bool {
+		return slices.Compare(commands[i].Path, commands[j].Path) < 0
+	})
+	return Catalog{
+		CatalogSchemaVersion: CatalogSchemaVersion,
+		CLI:                  CatalogCLI{Name: opts.CLIName, Version: opts.CLIVersion},
+		Output:               CatalogOutputFormats{DefaultFormat: "table", Formats: FormatterNames()},
+		Commands:             commands,
+	}
+}
+
+func FindCatalogCommand(root *cobra.Command, path []string, opts CatalogOptions) (CatalogCommand, bool) {
+	cur := root
+	canonical := make([]string, 0, len(path))
+	for _, segment := range path {
+		child := findChildCommand(cur, segment)
+		if child == nil {
+			return CatalogCommand{}, false
+		}
+		canonical = append(canonical, child.Name())
+		cur = child
+	}
+	cmd, ok := catalogCommandFromAnnotation(cur, canonical)
+	if !ok || (!opts.IncludeHidden && cmd.Hidden) {
+		return CatalogCommand{}, false
+	}
+	return cmd, true
+}
+
+func SearchCatalog(root *cobra.Command, query string, opts SearchOptions) []SearchResult {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = DefaultSearchLimit
+	}
+	tokens := strings.Fields(strings.ToLower(query))
+	if len(tokens) == 0 {
+		return []SearchResult{}
+	}
+	results := make([]SearchResult, 0)
+	for _, cmd := range BuildCatalog(root, opts.CatalogOptions).Commands {
+		view := newSearchView(cmd)
+		score, ok := scoreCatalogCommand(view, tokens, strings.ToLower(query))
+		if !ok {
+			continue
+		}
+		results = append(results, SearchResult{Score: score, Command: cmd})
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return slices.Compare(results[i].Command.Path, results[j].Command.Path) < 0
+	})
+	if len(results) > limit {
+		results = results[:limit]
+	}
+	return results
+}
+
+func walkCatalog(cmd *cobra.Command, path []string, opts CatalogOptions, out *[]CatalogCommand) {
+	path = slices.Clone(path)
+	if cmd != nil && cmd.Parent() != nil {
+		path = append(path, cmd.Name())
+	}
+	if cc, ok := catalogCommandFromAnnotation(cmd, path); ok {
+		if opts.IncludeHidden || !cc.Hidden {
+			*out = append(*out, cc)
+		}
+	}
+	for _, child := range cmd.Commands() {
+		walkCatalog(child, path, opts, out)
+	}
+}
+
+func catalogCommandFromAnnotation(cmd *cobra.Command, path []string) (CatalogCommand, bool) {
+	if cmd == nil || cmd.Annotations == nil {
+		return CatalogCommand{}, false
+	}
+	raw := cmd.Annotations[catalogCommandAnnotation]
+	if raw == "" {
+		return CatalogCommand{}, false
+	}
+	var entry CatalogCommand
+	if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		return CatalogCommand{}, false
+	}
+	entry.Path = slices.Clone(path)
+	return entry, true
+}
+
+func findChildCommand(parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name || child.HasAlias(name) {
+			return child
+		}
+	}
+	return nil
+}
+
+func catalogCommand(service string, spec CommandSpec, path []string) CatalogCommand {
+	flags := make([]CatalogFlag, 0, len(spec.Params))
+	for _, p := range spec.Params {
+		flags = append(flags, CatalogFlag{
+			Name:       p.Name,
+			Flag:       p.Flag,
+			Location:   p.In,
+			Type:       p.GoType,
+			Required:   p.Required,
+			Default:    p.Default,
+			Enum:       append([]string(nil), p.Enum...),
+			Format:     p.Format,
+			Deprecated: p.Deprecated,
+			Help:       p.Help,
+		})
+	}
+	cmd := CatalogCommand{
+		Path:        append([]string(nil), path...),
+		Service:     service,
+		Group:       spec.Group,
+		Use:         spec.Use,
+		Aliases:     append([]string(nil), spec.Aliases...),
+		Summary:     spec.Short,
+		Description: spec.Long,
+		Example:     spec.Example,
+		OperationID: spec.OperationID,
+		HTTP:        CatalogHTTP{Method: spec.Method, PathTemplate: spec.PathTpl},
+		Auth:        catalogAuth(spec.Security),
+		Flags:       flags,
+		Output: CatalogOutput{
+			ListPath:          spec.Output.ListPath,
+			DefaultColumns:    append([]string(nil), spec.Output.DefaultColumns...),
+			ResponseMediaType: spec.Output.ResponseMediaType,
+			Pagination:        catalogPagination(spec.Output.Pagination),
+			Streaming:         catalogStreaming(spec.Output.Streaming),
+		},
+		Hidden:     spec.Hidden,
+		Deprecated: spec.Deprecated,
+	}
+	if spec.RequestBody != nil {
+		cmd.Body = &CatalogBody{Required: spec.RequestBody.Required, MediaType: spec.RequestBody.MediaType}
+	}
+	return cmd
+}
+
+func catalogPagination(p *PaginationHint) *CatalogPagination {
+	if p == nil {
+		return nil
+	}
+	return &CatalogPagination{
+		Strategy:   p.Strategy,
+		TokenParam: p.TokenParam,
+		TokenField: p.TokenField,
+		LimitParam: p.LimitParam,
+	}
+}
+
+func catalogStreaming(s *StreamingHint) *CatalogStreaming {
+	if s == nil {
+		return nil
+	}
+	return &CatalogStreaming{Strategy: s.Strategy}
+}
+
+func catalogAuth(security *SecurityHint) CatalogAuth {
+	if security == nil {
+		return CatalogAuth{Required: true}
+	}
+	return CatalogAuth{Required: !security.Public, Scopes: append([]string(nil), security.Scopes...)}
+}
+
+type searchView struct {
+	path         []string
+	fullPath     string
+	service      string
+	group        string
+	use          string
+	aliases      []string
+	summary      string
+	description  string
+	operationID  string
+	method       string
+	pathTemplate string
+	flags        []searchFlagView
+}
+
+type searchFlagView struct {
+	name string
+	flag string
+	help string
+}
+
+func newSearchView(cmd CatalogCommand) searchView {
+	aliases := make([]string, 0, len(cmd.Aliases))
+	for _, alias := range cmd.Aliases {
+		aliases = append(aliases, strings.ToLower(alias))
+	}
+	flags := make([]searchFlagView, 0, len(cmd.Flags))
+	for _, flag := range cmd.Flags {
+		flags = append(flags, searchFlagView{
+			name: strings.ToLower(flag.Name),
+			flag: strings.ToLower(flag.Flag),
+			help: strings.ToLower(flag.Help),
+		})
+	}
+	path := make([]string, 0, len(cmd.Path))
+	for _, segment := range cmd.Path {
+		path = append(path, strings.ToLower(segment))
+	}
+	return searchView{
+		path:         path,
+		fullPath:     strings.Join(path, " "),
+		service:      strings.ToLower(cmd.Service),
+		group:        strings.ToLower(cmd.Group),
+		use:          strings.ToLower(cmd.Use),
+		aliases:      aliases,
+		summary:      strings.ToLower(cmd.Summary),
+		description:  strings.ToLower(cmd.Description),
+		operationID:  strings.ToLower(cmd.OperationID),
+		method:       strings.ToLower(cmd.HTTP.Method),
+		pathTemplate: strings.ToLower(cmd.HTTP.PathTemplate),
+		flags:        flags,
+	}
+}
+
+func scoreCatalogCommand(cmd searchView, tokens []string, fullQuery string) (int, bool) {
+	score := 0
+	for _, token := range tokens {
+		tokenScore := scoreToken(cmd, token)
+		if tokenScore == 0 {
+			return 0, false
+		}
+		score += tokenScore
+	}
+	if fullQuery == cmd.fullPath || fullQuery == cmd.operationID || fullQuery == cmd.use {
+		score += 100
+	}
+	return score, true
+}
+
+func scoreToken(cmd searchView, token string) int {
+	score := 0
+	score = max(score, scoreField(cmd.operationID, token, 90))
+	score = max(score, scoreField(cmd.use, token, 80))
+	for _, alias := range cmd.aliases {
+		score = max(score, scoreField(alias, token, 80))
+	}
+	for _, segment := range cmd.path {
+		if strings.HasPrefix(segment, token) {
+			score = max(score, 60)
+		}
+	}
+	score = max(score, scoreField(cmd.pathTemplate, token, 45))
+	score = max(score, scoreField(cmd.summary, token, 30))
+	score = max(score, scoreField(cmd.description, token, 30))
+	score = max(score, scoreField(cmd.service, token, 30))
+	score = max(score, scoreField(cmd.group, token, 30))
+	score = max(score, scoreField(cmd.method, token, 30))
+	for _, flag := range cmd.flags {
+		score = max(score, scoreField(flag.flag, token, 25))
+		score = max(score, scoreField(flag.name, token, 25))
+		score = max(score, scoreField(flag.help, token, 10))
+	}
+	return score
+}
+
+func scoreField(field string, token string, value int) int {
+	if strings.Contains(field, token) {
+		return value
+	}
+	return 0
+}

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -1,0 +1,175 @@
+package runtime
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
+	root := newRootWithModuleGroup()
+	Build(root, "demo", []CommandSpec{
+		{
+			Group:       "Users",
+			Use:         "get-user",
+			Aliases:     []string{"show-user"},
+			Short:       "Get a user",
+			Long:        "Get one user by id.",
+			OperationID: "getUser",
+			Method:      "GET",
+			PathTpl:     "/users/{id}",
+			Params: []ParamSpec{
+				{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true, Help: "User id"},
+				{Name: "workspace", Flag: "workspace", In: InQuery, GoType: "string", Default: "default", Enum: []string{"default", "prod"}, Format: "slug", Help: "Target workspace"},
+			},
+			RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+			Output: OutputHints{
+				ListPath:          "data.items",
+				DefaultColumns:    []string{"id", "name"},
+				ResponseMediaType: "application/json",
+				Pagination:        &PaginationHint{Strategy: "cursor", TokenParam: "page_token", TokenField: "next_page_token", LimitParam: "limit"},
+				Streaming:         &StreamingHint{Strategy: "sse"},
+			},
+			Security: &SecurityHint{Scopes: []string{"users:read"}},
+		},
+	})
+
+	catalog := BuildCatalog(root, CatalogOptions{CLIName: "myctl", CLIVersion: "v1.2.3"})
+	if catalog.CatalogSchemaVersion != CatalogSchemaVersion {
+		t.Fatalf("schema = %d, want %d", catalog.CatalogSchemaVersion, CatalogSchemaVersion)
+	}
+	if catalog.CLI.Name != "myctl" || catalog.CLI.Version != "v1.2.3" {
+		t.Fatalf("cli = %+v", catalog.CLI)
+	}
+	if len(catalog.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(catalog.Commands))
+	}
+
+	cmd := catalog.Commands[0]
+	if !reflect.DeepEqual(cmd.Path, []string{"demo", "users", "get-user"}) {
+		t.Fatalf("path = %#v", cmd.Path)
+	}
+	if cmd.Group != "Users" {
+		t.Fatalf("group = %q, want original casing", cmd.Group)
+	}
+	if cmd.Service != "demo" || cmd.Use != "get-user" || cmd.OperationID != "getUser" {
+		t.Fatalf("command identity = %+v", cmd)
+	}
+	if cmd.Auth.Required != true || !reflect.DeepEqual(cmd.Auth.Scopes, []string{"users:read"}) {
+		t.Fatalf("auth = %+v", cmd.Auth)
+	}
+	if cmd.Body == nil || !cmd.Body.Required || cmd.Body.MediaType != "application/json" {
+		t.Fatalf("body = %+v", cmd.Body)
+	}
+	if len(cmd.Flags) != 2 {
+		t.Fatalf("flags = %d, want 2", len(cmd.Flags))
+	}
+	if cmd.Flags[0].Location != InPath || !cmd.Flags[0].Required {
+		t.Fatalf("path flag = %+v", cmd.Flags[0])
+	}
+	if cmd.Flags[1].Default != "default" || !reflect.DeepEqual(cmd.Flags[1].Enum, []string{"default", "prod"}) {
+		t.Fatalf("query flag = %+v", cmd.Flags[1])
+	}
+	if cmd.Output.Pagination == nil || cmd.Output.Pagination.TokenParam != "page_token" {
+		t.Fatalf("pagination = %+v", cmd.Output.Pagination)
+	}
+	if cmd.Output.Streaming == nil || cmd.Output.Streaming.Strategy != "sse" {
+		t.Fatalf("streaming = %+v", cmd.Output.Streaming)
+	}
+
+	raw, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var roundTrip Catalog
+	if err := json.Unmarshal(raw, &roundTrip); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(roundTrip.Commands[0].Path, cmd.Path) {
+		t.Fatalf("round-trip path = %#v", roundTrip.Commands[0].Path)
+	}
+}
+
+func TestBuildCatalog_HiddenCommands(t *testing.T) {
+	root := newRootWithModuleGroup()
+	Build(root, "demo", []CommandSpec{
+		{Group: "Users", Use: "get-user", Short: "Get a user", Method: "GET", PathTpl: "/users/{id}"},
+		{Group: "Users", Use: "delete-user", Short: "Delete a user", Method: "DELETE", PathTpl: "/users/{id}", Hidden: true},
+	})
+
+	catalog := BuildCatalog(root, CatalogOptions{})
+	if len(catalog.Commands) != 1 || catalog.Commands[0].Use != "get-user" {
+		t.Fatalf("visible commands = %+v", catalog.Commands)
+	}
+	catalog = BuildCatalog(root, CatalogOptions{IncludeHidden: true})
+	if len(catalog.Commands) != 2 {
+		t.Fatalf("all commands = %d, want 2", len(catalog.Commands))
+	}
+}
+
+func TestFindAndSearchCatalog(t *testing.T) {
+	root := newRootWithModuleGroup()
+	Build(root, "demo", []CommandSpec{
+		{
+			Group:       "Users",
+			Use:         "get-user",
+			Aliases:     []string{"show-user"},
+			Short:       "Get a user",
+			OperationID: "getUser",
+			Method:      "GET",
+			PathTpl:     "/users/{id}",
+			Params:      []ParamSpec{{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true, Help: "User id"}},
+		},
+		{
+			Group:       "Users",
+			Use:         "list-users",
+			Short:       "List users",
+			OperationID: "listUsers",
+			Method:      "GET",
+			PathTpl:     "/users",
+		},
+	})
+
+	cmd, ok := FindCatalogCommand(root, []string{"demo", "users", "get-user"}, CatalogOptions{})
+	if !ok || cmd.OperationID != "getUser" {
+		t.Fatalf("find = %+v, %v", cmd, ok)
+	}
+	cmd, ok = FindCatalogCommand(root, []string{"demo", "users", "show-user"}, CatalogOptions{})
+	if !ok || !reflect.DeepEqual(cmd.Path, []string{"demo", "users", "get-user"}) {
+		t.Fatalf("alias find = %+v, %v", cmd, ok)
+	}
+	if _, ok := FindCatalogCommand(root, []string{"demo", "users"}, CatalogOptions{}); ok {
+		t.Fatal("group container should not resolve as generated command")
+	}
+
+	for _, query := range []string{"getUser", "/users/{id}", "show-user", "id"} {
+		results := SearchCatalog(root, query, SearchOptions{Limit: 10})
+		if len(results) == 0 || results[0].Command.Use != "get-user" {
+			t.Fatalf("query %q results = %+v", query, results)
+		}
+	}
+
+	results := SearchCatalog(root, "users", SearchOptions{Limit: 1})
+	if len(results) != 1 {
+		t.Fatalf("limited results = %d, want 1", len(results))
+	}
+}
+
+func TestBuildCatalog_DefaultAuthRequired(t *testing.T) {
+	root := newRootWithModuleGroup()
+	Build(root, "demo", []CommandSpec{{
+		Group:   "Users",
+		Use:     "get-user",
+		Short:   "Get a user",
+		Method:  "GET",
+		PathTpl: "/users/{id}",
+	}})
+
+	catalog := BuildCatalog(root, CatalogOptions{})
+	if len(catalog.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(catalog.Commands))
+	}
+	if !catalog.Commands[0].Auth.Required {
+		t.Fatal("nil security should require auth to match runtime behavior")
+	}
+}

--- a/pkg/runtime/formatter.go
+++ b/pkg/runtime/formatter.go
@@ -1,6 +1,9 @@
 package runtime
 
-import "io"
+import (
+	"io"
+	"sort"
+)
 
 type Formatter interface {
 	Format(w io.Writer, data []byte, hints OutputHints) error
@@ -15,8 +18,38 @@ var formatters = map[string]Formatter{
 	"raw":   rawFormatter{},
 }
 
+var formatterAliases = map[string]string{"yml": "yaml"}
+
 func RegisterFormatter(name string, f Formatter) {
 	formatters[name] = f
+}
+
+func FormatterNames() []string {
+	canonical := []string{"table", "json", "yaml", "raw"}
+	seen := map[string]struct{}{}
+	names := make([]string, 0, len(formatters))
+	for _, name := range canonical {
+		if _, ok := formatters[name]; ok {
+			names = append(names, name)
+			seen[name] = struct{}{}
+		}
+	}
+	extra := make([]string, 0)
+	for name := range formatters {
+		if name == "" {
+			continue
+		}
+		if _, ok := formatterAliases[name]; ok {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		extra = append(extra, name)
+	}
+	sort.Strings(extra)
+	names = append(names, extra...)
+	return names
 }
 
 type tableFormatter struct{}

--- a/pkg/runtime/formatter_test.go
+++ b/pkg/runtime/formatter_test.go
@@ -67,3 +67,19 @@ func TestRegisterFormatter(t *testing.T) {
 		t.Errorf("got %q, want test", buf.String())
 	}
 }
+
+func TestFormatterNames(t *testing.T) {
+	RegisterFormatter("custom", rawFormatter{})
+	defer delete(formatters, "custom")
+
+	got := FormatterNames()
+	want := []string{"table", "json", "yaml", "raw", "custom"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
### What's changed?

- Add a versioned command catalog exposed through `commands`, `commands show`, and `commands schema`.
- Add catalog-backed `search` for generated commands.
- Attach catalog payloads to Cobra commands via annotations and cover path, hidden, alias, auth, formatter, and JSON behavior with tests.

### Why

- Gives humans and agents a structured source of truth for generated CLI commands without scraping help output.