### PR TITLE
fix(runtime): send params with defaults even when flag not explicitly set

### DIFF
--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -122,7 +122,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 					}
 					continue
 				}
-				if !cmd.Flags().Changed(p.Flag) {
+				if !cmd.Flags().Changed(p.Flag) && p.Default == "" {
 					continue
 				}
 				switch v := vals[p.Name].(type) {


### PR DESCRIPTION
Previously, query params were only added to the request if the flag was explicitly passed by the user (cmd.Flags().Changed). This caused params with non-zero defaults (e.g. page=1, pageSize=20) to be silently omitted, resulting in server-side errors when page=0 was rejected.