### PR TITLE
[Feat] Support bulk pagination defaults in overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ generated Go code.
 `internal/overlay/iam.yaml`:
 
 ```yaml
+defaults:
+  pagination:
+    match_commands: ["list-*", "query-*"]
+    params:
+      page: "1"
+      pageSize: "20"
 commands:
   create-user:
     short: "Create a user in the IAM service"
@@ -287,6 +293,9 @@ Command `ignore: true` removes a generated command. Command `hidden: true`
 keeps it generated but hidden from normal help and catalog output unless
 `--include-hidden` is used. Parameter `hidden: true` is a legacy alias for
 `deprecated: true`; prefer `deprecated: true` for parameter overlays.
+Bulk pagination defaults fill matching command params that have no spec default.
+Explicit `commands.<use>.params.<name>.default` still wins when a command needs a
+different value.
 
 Run codegen with an overlay directory:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,13 +212,15 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `GoType` | `type` / `format` | narrowing only (post-v0.1) | overlay > spec |
 | `Help` | description / comment | override | overlay > spec |
 | `Required` | `required` / path rule | relaxation only (post-v0.1) | overlay > spec |
-| `Default` | spec or overlay | value | overlay > spec |
+| `Default` | spec or overlay | value | command overlay > spec > bulk overlay |
 | `Enum`, `Format` | spec | override (post-v0.1) | overlay > spec |
 | `Deprecated` | `param.deprecated` | bool; `param.hidden` is a legacy alias | overlay > spec |
 
 Two restricted-override rules: **`Required`** may only relax (required → optional), never tighten. **`GoType`** may only narrow (e.g. `string` → typed enum), never widen.
 
 Command `ignore` drops an operation during codegen, so it is absent from the generated CLI and catalog. Command `hidden` keeps the operation generated but hides it from normal help, search, and catalog output; `--include-hidden` can still inspect it. Parameter `hidden` does not hide a flag; it is retained only as a legacy spelling for `deprecated: true`. Prefer `deprecated: true` for parameter overlays.
+
+Module overlays may also define `defaults.pagination` with `match_commands` glob patterns and a param-value map. Bulk defaults only fill existing generated params with an empty default; they do not create params and do not replace defaults supplied by the upstream spec. A command-specific `commands.<use>.params.<name>.default` is applied afterward and wins over both spec and bulk defaults.
 
 ## Runtime request lifecycle
 

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -19,6 +19,12 @@
 
 commands: {}
 # Example:
+# defaults:
+#   pagination:
+#     match_commands: ["list-*", "query-*"]
+#     params:
+#       page: "1"
+#       pageSize: "20"
 # commands:
 #   create-user:
 #     aliases: [adduser]

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/format"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -41,75 +42,124 @@ func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides m
 	if cliName == "" {
 		cliName = name
 	}
-	merged := MergeOverlay(specs, overrides)
+	merged := MergeOverlayModule(specs, overlay.Module{Commands: overrides})
 	return renderModuleSpecs(name, cliName, merged)
 }
 
 func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {
+	return MergeOverlayModule(specs, overlay.Module{Commands: overrides})
+}
+
+func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
 	var merged []runtime.CommandSpec
 	for _, s := range specs {
-		o, ok := overrides[s.Use]
+		o, ok := mod.Commands[s.Use]
 		if ok && o.Ignore {
 			continue
 		}
-		cs := s
+		cs := cloneCommandSpec(s)
+		applyBulkDefaults(&cs, mod.Defaults)
 		if !ok {
 			merged = append(merged, cs)
 			continue
 		}
-		if o.Short != "" {
-			cs.Short = o.Short
-		}
-		if o.Long != "" {
-			cs.Long = o.Long
-		}
-		if o.Example != "" {
-			cs.Example = o.Example
-		}
-		if len(o.Notes) > 0 {
-			cs.Notes = append([]string(nil), o.Notes...)
-		}
-		if len(o.Prerequisites) > 0 {
-			cs.Prerequisites = append([]string(nil), o.Prerequisites...)
-		}
-		if len(o.KnownErrors) > 0 {
-			cs.KnownErrors = make([]runtime.KnownError, 0, len(o.KnownErrors))
-			for _, ke := range o.KnownErrors {
-				cs.KnownErrors = append(cs.KnownErrors, runtime.KnownError{Status: ke.Status, Cause: ke.Cause})
-			}
-		}
-		if len(o.Aliases) > 0 {
-			cs.Aliases = append(cs.Aliases, o.Aliases...)
-		}
-		if o.Group != "" {
-			cs.Group = o.Group
-		}
-		if o.Hidden != nil {
-			cs.Hidden = *o.Hidden
-		}
-		if len(o.Params) > 0 {
-			for j := range cs.Params {
-				po, pok := o.Params[cs.Params[j].Name]
-				if !pok {
-					continue
-				}
-				if po.Flag != "" {
-					cs.Params[j].Flag = po.Flag
-				}
-				if po.Help != "" {
-					cs.Params[j].Help = po.Help
-				}
-				if po.Default != "" {
-					cs.Params[j].Default = po.Default
-				}
-				if po.Deprecated || po.DeprecatedAlias {
-					cs.Params[j].Deprecated = true
-				}
-			}
-		}
+		applyCommandOverride(&cs, o)
 		merged = append(merged, cs)
 	}
 	return merged
+}
+
+func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
+	cloned := spec
+	cloned.Aliases = append([]string(nil), spec.Aliases...)
+	cloned.Notes = append([]string(nil), spec.Notes...)
+	cloned.Prerequisites = append([]string(nil), spec.Prerequisites...)
+	cloned.KnownErrors = append([]runtime.KnownError(nil), spec.KnownErrors...)
+	cloned.Params = append([]runtime.ParamSpec(nil), spec.Params...)
+	for i := range cloned.Params {
+		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
+	}
+	return cloned
+}
+
+func applyBulkDefaults(spec *runtime.CommandSpec, defaults overlay.Defaults) {
+	if defaults.Pagination == nil || !matchesAny(defaults.Pagination.MatchCommands, spec.Use) {
+		return
+	}
+	for i := range spec.Params {
+		if spec.Params[i].Default != "" {
+			continue
+		}
+		if value, ok := defaults.Pagination.Params[spec.Params[i].Name]; ok {
+			spec.Params[i].Default = value
+		}
+	}
+}
+
+func matchesAny(patterns []string, value string) bool {
+	for _, pattern := range patterns {
+		if pattern == "" {
+			continue
+		}
+		matched, err := path.Match(pattern, value)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) {
+	if override.Short != "" {
+		spec.Short = override.Short
+	}
+	if override.Long != "" {
+		spec.Long = override.Long
+	}
+	if override.Example != "" {
+		spec.Example = override.Example
+	}
+	if len(override.Notes) > 0 {
+		spec.Notes = append([]string(nil), override.Notes...)
+	}
+	if len(override.Prerequisites) > 0 {
+		spec.Prerequisites = append([]string(nil), override.Prerequisites...)
+	}
+	if len(override.KnownErrors) > 0 {
+		spec.KnownErrors = make([]runtime.KnownError, 0, len(override.KnownErrors))
+		for _, ke := range override.KnownErrors {
+			spec.KnownErrors = append(spec.KnownErrors, runtime.KnownError{Status: ke.Status, Cause: ke.Cause})
+		}
+	}
+	if len(override.Aliases) > 0 {
+		spec.Aliases = append(spec.Aliases, override.Aliases...)
+	}
+	if override.Group != "" {
+		spec.Group = override.Group
+	}
+	if override.Hidden != nil {
+		spec.Hidden = *override.Hidden
+	}
+	if len(override.Params) > 0 {
+		for j := range spec.Params {
+			po, pok := override.Params[spec.Params[j].Name]
+			if !pok {
+				continue
+			}
+			if po.Flag != "" {
+				spec.Params[j].Flag = po.Flag
+			}
+			if po.Help != "" {
+				spec.Params[j].Help = po.Help
+			}
+			if po.Default != "" {
+				spec.Params[j].Default = po.Default
+			}
+			if po.Deprecated || po.DeprecatedAlias {
+				spec.Params[j].Deprecated = true
+			}
+		}
+	}
 }
 
 func renderModuleSpecs(name, cliName string, specs []runtime.CommandSpec) error {

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -3,6 +3,7 @@ package render
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -180,6 +181,101 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayModule_BulkPaginationDefaults(t *testing.T) {
+	specs := []runtime.CommandSpec{
+		{
+			Group: "Users", Use: "list-users", Short: "list users", Method: "GET", PathTpl: "/users",
+			Params: []runtime.ParamSpec{
+				{Name: "page", Flag: "page", In: "query", GoType: "string"},
+				{Name: "pageSize", Flag: "page-size", In: "query", GoType: "string"},
+			},
+		},
+		{
+			Group: "Users", Use: "query-users", Short: "query users", Method: "GET", PathTpl: "/users/query",
+			Params: []runtime.ParamSpec{
+				{Name: "page", Flag: "page", In: "query", GoType: "string"},
+				{Name: "pageSize", Flag: "page-size", In: "query", GoType: "string"},
+			},
+		},
+		{
+			Group: "Users", Use: "get-user", Short: "get user", Method: "GET", PathTpl: "/users/{id}",
+			Params: []runtime.ParamSpec{
+				{Name: "id", Flag: "id", In: "path", GoType: "string"},
+			},
+		},
+	}
+
+	bulk := MergeOverlayModule(specs, overlay.Module{
+		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
+			MatchCommands: []string{"list-*", "query-*"},
+			Params:        map[string]string{"page": "1", "pageSize": "20"},
+		}},
+		Commands: map[string]overlay.Override{
+			"query-users": {Params: map[string]overlay.ParamOverride{"page": {Default: "7"}}},
+		},
+	})
+	explicit := MergeOverlay(specs, map[string]overlay.Override{
+		"list-users": {
+			Params: map[string]overlay.ParamOverride{
+				"page":     {Default: "1"},
+				"pageSize": {Default: "20"},
+			},
+		},
+		"query-users": {
+			Params: map[string]overlay.ParamOverride{
+				"page":     {Default: "7"},
+				"pageSize": {Default: "20"},
+			},
+		},
+	})
+
+	if !reflect.DeepEqual(bulk, explicit) {
+		t.Fatalf("bulk defaults differ from explicit overrides:\nbulk: %#v\nexplicit: %#v", bulk, explicit)
+	}
+	if got := paramDefault(t, bulk, "get-user", "id"); got != "" {
+		t.Fatalf("non-matching command default = %q, want empty", got)
+	}
+}
+
+func TestMergeOverlayModule_BulkDefaultsDoNotReplaceSpecDefaults(t *testing.T) {
+	specs := []runtime.CommandSpec{
+		{
+			Group: "Users", Use: "list-users", Short: "list users", Method: "GET", PathTpl: "/users",
+			Params: []runtime.ParamSpec{
+				{Name: "page", Flag: "page", In: "query", GoType: "string", Default: "5"},
+				{Name: "pageSize", Flag: "page-size", In: "query", GoType: "string"},
+			},
+		},
+	}
+
+	merged := MergeOverlayModule(specs, overlay.Module{
+		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
+			MatchCommands: []string{"list-*"},
+			Params:        map[string]string{"page": "1", "pageSize": "20"},
+		}},
+		Commands: map[string]overlay.Override{
+			"list-users": {Params: map[string]overlay.ParamOverride{"page": {Default: "9"}}},
+		},
+	})
+
+	if got := paramDefault(t, merged, "list-users", "page"); got != "9" {
+		t.Fatalf("per-command default = %q, want 9", got)
+	}
+	if got := paramDefault(t, merged, "list-users", "pageSize"); got != "20" {
+		t.Fatalf("bulk pageSize default = %q, want 20", got)
+	}
+
+	withoutCommandOverride := MergeOverlayModule(specs, overlay.Module{
+		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
+			MatchCommands: []string{"list-*"},
+			Params:        map[string]string{"page": "1"},
+		}},
+	})
+	if got := paramDefault(t, withoutCommandOverride, "list-users", "page"); got != "5" {
+		t.Fatalf("spec default = %q, want 5", got)
+	}
+}
+
 func TestRenderModule_NilOverrides(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
@@ -199,6 +295,23 @@ func TestRenderModule_NilOverrides(t *testing.T) {
 	if !strings.Contains(string(out), `"raw short"`) {
 		t.Errorf("expected raw short preserved when overrides is nil")
 	}
+}
+
+func paramDefault(t *testing.T, specs []runtime.CommandSpec, use string, name string) string {
+	t.Helper()
+	for _, spec := range specs {
+		if spec.Use != use {
+			continue
+		}
+		for _, param := range spec.Params {
+			if param.Name == name {
+				return param.Default
+			}
+		}
+		t.Fatalf("param %s not found on command %s", name, use)
+	}
+	t.Fatalf("command %s not found", use)
+	return ""
 }
 
 func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -183,7 +183,7 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 		}
 
 		specs := normalize.Normalize(mod)
-		specs = render.MergeOverlay(specs, overlays[src.Name])
+		specs = render.MergeOverlayModule(specs, overlays[src.Name])
 		cliName := src.Name
 		if src.DisplayName != "" {
 			cliName = src.DisplayName

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -36,15 +36,25 @@ type KnownError struct {
 	Cause  string `yaml:"cause"`
 }
 
-type moduleFile struct {
+type Module struct {
+	Defaults Defaults            `yaml:"defaults"`
 	Commands map[string]Override `yaml:"commands"`
 }
 
-// LoadDir reads every <module>.yaml under dir and returns a nested map keyed
-// by module name then command Use string. An empty or non-existent dir yields
-// an empty map without error — overlays are always optional.
-func LoadDir(dir string) (map[string]map[string]Override, error) {
-	out := map[string]map[string]Override{}
+type Defaults struct {
+	Pagination *PaginationDefaults `yaml:"pagination"`
+}
+
+type PaginationDefaults struct {
+	MatchCommands []string          `yaml:"match_commands"`
+	Params        map[string]string `yaml:"params"`
+}
+
+// LoadDir reads every <module>.yaml under dir and returns module overlays keyed
+// by module name. An empty or non-existent dir yields an empty map without
+// error; overlays are always optional.
+func LoadDir(dir string) (map[string]Module, error) {
+	out := map[string]Module{}
 	if dir == "" {
 		return out, nil
 	}
@@ -64,12 +74,12 @@ func LoadDir(dir string) (map[string]map[string]Override, error) {
 		if rerr != nil {
 			return nil, fmt.Errorf("overlay: read %s: %w", path, rerr)
 		}
-		var mf moduleFile
-		if yerr := yaml.Unmarshal(data, &mf); yerr != nil {
+		var mod Module
+		if yerr := yaml.Unmarshal(data, &mod); yerr != nil {
 			return nil, fmt.Errorf("overlay: parse %s: %w", path, yerr)
 		}
 		module := strings.TrimSuffix(e.Name(), ".yaml")
-		out[module] = mf.Commands
+		out[module] = mod
 	}
 	return out, nil
 }

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -48,21 +48,27 @@ func TestLoadDir_ParsesMultipleModules(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("want 2 modules, got %d: %v", len(got), got)
 	}
-	u := got["iam"]["create-user"]
+	u := got["iam"].Commands["create-user"]
 	if u.Short != "Create a user" || u.Long == "" || u.Example == "" {
 		t.Errorf("iam create-user override incomplete: %+v", u)
 	}
 	if len(u.Aliases) != 2 || u.Aliases[0] != "adduser" || u.Aliases[1] != "new-user" {
 		t.Errorf("iam create-user aliases: %v", u.Aliases)
 	}
-	if got["billing"]["list-invoices"].Short != "List invoices" {
-		t.Errorf("billing list-invoices: %+v", got["billing"]["list-invoices"])
+	if got["billing"].Commands["list-invoices"].Short != "List invoices" {
+		t.Errorf("billing list-invoices: %+v", got["billing"].Commands["list-invoices"])
 	}
 }
 
 func TestLoadDir_ParsesExtendedFields(t *testing.T) {
 	dir := t.TempDir()
-	writeFile(t, filepath.Join(dir, "iam.yaml"), `commands:
+	writeFile(t, filepath.Join(dir, "iam.yaml"), `defaults:
+  pagination:
+    match_commands: ["list-*", "query-*"]
+    params:
+      page: "1"
+      pageSize: "20"
+commands:
   create-user:
     group: "Identity"
     hidden: true
@@ -90,7 +96,17 @@ func TestLoadDir_ParsesExtendedFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadDir: %v", err)
 	}
-	cu := got["iam"]["create-user"]
+	mod := got["iam"]
+	if mod.Defaults.Pagination == nil {
+		t.Fatal("pagination defaults were not parsed")
+	}
+	if len(mod.Defaults.Pagination.MatchCommands) != 2 || mod.Defaults.Pagination.MatchCommands[0] != "list-*" {
+		t.Errorf("pagination match commands = %#v", mod.Defaults.Pagination.MatchCommands)
+	}
+	if mod.Defaults.Pagination.Params["page"] != "1" || mod.Defaults.Pagination.Params["pageSize"] != "20" {
+		t.Errorf("pagination params = %#v", mod.Defaults.Pagination.Params)
+	}
+	cu := mod.Commands["create-user"]
 	if cu.Group != "Identity" {
 		t.Errorf("group = %q, want Identity", cu.Group)
 	}
@@ -123,11 +139,11 @@ func TestLoadDir_ParsesExtendedFields(t *testing.T) {
 	if !lp.DeprecatedAlias {
 		t.Error("legacy param hidden alias = false, want true")
 	}
-	du := got["iam"]["delete-user"]
+	du := mod.Commands["delete-user"]
 	if !du.Ignore {
 		t.Error("delete-user ignore = false, want true")
 	}
-	gu := got["iam"]["get-user"]
+	gu := mod.Commands["get-user"]
 	if gu.Hidden == nil || *gu.Hidden {
 		t.Errorf("get-user hidden = %v, want false", gu.Hidden)
 	}


### PR DESCRIPTION
## Summary

- Add module-level overlay pagination defaults with command glob matching.
- Merge bulk defaults before per-command parameter overrides so explicit command defaults still win.
- Document the precedence and example schema.

Closes #34

## Verification

- `make check`
- `go test ./internal/codegen/render ./internal/lathecmd`
- `git diff --check`

## Compatibility

- Generated `CommandSpec` defaults can now come from `defaults.pagination` overlays.
- Catalog/runtime schema is unchanged; runtime still receives only merged `CommandSpec` values.
- Existing per-command `params.<name>.default` overlays continue to work and take precedence.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.