### PR TITLE
[Feat] Add generated CLI run helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ graph TD
 | `internal/auth` | runtime | `auth login/logout/status`. Calls the configured validate endpoint. |
 | `pkg/config` | runtime | `Manifest` (CLI identity) and `Hosts` (per-hostname credentials). `Bind(m)` seeds package-level helpers. |
 | `pkg/runtime` | runtime | `CommandSpec` IR, `Build`, body builder, HTTP client with retry, `Authenticator` interface, `Formatter` registry, `LatheError`, schema version contract. |
-| `pkg/lathe` | runtime | `NewApp(m)` — root cobra command with auth subtree and module groups. |
+| `pkg/lathe` | runtime | `Run(opts)` standard generated-CLI entrypoint; `NewApp(m)` for advanced root command composition. |
 
 ## Spec lifecycle
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -152,12 +152,9 @@ package main
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
 
-	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/lathe"
-	"github.com/lathe-cli/lathe/pkg/runtime"
 
 	"example.com/acme/internal/generated"
 )
@@ -166,18 +163,10 @@ import (
 var manifestBytes []byte
 
 func main() {
-	m, err := config.Load(manifestBytes)
-	if err != nil {
-		panic(err)
-	}
-	config.Bind(m)
-
-	root := lathe.NewApp(m)
-	if err := generated.MountModules(root); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	os.Exit(runtime.Execute(root))
+	os.Exit(lathe.Run(lathe.RunOptions{
+		Manifest: manifestBytes,
+		Mount:    generated.MountModules,
+	}))
 }
 ```
 

--- a/examples/petstore/cmd/petstore/main.go
+++ b/examples/petstore/cmd/petstore/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
 
-	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/lathe"
-	"github.com/lathe-cli/lathe/pkg/runtime"
 
 	"example/petstore/internal/generated"
 )
@@ -16,16 +13,8 @@ import (
 var manifestBytes []byte
 
 func main() {
-	m, err := config.Load(manifestBytes)
-	if err != nil {
-		panic(err)
-	}
-	config.Bind(m)
-
-	root := lathe.NewApp(m)
-	if err := generated.MountModules(root); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	os.Exit(runtime.Execute(root))
+	os.Exit(lathe.Run(lathe.RunOptions{
+		Manifest: manifestBytes,
+		Mount:    generated.MountModules,
+	}))
 }

--- a/examples/richapi/cmd/richapi/main.go
+++ b/examples/richapi/cmd/richapi/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	_ "embed"
-	"fmt"
 	"os"
 
-	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/lathe"
-	"github.com/lathe-cli/lathe/pkg/runtime"
 
 	"example/richapi/internal/generated"
 )
@@ -16,16 +13,8 @@ import (
 var manifestBytes []byte
 
 func main() {
-	m, err := config.Load(manifestBytes)
-	if err != nil {
-		panic(err)
-	}
-	config.Bind(m)
-
-	root := lathe.NewApp(m)
-	if err := generated.MountModules(root); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
-	os.Exit(runtime.Execute(root))
+	os.Exit(lathe.Run(lathe.RunOptions{
+		Manifest: manifestBytes,
+		Mount:    generated.MountModules,
+	}))
 }

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -13,13 +13,13 @@ import (
 const authGroupID = "auth"
 
 // NewApp builds the root cobra command for a lathe-style CLI identified by m.
-// Callers (typically a small main.go) are responsible for:
-//   - calling config.Bind(m) before Execute() so package-level helpers
-//     (hosts.configDir, runtime.ResolveHost) can reach the bound manifest;
-//   - mounting generated module command trees onto the returned *cobra.Command;
-//   - invoking .Execute() and mapping runtime.ErrNotAuthenticated to the
-//     desired exit code.
+// It binds m for package-level helpers before returning the command.
+// Callers that need the standard generated-CLI entrypoint should use Run.
+// Advanced callers may still mount generated module command trees directly
+// onto the returned *cobra.Command and execute it themselves.
 func NewApp(m *config.Manifest) *cobra.Command {
+	config.Bind(m)
+
 	cmd := &cobra.Command{
 		Use:          m.CLI.Name,
 		Short:        m.CLI.Short,

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -1,8 +1,15 @@
 package lathe
 
 import (
+	"bytes"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
 func TestRootHelpExposesAgentHint(t *testing.T) {
@@ -20,5 +27,117 @@ func TestRootHelpExposesAgentHint(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("--help missing %q\nfull output:\n%s", want, out)
 		}
+	}
+}
+
+func TestNewAppBindsManifest(t *testing.T) {
+	m := testManifest()
+	root := NewApp(m)
+	if root.Use != "myctl" {
+		t.Fatalf("root.Use = %q, want myctl", root.Use)
+	}
+	if got := config.Active(); got != m {
+		t.Fatalf("bound manifest = %p, want %p", got, m)
+	}
+}
+
+func TestRunMountsAndExecutesGeneratedCommands(t *testing.T) {
+	restoreVersionInfo(t)
+
+	var stdout, stderr bytes.Buffer
+	code := run(RunOptions{
+		Manifest: []byte("cli:\n  name: myctl\n  short: test cli\n"),
+		Mount: func(root *cobra.Command) error {
+			root.AddCommand(&cobra.Command{
+				Use: "ping",
+				Run: func(cmd *cobra.Command, _ []string) {
+					cmd.Print("pong")
+				},
+			})
+			return nil
+		},
+		Version: "1.2.3",
+		Commit:  "abc123",
+		Date:    "2026-05-26",
+	}, []string{"ping"}, &stdout, &stderr)
+	if code != runtime.ExitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if stdout.String() != "pong" {
+		t.Fatalf("stdout = %q, want pong", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = run(RunOptions{
+		Manifest: []byte("cli:\n  name: myctl\n  short: test cli\n"),
+		Version:  "1.2.3",
+		Commit:   "abc123",
+		Date:     "2026-05-26",
+	}, []string{"version"}, &stdout, &stderr)
+	if code != runtime.ExitOK {
+		t.Fatalf("version exit = %d, stderr = %q", code, stderr.String())
+	}
+	if got, want := stdout.String(), "myctl 1.2.3 (abc123, 2026-05-26)\n"; got != want {
+		t.Fatalf("version output = %q, want %q", got, want)
+	}
+}
+
+func restoreVersionInfo(t *testing.T) {
+	t.Helper()
+
+	oldVersion := Version
+	oldCommit := Commit
+	oldDate := Date
+	t.Cleanup(func() {
+		Version = oldVersion
+		Commit = oldCommit
+		Date = oldDate
+	})
+}
+
+func TestRunReportsInvalidManifest(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(RunOptions{Manifest: []byte("cli: {}\n")}, []string{"--help"}, &stdout, &stderr)
+	if code != runtime.ExitGeneral {
+		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
+	}
+	if !strings.Contains(stderr.String(), "cli.name is required") {
+		t.Fatalf("stderr missing manifest error: %q", stderr.String())
+	}
+}
+
+func TestRunReportsMountError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(RunOptions{
+		Manifest: []byte("cli:\n  name: myctl\n"),
+		Mount: func(*cobra.Command) error {
+			return errors.New("mount failed")
+		},
+	}, []string{"--help"}, &stdout, &stderr)
+	if code != runtime.ExitGeneral {
+		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
+	}
+	if !strings.Contains(stderr.String(), "mount failed") {
+		t.Fatalf("stderr missing mount error: %q", stderr.String())
+	}
+}
+
+func TestRunUsesRuntimeExecuteErrors(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(RunOptions{
+		Manifest: []byte("cli:\n  name: myctl\n"),
+		Mount: func(root *cobra.Command) error {
+			root.AddCommand(&cobra.Command{
+				Use: "needs-auth",
+				RunE: func(*cobra.Command, []string) error {
+					return runtime.ErrNotAuthenticated
+				},
+			})
+			return nil
+		},
+	}, []string{"needs-auth"}, &stdout, &stderr)
+	if code != runtime.ExitNotAuthenticated {
+		t.Fatalf("exit = %d, want %d", code, runtime.ExitNotAuthenticated)
 	}
 }

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -1,0 +1,64 @@
+package lathe
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+// RunOptions configures the standard entrypoint for a generated Lathe CLI.
+type RunOptions struct {
+	// Manifest is the embedded cli.yaml content.
+	Manifest []byte
+
+	// Mount attaches generated module commands to the root command.
+	Mount func(*cobra.Command) error
+
+	// Version, Commit, and Date are build-time values shown by the version command.
+	Version string
+	Commit  string
+	Date    string
+}
+
+// Run executes a generated Lathe CLI and returns the process exit code.
+func Run(opts RunOptions) int {
+	return run(opts, os.Args[1:], os.Stdout, os.Stderr)
+}
+
+func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
+	m, err := config.Load(opts.Manifest)
+	if err != nil {
+		return runtime.FormatError(err, "table", stderr)
+	}
+
+	setVersionInfo(opts)
+
+	root := NewApp(m)
+	root.SetArgs(args)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+
+	if opts.Mount != nil {
+		if err := opts.Mount(root); err != nil {
+			return runtime.FormatError(err, "table", stderr)
+		}
+	}
+
+	return runtime.Execute(root)
+}
+
+func setVersionInfo(opts RunOptions) {
+	if opts.Version != "" {
+		Version = opts.Version
+	}
+	if opts.Commit != "" {
+		Commit = opts.Commit
+	}
+	if opts.Date != "" {
+		Date = opts.Date
+	}
+}

--- a/pkg/lathe/version.go
+++ b/pkg/lathe/version.go
@@ -1,10 +1,6 @@
 package lathe
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 var (
 	Version = "dev"
@@ -17,7 +13,7 @@ func versionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, _ []string) {
-			fmt.Printf("%s %s (%s, %s)\n", cmd.Root().Use, Version, Commit, Date)
+			cmd.Printf("%s %s (%s, %s)\n", cmd.Root().Use, Version, Commit, Date)
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Adds a standard `lathe.Run` entrypoint for generated CLIs so downstream `main.go` files no longer need to manually load and bind the manifest, mount modules, and route execution through the runtime.

Also updates examples and CLI usage docs to use the helper, while keeping `NewApp` available for advanced root command composition.

## Verification

- `make check`
- `GOWORK=<temp> go test ./...` in `daocloud-skills` against this local Lathe checkout
- `GOWORK=<temp> go build -o <temp>/dc ./cmd/dc` in `daocloud-skills`
- `<temp>/dc version`
- `<temp>/dc commands schema --json`
- `<temp>/dc search alerts --json`

## Compatibility

Additive runtime API. Existing downstream code using `config.Load`, `config.Bind`, `lathe.NewApp`, and direct `root.Execute` continues to compile and run. `NewApp` now binds the provided manifest itself; callers that already bind the same manifest remain compatible. Catalog schema and generated command shape are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
