### PR TITLE
[Fix] Handle body string fields and schema errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ lathe handles everything else.
 - **Three native backends** — Swagger 2.0, OpenAPI 3, and `.proto` (with `google.api.http`). Each consumed in its real form; no cross-transcoding.
 - **Reproducible** — every spec pinned at an immutable tag; floating branches rejected. Commit SHA recorded and verified.
 - **Hostname-keyed auth** — per-host credentials modeled on `gh`. Public endpoints skip auth; scoped endpoints show required OAuth scopes.
-- **Rich CLI** — body builder (`--file`, `--set`), `-o table|json|yaml|raw`, enum validation, cursor-based pagination (`--all`), SSE streaming, parameter defaults and deprecation warnings.
+- **Rich CLI** — body builder (`--file`, `--set`, `--set-str`), `-o table|json|yaml|raw`, enum validation, cursor-based pagination (`--all`), SSE streaming, parameter defaults and deprecation warnings.
 - **Overlay layer** — polish help text, aliases, and examples per-module without editing generated code.
 - **Extensible** — `Authenticator` and `Formatter` interfaces for custom auth schemes and output formats.
 - **Production-ready** — typed error model with stable exit codes (0–4), `--debug` HTTP tracing, schema version contract between generated code and runtime.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,7 @@ sequenceDiagram
         Host-->>Runner: selected host + credentials
     end
 
-    Runner->>Body: assemble body (--file, --set dotted.paths)
+    Runner->>Body: assemble body (--file, --set dotted.paths, --set-str dotted.paths)
     Body-->>Runner: JSON payload
 
     Runner->>HTTP: method + PathTpl(params) + body + auth header

--- a/examples/petstore/README.md
+++ b/examples/petstore/README.md
@@ -46,4 +46,4 @@ See the [Quick start](../../README.md#quick-start) in the main README. The key f
 
 - **`cli.yaml`** — CLI name, description, auth endpoint
 - **`specs/sources.yaml`** — upstream specs pinned at immutable tags
-- **`cmd/<name>/main.go`** — embed `cli.yaml`, call `lathe.NewApp` + `generated.MountModules`
+- **`cmd/<name>/main.go`** — embed `cli.yaml`, call `lathe.NewApp`, then handle `generated.MountModules` errors

--- a/examples/petstore/run.sh
+++ b/examples/petstore/run.sh
@@ -117,6 +117,7 @@ package main
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 
 	"github.com/samzong/lathe/pkg/config"
@@ -136,7 +137,10 @@ func main() {
 	}
 	config.Bind(m)
 	root := lathe.NewApp(m)
-	generated.MountModules(root)
+	if err := generated.MountModules(root); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	os.Exit(runtime.Execute(root))
 }
 GOEOF

--- a/examples/richapi/run.sh
+++ b/examples/richapi/run.sh
@@ -309,6 +309,7 @@ package main
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 
 	"github.com/samzong/lathe/pkg/config"
@@ -328,7 +329,10 @@ func main() {
 	}
 	config.Bind(m)
 	root := lathe.NewApp(m)
