### PR TITLE
feat(codegen): support display_name override for CLI module path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /go.work
 /go.work.sum
 .DS_Store
+.idea
 
 /.cache/
 /internal/generated/

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -20,6 +20,7 @@ const (
 
 type moduleCtx struct {
 	Module        string
+	CLIName       string
 	RuntimePkg    string
 	SchemaVersion int
 	Ops           []runtime.CommandSpec
@@ -34,9 +35,14 @@ const RuntimePkg = "github.com/samzong/lathe/pkg/runtime"
 // keyed by command Use string; each override's non-empty fields are baked into
 // the corresponding CommandSpec (Aliases are appended, not replaced). Passing
 // a nil map means "no overlay", equivalent to the pre-overlay behavior.
-func RenderModule(name string, specs []runtime.CommandSpec, overrides map[string]overlay.Override) error {
+// cliName is the name used in runtime.Build (the CLI-visible module path
+// segment); if empty it falls back to name.
+func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides map[string]overlay.Override) error {
+	if cliName == "" {
+		cliName = name
+	}
 	merged := MergeOverlay(specs, overrides)
-	return renderModuleSpecs(name, merged)
+	return renderModuleSpecs(name, cliName, merged)
 }
 
 func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {
@@ -94,10 +100,11 @@ func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Over
 	return merged
 }
 
-func renderModuleSpecs(name string, specs []runtime.CommandSpec) error {
+func renderModuleSpecs(name, cliName string, specs []runtime.CommandSpec) error {
 	var buf strings.Builder
 	ctx := moduleCtx{
 		Module:        name,
+		CLIName:       cliName,
 		RuntimePkg:    RuntimePkg,
 		SchemaVersion: runtime.SchemaVersion,
 		Ops:           specs,
@@ -206,7 +213,7 @@ func Mount(root *cobra.Command) error {
 	if err := runtime.AssertSchema(generatedSchemaVersion); err != nil {
 		return err
 	}
-	runtime.Build(root, {{printf "%q" .Module}}, Specs)
+	runtime.Build(root, {{printf "%q" .CLIName}}, Specs)
 	return nil
 }
 

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -29,7 +29,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		},
 	}
 
-	if err := RenderModule("demo", specs, overrides); err != nil {
+	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
 	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
@@ -75,7 +75,7 @@ func TestRenderModule_IgnoreDropsCommand(t *testing.T) {
 	overrides := map[string]overlay.Override{
 		"delete-addon": {Ignore: true},
 	}
-	if err := RenderModule("demo", specs, overrides); err != nil {
+	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
 	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
@@ -103,7 +103,7 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 	overrides := map[string]overlay.Override{
 		"get-item": {Group: "Items", Hidden: &hidden},
 	}
-	if err := RenderModule("demo", specs, overrides); err != nil {
+	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
 	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
@@ -142,7 +142,7 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 			},
 		},
 	}
-	if err := RenderModule("demo", specs, overrides); err != nil {
+	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
 	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
@@ -173,7 +173,7 @@ func TestRenderModule_NilOverrides(t *testing.T) {
 	specs := []runtime.CommandSpec{
 		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/x"},
 	}
-	if err := RenderModule("demo", specs, nil); err != nil {
+	if err := RenderModule("demo", "", specs, nil); err != nil {
 		t.Fatalf("RenderModule nil overrides: %v", err)
 	}
 	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -310,6 +310,9 @@ func sortedKeys[V any](m map[string]V) []string {
 }
 
 func moduleName(mod SkillModule) string {
+	if mod.Source != nil && mod.Source.DisplayName != "" {
+		return mod.Source.DisplayName
+	}
 	if mod.Source != nil && mod.Source.Name != "" {
 		return mod.Source.Name
 	}

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -184,7 +184,11 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 
 		specs := normalize.Normalize(mod)
 		specs = render.MergeOverlay(specs, overlays[src.Name])
-		if err := render.RenderModule(src.Name, specs, nil); err != nil {
+		cliName := src.Name
+		if src.DisplayName != "" {
+			cliName = src.DisplayName
+		}
+		if err := render.RenderModule(src.Name, cliName, specs, nil); err != nil {
 			return err
 		}
 		names = append(names, src.Name)

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -20,13 +20,14 @@ type Config struct {
 }
 
 type Source struct {
-	Name      string          `yaml:"-"`
-	RepoURL   string          `yaml:"repo_url"`
-	PinnedTag string          `yaml:"pinned_tag"`
-	Backend   string          `yaml:"backend"`
-	Swagger   *SwaggerConfig  `yaml:"swagger,omitempty"`
-	Proto     *ProtoConfig    `yaml:"proto,omitempty"`
-	OpenAPI3  *OpenAPI3Config `yaml:"openapi3,omitempty"`
+	Name        string          `yaml:"-"`
+	DisplayName string          `yaml:"display_name,omitempty"`
+	RepoURL     string          `yaml:"repo_url"`
+	PinnedTag   string          `yaml:"pinned_tag"`
+	Backend     string          `yaml:"backend"`
+	Swagger     *SwaggerConfig  `yaml:"swagger,omitempty"`
+	Proto       *ProtoConfig    `yaml:"proto,omitempty"`
+	OpenAPI3    *OpenAPI3Config `yaml:"openapi3,omitempty"`
 }
 
 type SwaggerConfig struct {


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep it focused. -->
support display_name override for CLI module path

## Verification

<!-- Paste exact commands run, for example `make test` or `make check`. -->
```
make test                   
go test ./...
?       github.com/samzong/lathe/cmd/lathe      [no test files]
ok      github.com/samzong/lathe/internal/auth  (cached)
ok      github.com/samzong/lathe/internal/codegen/backends/openapi3     (cached)
ok      github.com/samzong/lathe/internal/codegen/backends/proto        (cached)
ok      github.com/samzong/lathe/internal/codegen/backends/swagger      (cached)
ok      github.com/samzong/lathe/internal/codegen/normalize     (cached)
?       github.com/samzong/lathe/internal/codegen/rawir [no test files]
ok      github.com/samzong/lathe/internal/codegen/render        0.854s
ok      github.com/samzong/lathe/internal/lathecmd      1.479s
ok      github.com/samzong/lathe/internal/overlay       (cached)
ok      github.com/samzong/lathe/internal/sourceconfig  (cached)
ok      github.com/samzong/lathe/internal/specsync      (cached)
ok      github.com/samzong/lathe/internal/testutil      (cached)
ok      github.com/samzong/lathe/pkg/config     (cached)
ok      github.com/samzong/lathe/pkg/lathe      (cached)
ok      github.com/samzong/lathe/pkg/runtime    9.081s
```
## Compatibility

<!-- Note generated command shape, catalog schema, auth/body/output behavior, or docs changes. Write "None" if not applicable. -->

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
