### PR TITLE
[Chore] Update project owner references

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ changelog:
 
 release:
   github:
-    owner: samzong
+    owner: lathe-cli
     name: lathe
   prerelease: auto
   name_template: "{{ .Tag }}"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -23,7 +23,7 @@ Project maintainers are responsible for clarifying and enforcing standards of ac
 
 Report Code of Conduct concerns privately to the maintainer:
 
-- GitHub: https://github.com/samzong
+- GitHub: https://github.com/lathe-cli
 
 Security vulnerabilities should not be reported through this process. Follow `SECURITY.md` for vulnerability reports.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 samzong
+Copyright (c) 2026 lathe-cli
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -354,4 +354,4 @@ See [SECURITY.md](SECURITY.md) for private vulnerability disclosure.
 
 ## License
 
-[MIT](LICENSE) (c) samzong
+[MIT](LICENSE) (c) lathe-cli

--- a/README_zh.md
+++ b/README_zh.md
@@ -341,4 +341,4 @@ Lathe 分两步工作：
 
 ## 许可证
 
-[MIT](LICENSE) (c) samzong
+[MIT](LICENSE) (c) lathe-cli

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Please **do not** open a public GitHub issue for a vulnerability. Use GitHub's p
 2. Describe the issue with enough detail to reproduce: the spec, the command, and the impact you observed.
 3. Expect a first response within 7 days.
 
-If private advisories are disabled or unreachable, DM the maintainer on GitHub (`@samzong`) to arrange a private channel.
+If private advisories are disabled or unreachable, DM the maintainer on GitHub (`@lathe-cli`) to arrange a private channel.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

- Update remaining project owner references from `samzong` to `lathe-cli` in release metadata, license text, and public docs.
- Align Code of Conduct and Security contact references with the current GitHub organization.

## Verification

- `git diff --check HEAD~1..HEAD`

## Compatibility

- No generated command shape, catalog schema, auth/body/output behavior, or generated output changes.
- Documentation and release metadata now reference `lathe-cli`.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
