### PR TITLE
[Chore] Add project health and release foundations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Report incorrect generated CLI behavior, runtime behavior, or codegen output.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include a minimal reproduction so maintainers can verify the behavior quickly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What broke, and what did you expect instead?
+      placeholder: "Generated command sends the wrong request body for ..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Include the smallest spec/config shape and exact command sequence.
+      placeholder: |
+        1. Create cli.yaml with ...
+        2. Create specs/sources.yaml with ...
+        3. Run ...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Paste the relevant output, HTTP request shape, generated catalog entry, or error.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe the behavior Lathe should produce.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Lathe version, Go version, OS, and relevant tool versions.
+      placeholder: |
+        lathe: v0.2.1
+        go: go version ...
+        os: macOS/Linux/Windows ...
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Links, logs, screenshots, or notes. Redact tokens and secrets before posting.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/samzong/lathe/security/advisories/new
+    about: Please report vulnerabilities privately through GitHub Security Advisories.
+  - name: Contribution guide
+    url: https://github.com/samzong/lathe/blob/main/CONTRIBUTING.md
+    about: Read contribution workflow, scope, and local verification guidance.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Propose a scoped improvement to Lathe.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Lathe is a spec-to-agent-toolchain generator. Features should strengthen spec fidelity, reproducibility, generated command correctness, runtime catalog inspectability, auth/body/output behavior, or generated Skill quality.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user problem does this solve?
+      placeholder: "Agents cannot safely inspect ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should Lathe do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing workarounds, overlays, config, or external tools you considered.
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Affected surface
+      multiple: true
+      options:
+        - Swagger/OpenAPI/proto parsing
+        - Normalization/codegen
+        - Runtime HTTP/auth/body/output behavior
+        - Command catalog/search
+        - Generated Skill docs
+        - Release/install/docs/community
+    validations:
+      required: true
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility notes
+      description: Does this change generated command shape, catalog schema, or runtime behavior?

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changed and why? Keep it focused. -->
+
+## Verification
+
+<!-- Paste exact commands run, for example `make test` or `make check`. -->
+
+## Compatibility
+
+<!-- Note generated command shape, catalog schema, auth/body/output behavior, or docs changes. Write "None" if not applicable. -->
+
+## Checklist
+
+- [ ] Tests or focused verification cover the changed surface.
+- [ ] User-facing behavior changes are documented.
+- [ ] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
+- [ ] Commits are signed off when this is ready to merge.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "22 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - uses: github/codeql-action/autobuild@v4
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,32 @@
+name: scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "41 3 * * 2"
+  workflow_dispatch:
+
+jobs:
+  analysis:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,12 +3,59 @@ version: 2
 project_name: lathe
 
 builds:
