### PR TITLE
[Feat] Expose overlay operation notes in catalog

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,6 +193,7 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `Long` | `description` / comment block | override | overlay > spec |
 | `Aliases` | — | append | overlay-only |
 | `Example` | — | set | overlay-only |
+| `Notes`, `Prerequisites`, `KnownErrors` | — | set | overlay-only |
 | `Method`, `PathTpl`, `HasBody` | spec | locked | spec-only |
 | `OperationID` | `operationId` | — | spec-only |
 | `Hidden` | `x-cli-hidden` | bool | overlay > spec |

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -66,6 +66,18 @@ func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Over
 		if o.Example != "" {
 			cs.Example = o.Example
 		}
+		if len(o.Notes) > 0 {
+			cs.Notes = append([]string(nil), o.Notes...)
+		}
+		if len(o.Prerequisites) > 0 {
+			cs.Prerequisites = append([]string(nil), o.Prerequisites...)
+		}
+		if len(o.KnownErrors) > 0 {
+			cs.KnownErrors = make([]runtime.KnownError, 0, len(o.KnownErrors))
+			for _, ke := range o.KnownErrors {
+				cs.KnownErrors = append(cs.KnownErrors, runtime.KnownError{Status: ke.Status, Cause: ke.Cause})
+			}
+		}
 		if len(o.Aliases) > 0 {
 			cs.Aliases = append(cs.Aliases, o.Aliases...)
 		}
@@ -231,6 +243,23 @@ var Specs = []runtime.CommandSpec{
 		{{- end}}
 		{{- if $op.Example}}
 		Example:     {{printf "%q" $op.Example}},
+		{{- end}}
+		{{- if $op.Notes}}
+		Notes: []string{
+			{{- range $op.Notes}}{{printf "%q" .}},{{end}}
+		},
+		{{- end}}
+		{{- if $op.Prerequisites}}
+		Prerequisites: []string{
+			{{- range $op.Prerequisites}}{{printf "%q" .}},{{end}}
+		},
+		{{- end}}
+		{{- if $op.KnownErrors}}
+		KnownErrors: []runtime.KnownError{
+			{{- range $op.KnownErrors}}
+			{Status: {{.Status}}, Cause: {{printf "%q" .Cause}}},
+			{{- end}}
+		},
 		{{- end}}
 		{{- if $op.OperationID}}
 		OperationID: {{printf "%q" $op.OperationID}},

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -22,10 +22,13 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	}
 	overrides := map[string]overlay.Override{
 		"install-addon": {
-			Aliases: []string{"addon-install"},
-			Short:   "OVERLAY SHORT",
-			Long:    "OVERLAY LONG DESC",
-			Example: "myctl demo install-addon --name foo",
+			Aliases:       []string{"addon-install"},
+			Short:         "OVERLAY SHORT",
+			Long:          "OVERLAY LONG DESC",
+			Example:       "myctl demo install-addon --name foo",
+			Notes:         []string{"Use the canonical addon ID."},
+			Prerequisites: []string{"List clusters before installing."},
+			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing addon name"}},
 		},
 	}
 
@@ -43,6 +46,14 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`"OVERLAY LONG DESC"`,
 		`"myctl demo install-addon --name foo"`,
 		`"addon-install"`,
+		`Notes:`,
+		`"Use the canonical addon ID."`,
+		`Prerequisites:`,
+		`"List clusters before installing."`,
+		`KnownErrors:`,
+		`[]runtime.KnownError{`,
+		`Status: 400`,
+		`Cause: "missing addon name"`,
 		`"untouched short"`,
 		`generatedSchemaVersion`,
 		`func Mount(root *cobra.Command) error`,

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -180,7 +180,8 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, and help.\n")
 	b.WriteString("- `body`: request body requirement and media type.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
-	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints.\n\n")
+	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints.\n")
+	b.WriteString("- `notes`, `prerequisites`, and `known_errors`: overlay-provided operation context that is not inferred from the API spec.\n\n")
 	b.WriteString("## Command Detail\n\n")
 	fmt.Fprintf(&b, "Run `%s commands show <path...> --json` before executing an unfamiliar command. This is the source of truth for flags, body, auth, HTTP path, and output hints.\n\n", cli)
 	b.WriteString("## Schema\n\n")
@@ -263,6 +264,7 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
 			if out := outputSummary(spec.Output); out != "" {
 				fmt.Fprintf(&b, "- Output: %s\n", out)
 			}
+			writeOperationContext(&b, spec)
 			if spec.Example != "" {
 				writeExample(&b, spec.Example)
 			}
@@ -270,6 +272,37 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
 		}
 	}
 	return b.String()
