### PR TITLE
[Fix] Cap debug response buffering

### DIFF
--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -59,7 +59,7 @@ func HTTPClient(opts ClientOptions) *http.Client {
 		maxRetries = 3
 	}
 	if maxRetries > 0 {
-		transport = &retryTransport{inner: transport, maxRetries: maxRetries}
+		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug}
 	}
 	if opts.Debug {
 		transport = &debugTransport{inner: transport}

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -1,11 +1,19 @@
 package runtime
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"mime"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+)
+
+const (
+	maxDebugReqBody  = 1024
+	maxDebugRespBody = 4096
 )
 
 type debugTransport struct {
@@ -20,6 +28,11 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			v = "***"
 		}
 		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, v)
+	}
+	if req.Body != nil && isTextContent(req.Header.Get("Content-Type")) {
+		body, restored := peekBody(req.Body, maxDebugReqBody)
+		req.Body = restored
+		dumpBody(os.Stderr, ">", body, maxDebugReqBody)
 	}
 	fmt.Fprintln(os.Stderr)
 
@@ -36,7 +49,53 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for k, vs := range resp.Header {
 		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, strings.Join(vs, ", "))
 	}
+	if isTextContent(resp.Header.Get("Content-Type")) {
+		body, restored := peekBody(resp.Body, maxDebugRespBody)
+		resp.Body = restored
+		dumpBody(os.Stderr, "<", body, maxDebugRespBody)
+	}
 	fmt.Fprintln(os.Stderr)
 
 	return resp, nil
+}
+
+type bodyReader struct {
+	io.Reader
+	io.Closer
+}
+
+func isTextContent(ct string) bool {
+	if ct == "" {
+		return false
+	}
+	mt, _, _ := mime.ParseMediaType(ct)
+	switch {
+	case strings.HasPrefix(mt, "text/"):
+		return true
+	case mt == "application/json", mt == "application/xml", mt == "application/x-www-form-urlencoded":
+		return true
+	}
+	return false
+}
+
+func peekBody(body io.ReadCloser, max int) ([]byte, io.ReadCloser) {
+	peeked, err := io.ReadAll(io.LimitReader(body, int64(max)+1))
+	restored := bodyReader{Reader: io.MultiReader(bytes.NewReader(peeked), body), Closer: body}
+	if err != nil {
+		return nil, restored
+	}
+	return peeked, restored
+}
+
+func dumpBody(w io.Writer, prefix string, body []byte, max int) {
+	if len(body) == 0 {
+		return
+	}
+	if len(body) > max {
+		fmt.Fprintf(w, "%s [body at least %d bytes, showing first %d]\n", prefix, len(body), max)
+		fmt.Fprintln(w, string(body[:max]))
+	} else {
+		fmt.Fprintf(w, "%s [body %d bytes]\n", prefix, len(body))
+		fmt.Fprintln(w, string(body))
+	}
 }

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -1,0 +1,160 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStderr(t *testing.T) *os.File {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() {
+		w.Close()
+		os.Stderr = os.NewFile(2, "/dev/stderr")
+	})
+	return r
+}
+
+func readStderr(t *testing.T, r *os.File) string {
+	t.Helper()
+	os.Stderr.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
+func TestDebugTransport_LogsJSONBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	body := strings.NewReader(`{"name":"test"}`)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	if !strings.Contains(out, `{"name":"test"}`) {
+		t.Errorf("stderr missing request body:\n%s", out)
+	}
+	if !strings.Contains(out, `{"result":"ok"}`) {
+		t.Errorf("stderr missing response body:\n%s", out)
+	}
+	if !strings.Contains(out, "[body") {
+		t.Errorf("stderr missing body size label:\n%s", out)
+	}
+}
+
+func TestDebugTransport_TruncatesLargeBody(t *testing.T) {
+	large := strings.Repeat("x", 5000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(large))
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	if !strings.Contains(out, "showing first 4096") {
+		t.Errorf("stderr missing truncation label:\n%s", out)
+	}
+}
+
+func TestDebugTransport_SkipsBinaryBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte{0x89, 0x50, 0x4e, 0x47})
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	if strings.Contains(out, "[body") {
+		t.Errorf("stderr should not contain body dump for binary content:\n%s", out)
+	}
+}
+
+func TestDebugTransport_PreservesResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":1}`))
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	readStderr(t, r)
+
+	if string(body) != `{"data":1}` {
+		t.Errorf("response body = %q, want %q", string(body), `{"data":1}`)
+	}
+}
+
+func TestIsTextContent(t *testing.T) {
+	tests := []struct {
+		ct   string
+		want bool
+	}{
+		{"application/json", true},
+		{"application/xml", true},
+		{"text/plain", true},
+		{"text/html", true},
+		{"application/x-www-form-urlencoded", true},
+		{"image/png", false},
+		{"application/octet-stream", false},
+		{"", false},
+		{"application/json; charset=utf-8", true},
+	}
+	for _, tc := range tests {
+		if got := isTextContent(tc.ct); got != tc.want {
+			t.Errorf("isTextContent(%q) = %v, want %v", tc.ct, got, tc.want)
+		}
+	}
+}

--- a/pkg/runtime/retry.go
+++ b/pkg/runtime/retry.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"fmt"
 	"math"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 )
@@ -11,6 +13,7 @@ type retryTransport struct {
 	inner      http.RoundTripper
 	maxRetries int
 	sleepFn    func(time.Duration)
+	debug      bool
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -20,6 +23,15 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for attempt := 0; attempt <= t.maxRetries; attempt++ {
 		if attempt > 0 {
 			wait := retryBackoff(attempt, resp)
+			if t.debug {
+				reason := "backoff"
+				if resp != nil {
+					if ra := resp.Header.Get("Retry-After"); ra != "" {
+						reason = "Retry-After=" + ra
+					}
+				}
+				fmt.Fprintf(os.Stderr, "[retry %d/%d] %s - waiting %s (%s)\n", attempt, t.maxRetries, resp.Status, wait, reason)
+			}
 			if t.sleepFn != nil {
 				t.sleepFn(wait)
 			} else {


### PR DESCRIPTION
### What's changed?

- Log text request and response bodies in debug mode without consuming the caller-visible body.
- Cap debug response peeking before restoring the unread remainder for normal response reads.
- Add runtime debug transport tests for text, binary, truncation, and body preservation.

### Why

- Prevent debug logging from buffering large text responses before DoRawFull reads them.