-  - skip: true
+  - id: lathe-specsync
+    main: ./cmd/specsync
+    binary: lathe-specsync
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+  - id: lathe-codegen
+    main: ./cmd/codegen
+    binary: lathe-codegen
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - ids:
+      - lathe-specsync
+      - lathe-codegen
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 
 source:
   enabled: true
   name_template: "{{ .ProjectName }}_{{ .Version }}_source"
   format: tar.gz
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
 
 changelog:
   sort: asc

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,12 @@
+# Adopters
+
+No public adopters are listed yet.
+
+If you use Lathe in a public or internal project and can share a short note, open a pull request with:
+
+- Organization or project name.
+- API spec type: Swagger 2.0, OpenAPI 3, or protobuf with `google.api.http`.
+- Generated CLI use case.
+- Public link, if available.
+
+Private/internal users may list only a short anonymized note if public naming is not possible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+Lathe follows the Contributor Covenant Code of Conduct, version 2.1:
+
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+## Our Standards
+
+The Lathe community should be practical, respectful, and focused on improving the project. Good participation includes:
+
+- Explaining technical disagreements with evidence and clear tradeoffs.
+- Welcoming new users and contributors, including people who are still learning the project.
+- Keeping issue and PR discussions actionable.
+- Respecting different backgrounds, identities, experience levels, and viewpoints.
+
+Unacceptable behavior includes harassment, insults, intimidation, unwanted sexual attention, sustained off-topic disruption, or publishing private information without permission.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior. Maintainers may edit, hide, or remove comments, issues, pull requests, or other contributions that are not aligned with this Code of Conduct. Maintainers may also temporarily or permanently ban participants for harmful behavior.
+
+## Reporting
+
+Report Code of Conduct concerns privately to the maintainer:
+
+- GitHub: https://github.com/samzong
+
+Security vulnerabilities should not be reported through this process. Follow `SECURITY.md` for vulnerability reports.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,49 @@
+# Governance
+
+Lathe uses founder-led governance while the project is early. The goal is to keep decisions fast, technical, and aligned with the product boundary.
+
+## Decision Principles
+
+Maintainers prioritize:
+
+- Spec fidelity over manually authored command behavior.
+- Reproducible inputs over generated output drift.
+- Runtime safety over convenient but surprising API execution.
+- Agent inspectability over hidden behavior.
+- Small, reviewable changes over broad rewrites.
+
+## Maintainer Authority
+
+Maintainers can:
+
+- Accept or reject issues and pull requests.
+- Request design changes before implementation.
+- Close proposals that are outside Lathe's scope.
+- Cut releases and define release notes.
+- Enforce the Code of Conduct.
+
+## Decision Process
+
+Most changes are decided in issues and pull requests. A proposal should explain:
+
+- The user problem.
+- The affected surface.
+- Why existing configuration, overlays, or generated behavior are insufficient.
+- Compatibility impact for generated command shape, runtime catalog schema, auth, body handling, output, or generated Skills.
+- Verification evidence.
+
+For large changes, maintainers may ask for a short design issue before accepting an implementation PR.
+
+## Compatibility
+
+Lathe is pre-1.0. Breaking changes are allowed when they make the generated CLI safer, more correct, or easier to inspect, but they must be documented in release notes.
+
+Catalog schema changes should bump `runtime.CatalogSchemaVersion` and explain migration impact.
+
+## Releases
+
+Maintainers cut releases from signed tags. Release notes should explain user-visible changes, compatibility impact, and verification. Source archives, checksums, and installable binaries should be published for stable releases.
+
+## Becoming a Maintainer
+
+Maintainer access is earned through sustained, high-quality contributions that show judgment in Lathe's core areas: spec parsing, normalization, runtime behavior, catalog inspectability, docs, testing, and release hygiene.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,34 @@
+# Maintainers
+
+## Current Maintainers
+
+- samzong - project owner and release maintainer
+  - GitHub: https://github.com/samzong
+- scydas - project collaborator and code reviewer
+  - GitHub: https://github.com/scydas
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+- Triaging issues and pull requests.
+- Keeping project direction aligned with Lathe's product boundary.
+- Reviewing changes for correctness, safety, compatibility, and maintainability.
+- Cutting releases and publishing release notes.
+- Enforcing the Code of Conduct.
+- Responding to security reports according to `SECURITY.md`.
+
+## Review Expectations
+
+Pull requests should be reviewed for:
+
+- Whether the change fixes the stated problem.
+- Generated command correctness.
+- Runtime behavior for HTTP, auth, body, output, pagination, polling, and errors.
+- Catalog and generated Skill inspectability.
+- Focused tests or example runs that prove the changed surface.
+- Compatibility notes when generated behavior changes.
+
+## Security Reports
+
+Do not open public issues for vulnerabilities. Use GitHub Security Advisories as described in `SECURITY.md`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Generated CLIs ship with command catalog JSON, intent search, per-command detail
 JSON, auth metadata, body builders, structured output formats, and a repo-local
 Skill directory under `skills/<cli-name>/`.
 
+Try the local 60-second demo:
+
+```sh
+bash examples/petstore/run.sh
+```
+
+It generates a real CLI, then shows `search`, `commands show`, and `commands schema` output.
+
 ![lathe architecture](docs/images/architecture.png)
 
 ---
@@ -74,10 +82,30 @@ built, and which output format to prefer.
 | Real CLI UX | Hostname-keyed auth, --file, --set, --set-str, -o table\|json\|yaml\|raw, enum validation, pagination, streaming, and --debug. |
 | Overlay polish | Improve summaries, aliases, parameter help, grouping, and examples without editing generated code. |
 
