### PR TITLE
[Fix] Persist generated example skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.cache/
 /internal/generated/
 examples/*/bin/
+examples/*/skills/

--- a/examples/petstore/run.sh
+++ b/examples/petstore/run.sh
@@ -156,6 +156,11 @@ DEST="$LATHE_ROOT/examples/petstore/bin"
 mkdir -p "$DEST"
 cp bin/petstore "$DEST/petstore"
 
+SKILL_DEST="$LATHE_ROOT/examples/petstore/skills"
+rm -rf "$SKILL_DEST/petstore"
+mkdir -p "$SKILL_DEST"
+cp -R skills/petstore "$SKILL_DEST/petstore"
+
 # Demo
 echo ""
 echo "========== petstore --help =========="
@@ -165,3 +170,4 @@ echo "========== petstore pets --help =========="
 ./bin/petstore pets --help
 echo ""
 echo "Done. Binary saved to examples/petstore/bin/petstore"
+echo "Done. Skill saved to examples/petstore/skills/petstore"

--- a/examples/richapi/run.sh
+++ b/examples/richapi/run.sh
@@ -396,6 +396,12 @@ DEST="$LATHE_ROOT/examples/richapi/bin"
 mkdir -p "$DEST"
 cp bin/richapi "$DEST/richapi"
 
+SKILL_DEST="$LATHE_ROOT/examples/richapi/skills"
+rm -rf "$SKILL_DEST/richapi"
+mkdir -p "$SKILL_DEST"
+cp -R skills/richapi "$SKILL_DEST/richapi"
+
 echo "=========================================="
 echo "  Done. Binary saved to examples/richapi/bin/richapi"
+echo "  Done. Skill saved to examples/richapi/skills/richapi"
 echo "=========================================="


### PR DESCRIPTION
### What's changed?

- Copy generated Skill directories from the petstore and richapi example runs into `examples/<name>/skills/<name>/` alongside the existing binary output.
- Ignore `examples/*/skills/` as local generated example output, matching the existing `examples/*/bin/` behavior.

### Why

- Example runs should leave behind both the generated CLI binary and its agent-facing Skill so users can inspect or load the generated Skill after the script exits.
