### PR TITLE
[Feat] Support required parameter overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ commands:
         --set email=alice@example.com \
         --set role=viewer
     params:
+      type:
+        help: "Required by the backend even when the upstream spec omits it"
+        required: true
       role:
         help: "User role (viewer, editor, admin)"
         default: viewer
@@ -295,7 +298,8 @@ keeps it generated but hidden from normal help and catalog output unless
 `deprecated: true`; prefer `deprecated: true` for parameter overlays.
 Bulk pagination defaults fill matching command params that have no spec default.
 Explicit `commands.<use>.params.<name>.default` still wins when a command needs a
-different value.
+different value. Parameter `required: true` marks an existing generated flag as
+required when an upstream spec is incomplete; it does not create new flags.
 
 Run codegen with an overlay directory:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,12 +211,12 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `In` | spec | locked | spec-only |
 | `GoType` | `type` / `format` | narrowing only (post-v0.1) | overlay > spec |
 | `Help` | description / comment | override | overlay > spec |
-| `Required` | `required` / path rule | relaxation only (post-v0.1) | overlay > spec |
+| `Required` | `required` / path rule | tighten optional → required | overlay > spec |
 | `Default` | spec or overlay | value | command overlay > spec > bulk overlay |
 | `Enum`, `Format` | spec | override (post-v0.1) | overlay > spec |
 | `Deprecated` | `param.deprecated` | bool; `param.hidden` is a legacy alias | overlay > spec |
 
-Two restricted-override rules: **`Required`** may only relax (required → optional), never tighten. **`GoType`** may only narrow (e.g. `string` → typed enum), never widen.
+Two restricted-override rules: **`Required`** may only tighten (optional → required), never relax. **`GoType`** may only narrow (e.g. `string` → typed enum), never widen.
 
 Command `ignore` drops an operation during codegen, so it is absent from the generated CLI and catalog. Command `hidden` keeps the operation generated but hides it from normal help, search, and catalog output; `--include-hidden` can still inspect it. Parameter `hidden` does not hide a flag; it is retained only as a legacy spelling for `deprecated: true`. Prefer `deprecated: true` for parameter overlays.
 

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -40,6 +40,9 @@ commands: {}
 #     group: "Identity"
 #     hidden: false
 #     params:
+#       type:
+#         help: "Required by the backend even when the upstream spec omits it"
+#         required: true
 #       workspace:
 #         flag: ws
 #         help: "Target workspace name"

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -152,6 +152,9 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 			if po.Help != "" {
 				spec.Params[j].Help = po.Help
 			}
+			if po.Required {
+				spec.Params[j].Required = true
+			}
 			if po.Default != "" {
 				spec.Params[j].Default = po.Default
 			}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -181,6 +181,40 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 	}
 }
 