+}
+
+func writeOperationContext(b *strings.Builder, spec runtime.CommandSpec) {
+	writeStringList(b, "Notes", spec.Notes)
+	writeStringList(b, "Prerequisites", spec.Prerequisites)
+	if len(spec.KnownErrors) == 0 {
+		return
+	}
+	b.WriteString("- Known errors:\n")
+	for _, err := range spec.KnownErrors {
+		label := "unspecified status"
+		if err.Status != 0 {
+			label = fmt.Sprintf("HTTP %d", err.Status)
+		}
+		cause := oneLine(err.Cause)
+		if cause == "" {
+			fmt.Fprintf(b, "  - %s\n", label)
+			continue
+		}
+		fmt.Fprintf(b, "  - %s: %s\n", label, cause)
+	}
+}
+
+func writeStringList(b *strings.Builder, label string, values []string) {
+	if len(values) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "- %s:\n", label)
+	for _, value := range values {
+		fmt.Fprintf(b, "  - %s\n", oneLine(value))
+	}
 }
 
 func writeExample(b *strings.Builder, example string) {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -44,7 +44,14 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		{Group: "Users", Use: "delete-user", Short: "Delete user", Method: "DELETE", PathTpl: "/users/{id}", Hidden: true},
 	}
 	merged := MergeOverlay(specs, map[string]overlay.Override{
-		"create-user": {Short: "Create a user", Group: "Accounts", Example: "acmectl users accounts create-user --set name=alice"},
+		"create-user": {
+			Short:         "Create a user",
+			Group:         "Accounts",
+			Example:       "acmectl users accounts create-user --set name=alice",
+			Notes:         []string{"clusterFilter expects a cluster UUID."},
+			Prerequisites: []string{"Find the cluster UUID first."},
+			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing start/end"}},
+		},
 	})
 
 	if err := RenderSkillDirectory(filepath.Join(dir, "skills", "acmectl"), manifest, []SkillModule{{
@@ -101,6 +108,12 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Body: required; media type `application/json`",
 		"pagination `cursor`",
 		"streaming `sse`",
+		"Notes:",
+		"clusterFilter expects a cluster UUID.",
+		"Prerequisites:",
+		"Find the cluster UUID first.",
+		"Known errors:",
+		"HTTP 400: missing start/end",
 		"Example: `acmectl users accounts create-user --set name=alice`",
 	} {
 		if !strings.Contains(module, want) {

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -10,14 +10,17 @@ import (
 )
 
 type Override struct {
-	Aliases []string                 `yaml:"aliases"`
-	Short   string                   `yaml:"short"`
-	Long    string                   `yaml:"long"`
-	Example string                   `yaml:"example"`
-	Group   string                   `yaml:"group"`
-	Hidden  *bool                    `yaml:"hidden"`
-	Ignore  bool                     `yaml:"ignore"`
-	Params  map[string]ParamOverride `yaml:"params"`
+	Aliases       []string                 `yaml:"aliases"`
+	Short         string                   `yaml:"short"`
+	Long          string                   `yaml:"long"`
+	Example       string                   `yaml:"example"`
+	Group         string                   `yaml:"group"`
+	Hidden        *bool                    `yaml:"hidden"`
+	Ignore        bool                     `yaml:"ignore"`
+	Params        map[string]ParamOverride `yaml:"params"`
+	Notes         []string                 `yaml:"notes"`
+	Prerequisites []string                 `yaml:"prerequisites"`
+	KnownErrors   []KnownError             `yaml:"known_errors"`
 }
 
 type ParamOverride struct {
@@ -26,6 +29,11 @@ type ParamOverride struct {
 	Default    string `yaml:"default"`
 	Hidden     bool   `yaml:"hidden"`
 	Deprecated bool   `yaml:"deprecated"`
+}
+
+type KnownError struct {
+	Status int    `yaml:"status"`
+	Cause  string `yaml:"cause"`
 }
 
 type moduleFile struct {

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -66,6 +66,13 @@ func TestLoadDir_ParsesExtendedFields(t *testing.T) {
   create-user:
     group: "Identity"
     hidden: true
+    notes:
+      - "Use the canonical user ID."
+    prerequisites:
+      - "List users before creating dependent resources."
+    known_errors:
+      - status: 400
+        cause: "missing user name"
     params:
       status:
         flag: user-status
@@ -87,6 +94,15 @@ func TestLoadDir_ParsesExtendedFields(t *testing.T) {
 	}
 	if cu.Hidden == nil || !*cu.Hidden {
 		t.Errorf("hidden = %v, want true", cu.Hidden)
+	}
+	if len(cu.Notes) != 1 || cu.Notes[0] != "Use the canonical user ID." {
+		t.Errorf("notes = %#v", cu.Notes)
+	}
+	if len(cu.Prerequisites) != 1 || cu.Prerequisites[0] != "List users before creating dependent resources." {
+		t.Errorf("prerequisites = %#v", cu.Prerequisites)
+	}
+	if len(cu.KnownErrors) != 1 || cu.KnownErrors[0].Status != 400 || cu.KnownErrors[0].Cause != "missing user name" {
+		t.Errorf("known errors = %#v", cu.KnownErrors)
 	}
 	sp := cu.Params["status"]
 	if sp.Flag != "user-status" {

--- a/pkg/lathe/catalog_test.go
+++ b/pkg/lathe/catalog_test.go
@@ -42,6 +42,9 @@ func TestCommandsShowAndSearchJSON(t *testing.T) {
 		Params: []runtime.ParamSpec{
 			{Name: "id", Flag: "id", In: runtime.InPath, GoType: "string", Required: true, Help: "User id"},
 		},
+		Notes:         []string{"Use the canonical user ID."},
+		Prerequisites: []string{"List users before fetching details."},
+		KnownErrors:   []runtime.KnownError{{Status: 400, Cause: "missing id"}},
 	}})
 
 	out, err := execute(root, "commands", "show", "demo", "users", "get-user", "--json")
@@ -54,6 +57,15 @@ func TestCommandsShowAndSearchJSON(t *testing.T) {
 	}
 	if strings.Join(entry.Path, " ") != "demo users get-user" || entry.Group != "Users" {
 		t.Fatalf("entry = %+v", entry)
+	}
+	if len(entry.Notes) != 1 || entry.Notes[0] != "Use the canonical user ID." {
+		t.Fatalf("notes = %#v", entry.Notes)
+	}
+	if len(entry.Prerequisites) != 1 || entry.Prerequisites[0] != "List users before fetching details." {
+		t.Fatalf("prerequisites = %#v", entry.Prerequisites)
+	}
+	if len(entry.KnownErrors) != 1 || entry.KnownErrors[0].Status != 400 || entry.KnownErrors[0].Cause != "missing id" {
+		t.Fatalf("known errors = %#v", entry.KnownErrors)
 	}
 
 	out, err = execute(root, "search", "getUser", "--json")

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 2
+const CatalogSchemaVersion = 3
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -43,22 +43,25 @@ type CatalogOutputFormats struct {
 }
 
 type CatalogCommand struct {
-	Path        []string      `json:"path"`
-	Service     string        `json:"service"`
-	Group       string        `json:"group"`
-	Use         string        `json:"use"`
-	Aliases     []string      `json:"aliases,omitempty"`
-	Summary     string        `json:"summary,omitempty"`
-	Description string        `json:"description,omitempty"`
-	Example     string        `json:"example,omitempty"`
-	OperationID string        `json:"operation_id,omitempty"`
-	HTTP        CatalogHTTP   `json:"http"`
-	Auth        CatalogAuth   `json:"auth"`
-	Body        *CatalogBody  `json:"body,omitempty"`
-	Flags       []CatalogFlag `json:"flags"`
-	Output      CatalogOutput `json:"output"`
-	Hidden      bool          `json:"hidden"`
-	Deprecated  bool          `json:"deprecated"`
+	Path          []string      `json:"path"`
+	Service       string        `json:"service"`
+	Group         string        `json:"group"`
+	Use           string        `json:"use"`
+	Aliases       []string      `json:"aliases,omitempty"`
+	Summary       string        `json:"summary,omitempty"`
+	Description   string        `json:"description,omitempty"`
+	Example       string        `json:"example,omitempty"`
+	OperationID   string        `json:"operation_id,omitempty"`
+	HTTP          CatalogHTTP   `json:"http"`
+	Auth          CatalogAuth   `json:"auth"`
+	Body          *CatalogBody  `json:"body,omitempty"`
+	Flags         []CatalogFlag `json:"flags"`
+	Output        CatalogOutput `json:"output"`
+	Hidden        bool          `json:"hidden"`
+	Deprecated    bool          `json:"deprecated"`
+	Notes         []string      `json:"notes,omitempty"`
+	Prerequisites []string      `json:"prerequisites,omitempty"`
+	KnownErrors   []KnownError  `json:"known_errors,omitempty"`
 }
 
 type CatalogHTTP struct {
@@ -267,8 +270,11 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 			Pagination:        catalogPagination(spec.Output.Pagination),
 			Streaming:         catalogStreaming(spec.Output.Streaming),
 		},
-		Hidden:     spec.Hidden,
-		Deprecated: spec.Deprecated,
+		Hidden:        spec.Hidden,
+		Deprecated:    spec.Deprecated,
+		Notes:         append([]string(nil), spec.Notes...),
+		Prerequisites: append([]string(nil), spec.Prerequisites...),
+		KnownErrors:   append([]KnownError(nil), spec.KnownErrors...),
 	}
 	if spec.RequestBody != nil {
 		cmd.Body = &CatalogBody{Required: spec.RequestBody.Required, MediaType: spec.RequestBody.MediaType, Schema: spec.RequestBody.Schema}

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -30,7 +30,10 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 				Pagination:        &PaginationHint{Strategy: "cursor", TokenParam: "page_token", TokenField: "next_page_token", LimitParam: "limit"},
 				Streaming:         &StreamingHint{Strategy: "sse"},
 			},
-			Security: &SecurityHint{Scopes: []string{"users:read"}},
+			Security:      &SecurityHint{Scopes: []string{"users:read"}},
+			Notes:         []string{"Use the canonical user ID."},
+			Prerequisites: []string{"List users before fetching details."},
+			KnownErrors:   []KnownError{{Status: 400, Cause: "missing id"}},
 		},
 	})
 
@@ -79,6 +82,15 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	if cmd.Output.Streaming == nil || cmd.Output.Streaming.Strategy != "sse" {
 		t.Fatalf("streaming = %+v", cmd.Output.Streaming)
 	}
+	if !reflect.DeepEqual(cmd.Notes, []string{"Use the canonical user ID."}) {
+		t.Fatalf("notes = %#v", cmd.Notes)
+	}
+	if !reflect.DeepEqual(cmd.Prerequisites, []string{"List users before fetching details."}) {
+		t.Fatalf("prerequisites = %#v", cmd.Prerequisites)
+	}
+	if !reflect.DeepEqual(cmd.KnownErrors, []KnownError{{Status: 400, Cause: "missing id"}}) {
+		t.Fatalf("known errors = %#v", cmd.KnownErrors)
+	}
 
 	raw, err := json.Marshal(catalog)
 	if err != nil {
@@ -93,6 +105,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if roundTrip.Commands[0].Body.Schema.Properties["name"].Type != "string" {
 		t.Fatalf("round-trip body schema = %+v", roundTrip.Commands[0].Body.Schema)
+	}
+	if !reflect.DeepEqual(roundTrip.Commands[0].KnownErrors, cmd.KnownErrors) {
+		t.Fatalf("round-trip known errors = %#v", roundTrip.Commands[0].KnownErrors)
 	}
 }
 

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -3,21 +3,24 @@ package runtime
 const SchemaVersion = 5
 
 type CommandSpec struct {
-	Group       string
-	Use         string
-	Aliases     []string
-	Short       string
-	Long        string
-	Example     string
-	OperationID string
-	Hidden      bool
-	Deprecated  bool
-	Method      string
-	PathTpl     string
-	Params      []ParamSpec
-	RequestBody *RequestBody
-	Output      OutputHints
-	Security    *SecurityHint
+	Group         string
+	Use           string
+	Aliases       []string
+	Short         string
+	Long          string
+	Example       string
+	OperationID   string
+	Hidden        bool
+	Deprecated    bool
+	Method        string
+	PathTpl       string
+	Params        []ParamSpec
+	RequestBody   *RequestBody
+	Output        OutputHints
+	Security      *SecurityHint
+	Notes         []string     `json:",omitempty"`
+	Prerequisites []string     `json:",omitempty"`
+	KnownErrors   []KnownError `json:",omitempty"`
 }
 
 type ParamSpec struct {
@@ -75,4 +78,9 @@ type StreamingHint struct {
 type SecurityHint struct {
 	Public bool
 	Scopes []string
+}
+
+type KnownError struct {
+	Status int    `json:"status,omitempty"`
+	Cause  string `json:"cause,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Add overlay fields for operation-level notes, prerequisites, and known errors, then merge them into `CommandSpec`.
- Expose those fields in catalog JSON and generated Skill module references.
- Document the new overlay-only merge behavior.

Fixes #35

## Verification

- `go test ./internal/overlay ./internal/codegen/render ./pkg/runtime ./pkg/lathe`
- `make check`
- `go test -modfile=<temp> ./...` in `daocloud-skills` with `replace github.com/lathe-cli/lathe=/Users/x/git/samzong/lathe`
- `go build -modfile=<temp> -trimpath -o <temp>/dc ./cmd/dc` in `daocloud-skills`
- `<temp>/dc commands schema --json`
- `<temp>/dc commands show insight probe add-probe --json`

## Compatibility

- Catalog JSON schema version increases from 2 to 3 because `notes`, `prerequisites`, and `known_errors` are new structured fields.
- Runtime `SchemaVersion` stays at 5, so existing generated CLIs continue to mount without regeneration.
- Existing overlays that only use `example` continue to work; the new fields are optional.
- New generated code that uses these fields requires this runtime version or newer.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
