### PR TITLE
[Fix] Preserve multiline Skill examples

### DIFF
--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -264,12 +264,30 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
 				fmt.Fprintf(&b, "- Output: %s\n", out)
 			}
 			if spec.Example != "" {
-				fmt.Fprintf(&b, "- Example: `%s`\n", strings.ReplaceAll(oneLine(spec.Example), "`", "'"))
+				writeExample(&b, spec.Example)
 			}
 			b.WriteString("\n")
 		}
 	}
 	return b.String()
+}
+
+func writeExample(b *strings.Builder, example string) {
+	text := strings.TrimRight(example, "\n")
+	if strings.Contains(text, "\n") {
+		fence := markdownFence(text)
+		fmt.Fprintf(b, "- Example:\n\n%s\n%s\n%s\n", fence, text, fence)
+		return
+	}
+	fmt.Fprintf(b, "- Example: `%s`\n", strings.ReplaceAll(oneLine(text), "`", "'"))
+}
+
+func markdownFence(text string) string {
+	fence := "```"
+	for strings.Contains(text, fence) {
+		fence += "`"
+	}
+	return fence
 }
 
 func visibleSpecs(specs []runtime.CommandSpec) []runtime.CommandSpec {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -112,6 +112,44 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 }
 
+func TestRenderModuleReference_FormatsExamples(t *testing.T) {
+	manifest := &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}
+	module := SkillModule{
+		Source: &sourceconfig.Source{Name: "users"},
+		Specs: []runtime.CommandSpec{
+			{
+				Group:   "Users",
+				Use:     "get-user",
+				Short:   "Get user",
+				Method:  "GET",
+				PathTpl: "/users/{id}",
+				Example: "acmectl users users get-user --id 123",
+			},
+			{
+				Group:   "Users",
+				Use:     "query-logs",
+				Short:   "Query logs",
+				Method:  "POST",
+				PathTpl: "/logs/query",
+				Example: "END=$(date +%s); START=$((END - 3600))\n" +
+					"acmectl users users query-logs \\\n" +
+					"  --start $START --end $END -o json\n" +
+					"jq '.items[]'",
+			},
+		},
+	}
+
+	got := renderModuleReference(manifest, module)
+	for _, want := range []string{
+		"- Example: `acmectl users users get-user --id 123`",
+		"- Example:\n\n```\nEND=$(date +%s); START=$((END - 3600))\nacmectl users users query-logs \\\n  --start $START --end $END -o json\njq '.items[]'\n```",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("module reference missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderSkillDirectory_RejectsUnsafeRoot(t *testing.T) {
 	err := RenderSkillDirectory("", &config.Manifest{CLI: config.CLIInfo{Name: "x"}}, nil)
 	if err == nil {


### PR DESCRIPTION
## Summary

Preserves multiline overlay examples when rendering generated Skill module references. Single-line examples still render inline, while multiline examples now render as fenced markdown blocks with line breaks and indentation intact.

Fixes #33.

## Verification

- `go test ./internal/codegen/render`
- `make check`

## Compatibility

Generated Skill reference markdown changes for commands with multiline examples. Catalog schema, generated command shape, auth behavior, body handling, and runtime behavior are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