+func TestMergeOverlay_ParamRequiredOverride(t *testing.T) {
+	specs := []runtime.CommandSpec{
+		{
+			Group: "Users", Use: "get-user", Short: "get", Method: "GET", PathTpl: "/users",
+			Params: []runtime.ParamSpec{
+				{Name: "type", Flag: "type", In: "query", GoType: "string", Help: "original help"},
+			},
+		},
+	}
+
+	merged := MergeOverlay(specs, map[string]overlay.Override{
+		"get-user": {
+			Params: map[string]overlay.ParamOverride{
+				"type":    {Required: true, Help: "override help"},
+				"missing": {Required: true},
+			},
+		},
+	})
+
+	if len(merged) != 1 {
+		t.Fatalf("merged specs = %d, want 1", len(merged))
+	}
+	if len(merged[0].Params) != 1 {
+		t.Fatalf("params = %d, want 1", len(merged[0].Params))
+	}
+	param := merged[0].Params[0]
+	if !param.Required {
+		t.Fatalf("required = false, want true")
+	}
+	if param.Help != "override help" {
+		t.Fatalf("help = %q, want override help", param.Help)
+	}
+}
+
 func TestMergeOverlayModule_BulkPaginationDefaults(t *testing.T) {
 	specs := []runtime.CommandSpec{
 		{

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -27,11 +27,14 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 	specs := []runtime.CommandSpec{
 		{
-			Group:       "Users",
-			Use:         "create-user",
-			Short:       "Raw summary",
-			Method:      "POST",
-			PathTpl:     "/users",
+			Group:   "Users",
+			Use:     "create-user",
+			Short:   "Raw summary",
+			Method:  "POST",
+			PathTpl: "/users",
+			Params: []runtime.ParamSpec{
+				{Name: "type", Flag: "type", In: runtime.InQuery, GoType: "string", Required: true, Help: "Receiver type"},
+			},
 			RequestBody: &runtime.RequestBody{Required: true, MediaType: "application/json"},
 			Output: runtime.OutputHints{
 				ListPath:          "items",
@@ -106,6 +109,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Summary: Create a user",
 		"Auth: required; scopes: `users:write`",
 		"Body: required; media type `application/json`",
+		"`--type` (query, required): Receiver type",
 		"pagination `cursor`",
 		"streaming `sse`",
 		"Notes:",

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -26,6 +26,7 @@ type Override struct {
 type ParamOverride struct {
 	Flag            string `yaml:"flag"`
 	Help            string `yaml:"help"`
+	Required        bool   `yaml:"required"`
 	Default         string `yaml:"default"`
 	DeprecatedAlias bool   `yaml:"hidden"`
 	Deprecated      bool   `yaml:"deprecated"`

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -83,6 +83,7 @@ commands:
       status:
         flag: user-status
         help: "Account status"
+        required: true
         default: "active"
         deprecated: true
       legacy:
@@ -128,6 +129,9 @@ commands:
 	}
 	if sp.Help != "Account status" {
 		t.Errorf("param help = %q, want Account status", sp.Help)
+	}
+	if !sp.Required {
+		t.Error("param required = false, want true")
 	}
 	if sp.Default != "active" {
 		t.Errorf("param default = %q, want active", sp.Default)

--- a/pkg/lathe/catalog_test.go
+++ b/pkg/lathe/catalog_test.go
@@ -41,6 +41,7 @@ func TestCommandsShowAndSearchJSON(t *testing.T) {
 		PathTpl:     "/users/{id}",
 		Params: []runtime.ParamSpec{
 			{Name: "id", Flag: "id", In: runtime.InPath, GoType: "string", Required: true, Help: "User id"},
+			{Name: "type", Flag: "type", In: runtime.InQuery, GoType: "string", Required: true, Help: "User type"},
 		},
 		Notes:         []string{"Use the canonical user ID."},
 		Prerequisites: []string{"List users before fetching details."},
@@ -66,6 +67,9 @@ func TestCommandsShowAndSearchJSON(t *testing.T) {
 	}
 	if len(entry.KnownErrors) != 1 || entry.KnownErrors[0].Status != 400 || entry.KnownErrors[0].Cause != "missing id" {
 		t.Fatalf("known errors = %#v", entry.KnownErrors)
+	}
+	if len(entry.Flags) != 2 || !entry.Flags[1].Required || entry.Flags[1].Name != "type" {
+		t.Fatalf("required query flag = %#v", entry.Flags)
 	}
 
 	out, err = execute(root, "search", "getUser", "--json")

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -187,6 +187,47 @@ func TestBuild_SetStrSendsStringBodyFields(t *testing.T) {
 	}
 }
 
+func TestBuild_RequiredQueryParamBlocksBeforeRequest(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	specs := []CommandSpec{{
+		Group:   "Receivers",
+		Use:     "get-receiver",
+		Method:  "GET",
+		PathTpl: "/receivers",
+		Params: []ParamSpec{
+			{Name: "type", Flag: "type", In: InQuery, GoType: "string", Required: true, Help: "Receiver type"},
+		},
+		Security: &SecurityHint{Public: true},
+	}}
+
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	Build(root, "demo", specs)
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "receivers", "get-receiver"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected required flag error")
+	}
+	if !strings.Contains(err.Error(), "required flag") || !strings.Contains(err.Error(), "type") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server hits = %d, want 0", hits)
+	}
+}
+
 func TestBuild_PaginationFlagsAttached(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:   "Items",


### PR DESCRIPTION
## Summary

- Add `params.<name>.required: true` to overlay parsing.
- Merge required parameter overrides into existing generated `CommandSpec` params.
- Document the tighten-only overlay behavior and cover catalog, runtime validation, and Skill references with tests.

Closes #36

## Verification

- `make check`
- Temporary downstream check in `daocloud-skills` with local lathe binary:
  - `make specsync LATHE=/tmp/lathe-local.5p3xBl`
  - `make codegen LATHE=/tmp/lathe-local.5p3xBl`
  - `make build`
  - `go test ./...`

## Compatibility

Existing overlays are unchanged unless they opt into `required: true`. Required overrides only tighten existing generated params; they do not create new flags or relax required params. Catalog schema is unchanged because `required` was already present on flags. No generated output under `internal/generated/`, `.cache/`, or ad-hoc `skills/<cli-name>/` directories is committed.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
