### PR TITLE
[Build] Publish source archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -24,7 +24,7 @@ jobs:
       - name: Run tests
         run: go test -race ./...
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,22 +5,10 @@ project_name: lathe
 builds:
   - skip: true
 
-# lathe is a library/template — downstream projects build their own binary.
-# This goreleaser config packages source archives and creates GitHub releases
-# with changelogs so downstream consumers can pin lathe versions.
-
-archives:
-  - format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_source"
-    files:
-      - LICENSE
-      - README.md
-      - pkg/**/*
-      - internal/**/*
-      - cmd/**/*
-      - go.mod
-      - go.sum
-      - Makefile
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}_{{ .Version }}_source"
+  format: tar.gz
 
 changelog:
   sort: asc


### PR DESCRIPTION
### What's changed?

- Switch GoReleaser from the binary archive pipe to the source archive pipe so tag releases publish a source archive asset.
- Update GitHub Actions to Node 24-compatible action majors.

### Why

- The v0.2.0 release workflow succeeded but did not upload custom release assets because `archives` only packages built binaries and this project skips binary builds.
- The workflow also emitted Node 20 deprecation annotations that the newer action majors avoid.