-	generated.MountModules(root)
+	if err := generated.MountModules(root); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	os.Exit(runtime.Execute(root))
 }
 GOEOF

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -147,9 +147,12 @@ import (
 
 const generatedSchemaVersion = {{.SchemaVersion}}
 
-func Mount(root *cobra.Command) {
-	runtime.AssertSchema(generatedSchemaVersion)
+func Mount(root *cobra.Command) error {
+	if err := runtime.AssertSchema(generatedSchemaVersion); err != nil {
+		return err
+	}
 	runtime.Build(root, {{printf "%q" .Module}}, Specs)
+	return nil
 }
 
 var Specs = []runtime.CommandSpec{
@@ -240,10 +243,13 @@ import (
 // The import list above is the single source of truth for which modules
 // are compiled into this binary. main.go wires this call after
 // app.NewApp() so the framework package never imports downstream code.
-func MountModules(root *cobra.Command) {
+func MountModules(root *cobra.Command) error {
 {{- range .Modules}}
-	{{.}}.Mount(root)
+	if err := {{.}}.Mount(root); err != nil {
+		return err
+	}
 {{- end}}
+	return nil
 }
 `))
 

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -45,7 +45,9 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`"addon-install"`,
 		`"untouched short"`,
 		`generatedSchemaVersion`,
-		`runtime.AssertSchema`,
+		`func Mount(root *cobra.Command) error`,
+		`if err := runtime.AssertSchema(generatedSchemaVersion); err != nil`,
+		`return err`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q", want)
@@ -175,5 +177,35 @@ func TestRenderModule_NilOverrides(t *testing.T) {
 	}
 	if !strings.Contains(string(out), `"raw short"`) {
 		t.Errorf("expected raw short preserved when overrides is nil")
+	}
+}
+
+func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll("internal/generated", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RenderModulesGen([]string{"alpha", "beta"}); err != nil {
+		t.Fatalf("RenderModulesGen: %v", err)
+	}
+	out, err := os.ReadFile("internal/generated/modules_gen.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`func MountModules(root *cobra.Command) error`,
+		`if err := alpha.Mount(root); err != nil`,
+		`if err := beta.Mount(root); err != nil`,
+		`return err`,
+		`return nil`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q", want)
+		}
 	}
 }

--- a/pkg/runtime/body.go
+++ b/pkg/runtime/body.go
@@ -23,21 +23,42 @@ func ReadBody(path string) ([]byte, error) {
 // otherwise string. No schema validation — runtime stays schema-agnostic;
 // the spec only carries a SchemaRef for future use.
 func BuildBodyFromSet(sets []string) ([]byte, error) {
+	return buildBodyFromSet(sets, nil)
+}
+
+func buildBodyFromSet(sets []string, stringSets []string) ([]byte, error) {
 	out := map[string]any{}
 	for _, kv := range sets {
-		eq := strings.Index(kv, "=")
-		if eq < 0 {
-			return nil, fmt.Errorf("invalid --set %q (expected key=value)", kv)
+		path, value, err := parseSet(kv, "--set")
+		if err != nil {
+			return nil, err
 		}
-		path := kv[:eq]
-		if path == "" {
-			return nil, fmt.Errorf("invalid --set %q (empty key)", kv)
+		if err := setNested(out, strings.Split(path, "."), inferValue(value)); err != nil {
+			return nil, err
 		}
-		if err := setNested(out, strings.Split(path, "."), inferValue(kv[eq+1:])); err != nil {
+	}
+	for _, kv := range stringSets {
+		path, value, err := parseSet(kv, "--set-str")
+		if err != nil {
+			return nil, err
+		}
+		if err := setNested(out, strings.Split(path, "."), value); err != nil {
 			return nil, err
 		}
 	}
 	return json.Marshal(out)
+}
+
+func parseSet(kv string, flag string) (string, string, error) {
+	eq := strings.Index(kv, "=")
+	if eq < 0 {
+		return "", "", fmt.Errorf("invalid %s %q (expected key=value)", flag, kv)
+	}
+	path := kv[:eq]
+	if path == "" {
+		return "", "", fmt.Errorf("invalid %s %q (empty key)", flag, kv)
+	}
+	return path, kv[eq+1:], nil
 }
 
 func setNested(m map[string]any, keys []string, v any) error {

--- a/pkg/runtime/body_test.go
+++ b/pkg/runtime/body_test.go
@@ -48,6 +48,32 @@ func TestBuildBodyFromSet(t *testing.T) {
 	}
 }
 
+func TestBuildBodyFromSet_SetStrKeepsStrings(t *testing.T) {
+	raw, err := buildBodyFromSet(
+		[]string{"spec.replicas=3", "spec.enabled=true"},
+		[]string{"spec.stringReplicas=3", "spec.stringEnabled=true", "metadata.name=demo"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	want := map[string]any{
+		"spec": map[string]any{
+			"replicas":       float64(3),
+			"enabled":        true,
+			"stringReplicas": "3",
+			"stringEnabled":  "true",
+		},
+		"metadata": map[string]any{"name": "demo"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
 func TestBuildBodyFromSet_Errors(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -15,13 +15,14 @@ import (
 // segregate modules from core commands (e.g. auth) and from completion/help.
 const ModuleGroupID = "modules"
 
-func AssertSchema(generated int) {
+func AssertSchema(generated int) error {
 	if generated != SchemaVersion {
-		panic(fmt.Sprintf(
+		return fmt.Errorf(
 			"lathe schema mismatch: generated code uses schema %d but runtime expects %d — re-run codegen",
 			generated, SchemaVersion,
-		))
+		)
 	}
+	return nil
 }
 
 // Build mounts a service command tree under root, driven entirely by specs.
@@ -49,6 +50,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	vals := make(map[string]any, len(s.Params))
 	var bodyFile string
 	var bodySets []string
+	var bodyStringSets []string
 	var paginateAll bool
 	var maxPages int
 	var waitPoll bool
@@ -145,8 +147,8 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				body = form
 			} else if s.RequestBody != nil {
 				switch {
-				case cmd.Flags().Changed("set"):
-					raw, berr := BuildBodyFromSet(bodySets)
+				case cmd.Flags().Changed("set") || cmd.Flags().Changed("set-str"):
+					raw, berr := buildBodyFromSet(bodySets, bodyStringSets)
 					if berr != nil {
 						return berr
 					}
@@ -158,7 +160,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 					}
 					body = raw
 				case s.RequestBody.Required:
-					return fmt.Errorf("request body required: pass --file or --set")
+					return fmt.Errorf("request body required: pass --file, --set, or --set-str")
 				}
 			}
 
@@ -248,13 +250,17 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	}
 	if s.RequestBody != nil {
 		fileHelp := "path to JSON body file, or '-' for stdin"
-		setHelp := "set body field, e.g. --set spec.replicas=3 (repeatable; nested via dots)"
+		setHelp := "set body field with type inference, e.g. --set spec.replicas=3 (repeatable; nested via dots)"
+		setStrHelp := "set body field as string, e.g. --set-str spec.replicas=3 (repeatable; nested via dots)"
 		if s.RequestBody.Required {
-			fileHelp += " (use --file or --set)"
-			setHelp += " (use --file or --set)"
+			suffix := " (use --file, --set, or --set-str)"
+			fileHelp += suffix
+			setHelp += suffix
+			setStrHelp += suffix
 		}
 		cmd.Flags().StringVarP(&bodyFile, "file", "f", "", fileHelp)
-		cmd.Flags().StringSliceVar(&bodySets, "set", nil, setHelp)
+		cmd.Flags().StringArrayVar(&bodySets, "set", nil, setHelp)
+		cmd.Flags().StringArrayVar(&bodyStringSets, "set-str", nil, setStrHelp)
 	}
 	if s.Output.Pagination != nil {
 		cmd.Flags().BoolVar(&paginateAll, "all", false, "fetch all pages")

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1,6 +1,11 @@
 package runtime
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -73,21 +78,19 @@ func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 }
 
 func TestAssertSchema_Match(t *testing.T) {
-	AssertSchema(SchemaVersion)
+	if err := AssertSchema(SchemaVersion); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestAssertSchema_Mismatch(t *testing.T) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected panic on schema mismatch")
-		}
-		msg, ok := r.(string)
-		if !ok || !strings.Contains(msg, "re-run codegen") {
-			t.Errorf("unexpected panic value: %v", r)
-		}
-	}()
-	AssertSchema(SchemaVersion + 999)
+	err := AssertSchema(SchemaVersion + 999)
+	if err == nil {
+		t.Fatal("expected error on schema mismatch")
+	}
+	if !strings.Contains(err.Error(), "re-run codegen") {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestBuild_EmptySpecsMountsEmptyService(t *testing.T) {
@@ -116,10 +119,71 @@ func TestBuild_BodyFlagsAttachedWhenHasBody(t *testing.T) {
 	users := mustFindChild(t, svc, "users")
 	createUser := mustFindChild(t, users, "create-user")
 
-	for _, name := range []string{"file", "set"} {
+	for _, name := range []string{"file", "set", "set-str"} {
 		if createUser.Flag(name) == nil {
 			t.Errorf("create-user missing --%s flag", name)
 		}
+	}
+}
+
+func TestBuild_SetStrSendsStringBodyFields(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		rawBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	specs := []CommandSpec{{
+		Group:       "Users",
+		Use:         "create-user",
+		Method:      "POST",
+		PathTpl:     "/users",
+		RequestBody: &RequestBody{Required: true},
+		Security:    &SecurityHint{Public: true},
+	}}
+
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	Build(root, "demo", specs)
+	root.SetArgs([]string{
+		"--hostname", srv.URL,
+		"demo", "users", "create-user",
+		"--set", "spec.replicas=3",
+		"--set", "spec.enabled=true",
+		"--set-str", "spec.stringReplicas=3",
+		"--set-str", "spec.stringEnabled=true",
+		"--set-str", "spec.csv=a,b",
+	})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(rawBody, &got); err != nil {
+		t.Fatalf("invalid request JSON %q: %v", string(rawBody), err)
+	}
+	want := map[string]any{
+		"spec": map[string]any{
+			"replicas":       float64(3),
+			"enabled":        true,
+			"stringReplicas": "3",
+			"stringEnabled":  "true",
+			"csv":            "a,b",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
### What's changed?

- Add `--set-str` for request body fields that must remain JSON strings while keeping `--set` type inference.
- Use repeatable body flags without comma splitting.
- Propagate generated `Mount` / `MountModules` schema mismatch errors through the normal error path and update example wiring.

### Why

- Some APIs require string enum or numeric string fields that `--set` type inference cannot express.
- Stale generated code should fail with a clear returned error instead of crashing or being ignored.

### Verification

- `go test -count=1 ./pkg/runtime ./internal/codegen/render`
- `make check`