### PR TITLE
[Fix] Remove stale Makefile generation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 GO          ?= go
-GORELEASER ?= goreleaser
 OUT_DIR     := ./bin
 
 BOLD  := \033[1m
@@ -15,22 +14,8 @@ RESET := \033[0m
 
 build: ## Build local lathe binary into ./bin/lathe
 	@mkdir -p $(OUT_DIR)
-	$(GORELEASER) build --snapshot --clean --single-target --output $(OUT_DIR)/lathe
+	$(GO) build -trimpath -o $(OUT_DIR)/lathe ./cmd/lathe
 	@printf '\n$(GREEN)  ✓ built $(CYAN)$(OUT_DIR)/lathe$(RESET)\n\n'
-
-# ── Bootstrap ────────────────────────────────────────────────────────────────
-
-.PHONY: bootstrap sync-specs gen
-
-bootstrap: ## First-time setup — sync upstream specs + generate command tree
-	$(GO) run ./cmd/lathe bootstrap
-	@printf '\n$(GREEN)  ✓ bootstrap complete$(RESET) — next: $(CYAN)go build -o $(OUT_DIR)/<name> ./cmd/<name>$(RESET)\n\n'
-
-sync-specs: ## Fetch upstream specs pinned in specs/sources.yaml
-	$(GO) run ./cmd/lathe specsync
-
-gen: ## Regenerate internal/generated from cached specs
-	$(GO) run ./cmd/lathe codegen
 
 # ── Quality ──────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ sources:
 ### 3. Generate and Build
 
 ```sh
-make bootstrap
+lathe bootstrap
 go build -o bin/acmectl ./cmd/acmectl
 ```
 
-`make bootstrap` syncs pinned specs and runs codegen. Codegen emits generated Go
+`lathe bootstrap` syncs pinned specs and runs codegen. Codegen emits generated Go
 modules and, by default, a Skill directory at `skills/acmectl/`.
 
 ### 4. Use the CLI

--- a/README_zh.md
+++ b/README_zh.md
@@ -152,11 +152,11 @@ sources:
 ### 3. 生成并构建
 
 ```sh
-make bootstrap
+lathe bootstrap
 go build -o bin/acmectl ./cmd/acmectl
 ```
 
-`make bootstrap` 会同步锁定的规格并运行 codegen。Codegen 会生成 Go 模块，
+`lathe bootstrap` 会同步锁定的规格并运行 codegen。Codegen 会生成 Go 模块，
 并默认生成 Skill 目录 `skills/acmectl/`。
 
 ### 4. 使用 CLI

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,8 @@ lathe has two disjoint phases. They share types (`runtime.CommandSpec`) but run 
 flowchart LR
     subgraph codegen["Codegen-time (in the template repo)"]
         direction TB
-        S1[specs/sources.yaml] --> S2[make sync-specs]
-        S2 --> S3[make gen]
+        S1[specs/sources.yaml] --> S2[lathe specsync]
+        S2 --> S3[lathe codegen]
         S3 --> S4[internal/generated/*]
     end
 
@@ -164,7 +164,7 @@ graph TD
 ```mermaid
 stateDiagram-v2
     [*] --> Declared: edit specs/sources.yaml
-    Declared --> Cloned: make sync-specs\n(git clone + checkout pinned_tag)
+    Declared --> Cloned: lathe specsync\n(git clone + checkout pinned_tag)
     Cloned --> Staged: backend-specific staging\n(.cache/specs-sync/&lt;mod&gt;/)
     Staged --> Parsed: backend.Parse\n→ RawModule
     Parsed --> Normalized: normalize.Normalize\n→ []CommandSpec
@@ -277,7 +277,7 @@ These are structural, not stylistic. Violating any means the architecture breaks
 3. **Codegen is never invoked at `go build` time.** Downstream consumers need no Go toolchain tags, build flags, or network access to install.
 4. **Overlays bake at codegen-time.** The runtime has no overlay concept. This keeps `pkg/runtime` small and overlay bugs from being runtime bugs.
 5. **No ambient "current host".** The host is a per-invocation input. This mirrors `gh` and avoids the "oops, wrong cluster" class of bug.
-6. **`sync-state.yaml` guards the cache.** `make gen` refuses a cache that doesn't match `pinned_tag`. Stale generation fails loud, not silent.
+6. **`sync-state.yaml` guards the cache.** `lathe codegen` refuses a cache that doesn't match `pinned_tag`. Stale generation fails loud, not silent.
 7. **Static codegen.** Downstream binaries carry no spec parser. The generated file is a pure data literal.
 8. **Single Go binary.** No `protoc`, `buf`, or other toolchain at install time. `go install` is the install path.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -38,7 +38,7 @@ go build -o bin/lathe ./cmd/lathe
 ```
 
 Use the built binary as `lathe`, or pass its path explicitly in examples.
-For a Goreleaser-shaped local snapshot, install Goreleaser and run `make build`.
+Release-shaped snapshots are built by the release workflow with Goreleaser.
 
 ## Initialize the Go Module
 

--- a/internal/specsync/state.go
+++ b/internal/specsync/state.go
@@ -43,19 +43,19 @@ func SaveState(syncDir string, s *State) error {
 func VerifyState(syncDir, source, backend, wantTag string) error {
 	s, err := LoadState(syncDir)
 	if err != nil {
-		return fmt.Errorf("source %q: sync-state missing or unreadable (run `make sync-specs`): %w", source, err)
+		return fmt.Errorf("source %q: sync-state missing or unreadable (run `lathe specsync`): %w", source, err)
 	}
 	if s.Source != source {
 		return fmt.Errorf("source %q: sync-state mismatch (got %q)", source, s.Source)
 	}
 	if s.Backend != backend {
-		return fmt.Errorf("source %q: sync-state backend %q != config %q (re-run sync)", source, s.Backend, backend)
+		return fmt.Errorf("source %q: sync-state backend %q != config %q (re-run `lathe specsync`)", source, s.Backend, backend)
 	}
 	if s.SyncedFrom != wantTag {
-		return fmt.Errorf("source %q: synced_from=%q but pinned_tag=%q (re-run sync)", source, s.SyncedFrom, wantTag)
+		return fmt.Errorf("source %q: synced_from=%q but pinned_tag=%q (re-run `lathe specsync`)", source, s.SyncedFrom, wantTag)
 	}
 	if s.ResolvedSHA == "" {
-		return fmt.Errorf("source %q: sync-state missing resolved_sha (re-run `make sync-specs`)", source)
+		return fmt.Errorf("source %q: sync-state missing resolved_sha (re-run `lathe specsync`)", source)
 	}
 	return nil
 }

--- a/internal/specsync/state_test.go
+++ b/internal/specsync/state_test.go
@@ -86,7 +86,7 @@ func TestVerifyState_RejectsMissingFile(t *testing.T) {
 	if err == nil {
 		t.Fatalf("VerifyState accepted missing sync-state")
 	}
-	if !strings.Contains(err.Error(), "make sync-specs") {
-		t.Errorf("error should tell user to run make sync-specs: %v", err)
+	if !strings.Contains(err.Error(), "lathe specsync") {
+		t.Errorf("error should tell user to run lathe specsync: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Remove Makefile targets that only work in downstream generated CLI repos.
- Build the local Lathe binary with Go instead of requiring Goreleaser.
- Update docs and sync-state errors to use the real `lathe` commands.

## Verification

- `git diff HEAD~1..HEAD --check`
- `make build`
- `make check`

## Compatibility

- No generated command shape, catalog schema, auth, body, or output behavior changes.
- Docs now point downstream users to `lathe bootstrap`, `lathe specsync`, and `lathe codegen` instead of removed Make targets.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.