+## Project Resources
+
+- [Governance](GOVERNANCE.md): decision process and compatibility expectations.
+- [Maintainers](MAINTAINERS.md): maintainer responsibilities and review expectations.
+- [Showcase](SHOWCASE.md): runnable demos and real-world usage notes.
+- [Adopters](ADOPTERS.md): public and anonymized user entries.
+- [Contributing](CONTRIBUTING.md): local setup, PR workflow, and project scope.
+- [Security](SECURITY.md): private vulnerability reporting and supported versions.
+
 ## Quick Start
 
 Create a repository from [github.com/samzong/lathe](https://github.com/samzong/lathe),
 then configure two files.
+
+### Install the Tools
+
+Lathe release archives include two command-line tools:
+
+- `lathe-specsync`: sync pinned upstream specs into the local cache.
+- `lathe-codegen`: generate runtime command specs and optional Skill files.
+
+Download the archive for your platform from the [latest release](https://github.com/samzong/lathe/releases/latest), unpack it, and put both binaries on your `PATH`.
+
+When working from a source checkout, you can use the Make targets shown below instead of installing the release tools.
 
 ### 1. Define the CLI
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,6 +15,14 @@ API 生成生产级 Cobra CLI，并内置结构化命令发现、认证元数据
 生成的 CLI 自带 command catalog JSON、意图搜索、单命令详情 JSON、认证元数据、
 请求体构造器、结构化输出，以及仓库内的 Skill 目录 `skills/<cli-name>/`。
 
+本地 60 秒 demo：
+
+```sh
+bash examples/petstore/run.sh
+```
+
+它会生成真实 CLI，并展示 `search`、`commands show` 和 `commands schema` 输出。
+
 ![lathe 架构图](docs/images/architecture.png)
 
 ---
@@ -66,10 +74,30 @@ Lathe 的判断很简单：API 规格才是事实来源，CLI 应该从规格生
 | 真实 CLI 体验 | 按 hostname 管理认证，支持 `--file`、`--set`、`--set-str`、`-o table|json|yaml|raw`、枚举校验、分页、流式响应和 `--debug`。 |
 | Overlay 润色 | 不改生成代码，也能补充摘要、别名、参数帮助、分组和示例。 |
 
+## 项目资源
+
+- [Governance](GOVERNANCE.md)：决策流程和兼容性预期。
+- [Maintainers](MAINTAINERS.md)：维护者职责和 review 预期。
+- [Showcase](SHOWCASE.md)：可运行 demo 和真实使用记录。
+- [Adopters](ADOPTERS.md)：公开或匿名用户条目。
+- [Contributing](CONTRIBUTING.md)：本地 setup、PR 流程和项目范围。
+- [Security](SECURITY.md)：私密漏洞报告和支持版本。
+
 ## 快速开始
 
 基于 [github.com/samzong/lathe](https://github.com/samzong/lathe) 创建仓库，
 然后配置两个文件。
+
+### 安装工具
+
+Lathe release archive 包含两个命令行工具：
+
+- `lathe-specsync`：把锁定版本的上游 API 规格同步到本地 cache。
+- `lathe-codegen`：生成 runtime command specs 和可选 Skill 文件。
+
+从 [latest release](https://github.com/samzong/lathe/releases/latest) 下载对应平台的 archive，解压后把两个二进制放进 `PATH`。
+
+如果你是在 source checkout 里工作，也可以继续使用下面的 Make targets，不需要单独安装 release 工具。
 
 ### 1. 定义 CLI
 

--- a/SHOWCASE.md
+++ b/SHOWCASE.md
@@ -1,0 +1,33 @@
+# Showcase
+
+This page collects runnable Lathe examples and public adoption notes.
+
+## 60-Second Demo
+
+Run the Petstore demo from a source checkout:
+
+```sh
+bash examples/petstore/run.sh
+```
+
+The script builds a generated CLI from a small OpenAPI 3 spec, then demonstrates the agent loop:
+
+1. `petstore search "list pets" --json`
+2. `petstore commands show pets pets list --json`
+3. `petstore commands schema --json`
+
+This is the core Lathe promise: agents discover commands, inspect exact contracts, check schema compatibility, and only then execute.
+
+## Examples
+
+- `examples/petstore`: minimal OpenAPI 3 workflow from spec to generated CLI.
+- `examples/richapi`: broader dogfood example covering pagination, enums, headers, request bodies, public endpoints, streaming hints, and long-running operation hints.
+
+## Add a Showcase
+
+Open a pull request adding a short entry when you use Lathe in a real project. Good entries include:
+
+- What API spec type you use.
+- What generated CLI workflow Lathe replaced.
+- Which catalog or agent workflow made the project safer or faster.
+- Public links when available.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,39 @@
+# Security Hardening
+
+This document tracks repository-level security controls for Lathe. Some controls live in versioned files, while others must be enabled in GitHub repository settings.
+
+## Versioned Controls
+
+- CI: `.github/workflows/ci.yml`
+- Release automation: `.github/workflows/release.yml`
+- CodeQL scanning: `.github/workflows/codeql.yml`
+- OpenSSF Scorecard: `.github/workflows/scorecard.yml`
+- Dependabot version updates: `.github/dependabot.yml`
+- Security policy: `SECURITY.md`
+
+## GitHub Settings
+
+Verified on 2026-05-18:
+
+- Dependabot vulnerability alerts: enabled through the GitHub API.
+- Dependabot automated security fixes: enabled through the GitHub API.
+
+Still required after the workflows land on `main`:
+
+- Protect `main`.
+- Require pull requests before merging.
+- Require at least one approving review.
+- Dismiss stale approvals when new commits are pushed.
+- Require status checks to pass before merging.
+- Add the stable CI, CodeQL, and Scorecard check names after the first successful run on `main`.
+- Disable force pushes and deletions on `main`.
+- Enable private vulnerability reporting if it is not already available under GitHub Security Advisories.
+- Enable secret scanning and push protection when available for the repository plan.
+
+## Release Security
+
+Current release automation publishes checksums through GoReleaser. The next hardening steps are:
+
+- Sign release artifacts or provenance.
+- Document checksum verification in release notes.
+- Consider SLSA provenance once release binaries are stable.

--- a/examples/petstore/README.md
+++ b/examples/petstore/README.md
@@ -8,7 +8,7 @@ Demonstrates the full lathe workflow: OpenAPI 3 spec → codegen → working CLI
 bash examples/petstore/run.sh
 ```
 
-The script creates a throwaway project in `/tmp`, runs codegen, builds a real binary, and prints `--help` output. Everything is cleaned up on exit.
+The script creates a throwaway project in `/tmp`, runs codegen, builds a real binary, and prints `--help`, `search`, `commands show`, and `commands schema` output. Everything is cleaned up on exit.
 
 ## What the script does
 
@@ -19,6 +19,7 @@ The script creates a throwaway project in `/tmp`, runs codegen, builds a real bi
 5. Runs codegen → produces `internal/generated/`
 6. Writes `cmd/petstore/main.go` (wiring code)
 7. `go build` → runs `petstore --help`
+8. Demonstrates the agent loop with `search`, `commands show`, and `commands schema`
 
 ## Expected output
 

--- a/examples/petstore/run.sh
+++ b/examples/petstore/run.sh
@@ -169,5 +169,14 @@ echo ""
 echo "========== petstore pets --help =========="
 ./bin/petstore pets --help
 echo ""
+echo "========== petstore search \"list pets\" --json =========="
+./bin/petstore search "list pets" --json
+echo ""
+echo "========== petstore commands show pets pets list --json =========="
+./bin/petstore commands show pets pets list --json
+echo ""
+echo "========== petstore commands schema --json =========="
+./bin/petstore commands schema --json
+echo ""
 echo "Done. Binary saved to examples/petstore/bin/petstore"
 echo "Done. Skill saved to examples/petstore/skills/petstore"


### PR DESCRIPTION
## Summary

- Add GitHub community health files: issue forms, PR template, Code of Conduct, governance, maintainers, showcase, adopters, and security hardening notes.
- Enable versioned security automation with CodeQL, OpenSSF Scorecard, and Dependabot configuration.
- Turn GoReleaser from source-only output into installable `lathe-specsync` and `lathe-codegen` archives with checksums.
- Update README/README_zh and the petstore example so the 60-second demo shows `search`, `commands show`, and `commands schema`.
- This stays as one PR because the files are one cohesive open-source project-readiness pass; splitting would leave README links and release/community entry points temporarily inconsistent.

## Verification

- `git diff --cached --check`
- Added-line CJK validation, excluding `README_zh.md` as the translation doc
- `ruby -e 'require "yaml"; %w[.goreleaser.yml .github/dependabot.yml .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/workflows/codeql.yml .github/workflows/scorecard.yml .github/workflows/release.yml .github/workflows/ci.yml].each { |p| YAML.load_file(p) }; puts "yaml ok"'`
- `actionlint`
- `goreleaser check`
- `make example-petstore`
- `gh api -i repos/samzong/lathe/vulnerability-alerts`
- `gh api -i repos/samzong/lathe/automated-security-fixes`

## Compatibility

No generated command shape, runtime catalog schema, auth/body/output behavior, or generated Skill contract changes. This PR changes repository metadata, release packaging, documentation entry points, and the petstore demo output.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.