### PR TITLE
[Feat] Support flat single-module command paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ auth:
       fallback_field: data.email
 ```
 
+`cli.command_path` defaults to `auto`: one source module uses
+`<cli> <group> <operation>` when safe, while multiple modules keep
+`<cli> <module> <group> <operation>`. Use `namespaced` to always keep the
+module segment.
+
 ### 2. Pin API Sources
 
 `specs/sources.yaml`:

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -69,6 +69,11 @@ auth:
 ```
 
 The `cli.name` value becomes the generated binary name and root command name.
+`cli.command_path` defaults to `auto`: a single source module uses
+`<cli> <group> <operation>` when its groups do not conflict with root commands,
+and multiple modules use `<cli> <module> <group> <operation>`. Set it to
+`namespaced` to always keep the module segment, or `flat` to require the single
+module flat path and fail codegen on root command conflicts.
 
 ## Pin API Specs
 
@@ -220,7 +225,7 @@ lathe codegen -cache fixtures
 go mod tidy
 go build -o bin/petstore ./cmd/petstore
 bin/petstore search "list pets" --json
-bin/petstore commands show pets pets list --json
+bin/petstore commands show pets list --json
 bin/petstore commands schema --json
 ```
 
@@ -239,5 +244,5 @@ lathe codegen -cache fixtures
 go mod tidy
 go build -o bin/richapi ./cmd/richapi
 bin/richapi commands --json
-bin/richapi commands show acme users list --json
+bin/richapi commands show users list --json
 ```

--- a/examples/petstore/README.md
+++ b/examples/petstore/README.md
@@ -22,7 +22,7 @@ Authentication:
   auth        Authenticate petstore with a host
 
 Modules:
-  pets        pets API
+  pets        Pets operations
 
 Additional Commands:
   completion  Generate the autocompletion script for the specified shell

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -11,6 +11,7 @@ import (
 	"text/template"
 
 	"github.com/lathe-cli/lathe/internal/overlay"
+	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
@@ -25,6 +26,11 @@ type moduleCtx struct {
 	RuntimePkg    string
 	SchemaVersion int
 	Ops           []runtime.CommandSpec
+}
+
+type ModuleMount struct {
+	Name string
+	Flat bool
 }
 
 // RuntimePkg is the import path downstream-generated modules use to reach
@@ -44,6 +50,82 @@ func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides m
 	}
 	merged := MergeOverlayModule(specs, overlay.Module{Commands: overrides})
 	return renderModuleSpecs(name, cliName, merged)
+}
+
+func ResolveFlatCommandPath(policy string, moduleCount int, specs []runtime.CommandSpec) (bool, error) {
+	if policy == "" {
+		policy = config.CommandPathAuto
+	}
+	if moduleCount != 1 {
+		if policy == config.CommandPathFlat {
+			return false, fmt.Errorf("cli.command_path=flat requires exactly one source module")
+		}
+		return false, nil
+	}
+	switch policy {
+	case config.CommandPathNamespaced:
+		return false, nil
+	case config.CommandPathFlat:
+		if conflict, ok := flatPathConflict(specs); ok {
+			return false, fmt.Errorf("cli.command_path=flat conflicts with command %q", conflict)
+		}
+		return true, nil
+	case config.CommandPathAuto:
+		_, conflict := flatPathConflict(specs)
+		return !conflict, nil
+	default:
+		return false, fmt.Errorf("unknown cli.command_path %q", policy)
+	}
+}
+
+func RewriteCommandExamples(cli, module string, specs []runtime.CommandSpec, flat bool) []runtime.CommandSpec {
+	if cli == "" {
+		return specs
+	}
+	rewritten := make([]runtime.CommandSpec, 0, len(specs))
+	for _, spec := range specs {
+		next := cloneCommandSpec(spec)
+		if next.Example != "" {
+			next.Example = commandExample(next.Example, cli, module, next, flat)
+		}
+		rewritten = append(rewritten, next)
+	}
+	return rewritten
+}
+
+func flatPathConflict(specs []runtime.CommandSpec) (string, bool) {
+	seen := map[string]string{}
+	for _, spec := range specs {
+		name := rootCommandName(spec.Group)
+		if name == "" {
+			continue
+		}
+		if reservedRootCommands[name] {
+			return name, true
+		}
+		if group, ok := seen[name]; ok && group != spec.Group {
+			return name, true
+		}
+		seen[name] = spec.Group
+	}
+	return "", false
+}
+
+func rootCommandName(use string) string {
+	fields := strings.Fields(strings.ToLower(use))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+var reservedRootCommands = map[string]bool{
+	"auth":       true,
+	"commands":   true,
+	"completion": true,
+	"help":       true,
+	"search":     true,
+	"version":    true,
 }
 
 func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {
@@ -193,7 +275,7 @@ func renderModuleSpecs(name, cliName string, specs []runtime.CommandSpec) error 
 	return nil
 }
 
-func RenderModulesGen(names []string) error {
+func RenderModulesGen(modules []ModuleMount) error {
 	mp, err := modulePath()
 	if err != nil {
 		return err
@@ -201,8 +283,8 @@ func RenderModulesGen(names []string) error {
 	var buf strings.Builder
 	if err := modulesTmpl.Execute(&buf, struct {
 		Prefix  string
-		Modules []string
-	}{Prefix: mp + "/internal/generated/", Modules: names}); err != nil {
+		Modules []ModuleMount
+	}{Prefix: mp + "/internal/generated/", Modules: modules}); err != nil {
 		return err
 	}
 	formatted, err := format.Source([]byte(buf.String()))
@@ -213,7 +295,7 @@ func RenderModulesGen(names []string) error {
 	if err := os.WriteFile(ModulesGenFile, formatted, 0o644); err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "wrote %s: %d modules\n", ModulesGenFile, len(names))
+	fmt.Fprintf(os.Stderr, "wrote %s: %d modules\n", ModulesGenFile, len(modules))
 	return nil
 }
 
@@ -280,6 +362,13 @@ func Mount(root *cobra.Command) error {
 	}
 	runtime.Build(root, {{printf "%q" .CLIName}}, Specs)
 	return nil
+}
+
+func MountFlat(root *cobra.Command) error {
+	if err := runtime.AssertSchema(generatedSchemaVersion); err != nil {
+		return err
+	}
+	return runtime.BuildFlat(root, {{printf "%q" .CLIName}}, Specs)
 }
 
 var Specs = []runtime.CommandSpec{
@@ -382,7 +471,7 @@ import (
 	"github.com/spf13/cobra"
 
 {{- range .Modules}}
-	{{.}} "{{$.Prefix}}{{.}}"
+	{{.Name}} "{{$.Prefix}}{{.Name}}"
 {{- end}}
 )
 
@@ -392,7 +481,7 @@ import (
 // app.NewApp() so the framework package never imports downstream code.
 func MountModules(root *cobra.Command) error {
 {{- range .Modules}}
-	if err := {{.}}.Mount(root); err != nil {
+	if err := {{.Name}}.{{if .Flat}}MountFlat{{else}}Mount{{end}}(root); err != nil {
 		return err
 	}
 {{- end}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -357,7 +357,7 @@ func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RenderModulesGen([]string{"alpha", "beta"}); err != nil {
+	if err := RenderModulesGen([]ModuleMount{{Name: "alpha"}, {Name: "beta"}}); err != nil {
 		t.Fatalf("RenderModulesGen: %v", err)
 	}
 	out, err := os.ReadFile("internal/generated/modules_gen.go")
@@ -375,5 +375,127 @@ func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q", want)
 		}
+	}
+}
+
+func TestRenderModulesGen_UsesFlatMount(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll("internal/generated", 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RenderModulesGen([]ModuleMount{{Name: "alpha", Flat: true}}); err != nil {
+		t.Fatalf("RenderModulesGen: %v", err)
+	}
+	out, err := os.ReadFile("internal/generated/modules_gen.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(out); !strings.Contains(got, `if err := alpha.MountFlat(root); err != nil`) {
+		t.Fatalf("output did not use MountFlat:\n%s", got)
+	}
+}
+
+func TestResolveFlatCommandPath(t *testing.T) {
+	specs := []runtime.CommandSpec{{Group: "Users", Use: "list-users"}}
+	flat, err := ResolveFlatCommandPath("auto", 1, specs)
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if !flat {
+		t.Fatal("auto should flat mount a single non-conflicting module")
+	}
+
+	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{
+		{Group: "Pets", Use: "list-pets"},
+		{Group: "Pets", Use: "get-pet"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if !flat {
+		t.Fatal("auto should flat mount multiple operations in the same group")
+	}
+
+	flat, err = ResolveFlatCommandPath("auto", 2, specs)
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if flat {
+		t.Fatal("auto should keep multiple modules namespaced")
+	}
+
+	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{{Group: "Search", Use: "query"}})
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if flat {
+		t.Fatal("auto should keep conflicting single modules namespaced")
+	}
+
+	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{{Group: "Search API", Use: "query"}})
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if flat {
+		t.Fatal("auto should keep Cobra-normalized root command conflicts namespaced")
+	}
+
+	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{
+		{Group: "Users", Use: "list-users"},
+		{Group: "Users API", Use: "get-user"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if flat {
+		t.Fatal("auto should keep duplicate Cobra-normalized groups namespaced")
+	}
+
+	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{{Group: "Search", Use: "query"}})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected flat conflict error, got %v", err)
+	}
+
+	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{{Group: "Search API", Use: "query"}})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected Cobra-normalized flat conflict error, got %v", err)
+	}
+
+	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{
+		{Group: "Pets", Use: "list-pets"},
+		{Group: "Pets", Use: "get-pet"},
+	})
+	if err != nil {
+		t.Fatalf("same group operations should not conflict: %v", err)
+	}
+
+	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{
+		{Group: "Users", Use: "list-users"},
+		{Group: "Users API", Use: "get-user"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected duplicate group flat conflict error, got %v", err)
+	}
+}
+
+func TestRewriteCommandExamples_NormalizesMultiWordGroupPaths(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group:   "Payment API",
+		Use:     "list-payments",
+		Example: "acmectl billing payment api list-payments -o json",
+	}}
+
+	got := RewriteCommandExamples("acmectl", "billing", specs, true)
+	if got[0].Example != "acmectl payment list-payments -o json" {
+		t.Fatalf("flat example = %q", got[0].Example)
+	}
+
+	got = RewriteCommandExamples("acmectl", "billing", specs, false)
+	if got[0].Example != "acmectl billing payment list-payments -o json" {
+		t.Fatalf("namespaced example = %q", got[0].Example)
 	}
 }

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -23,6 +23,7 @@ type SkillModule struct {
 type moduleRef struct {
 	Module SkillModule
 	File   string
+	Flat   bool
 }
 
 const skillOwnerFile = ".lathe-skill"
@@ -35,7 +36,10 @@ func RenderSkillDirectory(root string, manifest *config.Manifest, modules []Skil
 	if err := verifySkillDirectoryOwned(clean); err != nil {
 		return err
 	}
-	refs := moduleReferences(modules)
+	refs, err := moduleReferences(manifest.CLI.CommandPath, modules)
+	if err != nil {
+		return err
+	}
 	if err := os.RemoveAll(clean); err != nil {
 		return err
 	}
@@ -52,7 +56,7 @@ func RenderSkillDirectory(root string, manifest *config.Manifest, modules []Skil
 		filepath.Join(clean, "references", "catalog.md"): renderCatalogReference(manifest),
 	}
 	for _, ref := range refs {
-		files[filepath.Join(clean, "references", "modules", ref.File)] = renderModuleReference(manifest, ref.Module)
+		files[filepath.Join(clean, "references", "modules", ref.File)] = renderModuleReference(manifest, ref.Module, ref.Flat)
 	}
 	for path, body := range files {
 		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
@@ -105,7 +109,7 @@ func SkillDirName(name string) string {
 	return out
 }
 
-func moduleReferences(modules []SkillModule) []moduleRef {
+func moduleReferences(policy string, modules []SkillModule) ([]moduleRef, error) {
 	mods := append([]SkillModule(nil), modules...)
 	sort.SliceStable(mods, func(i, j int) bool {
 		return moduleName(mods[i]) < moduleName(mods[j])
@@ -113,15 +117,19 @@ func moduleReferences(modules []SkillModule) []moduleRef {
 	used := map[string]int{}
 	refs := make([]moduleRef, 0, len(mods))
 	for _, mod := range mods {
+		flat, err := ResolveFlatCommandPath(policy, len(mods), mod.Specs)
+		if err != nil {
+			return nil, err
+		}
 		base := SkillDirName(moduleName(mod))
 		used[base]++
 		fileBase := base
 		if used[base] > 1 {
 			fileBase = fmt.Sprintf("%s-%d", base, used[base])
 		}
-		refs = append(refs, moduleRef{Module: mod, File: fileBase + ".md"})
+		refs = append(refs, moduleRef{Module: mod, File: fileBase + ".md", Flat: flat})
 	}
-	return refs
+	return refs, nil
 }
 
 func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
@@ -198,7 +206,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	return b.String()
 }
 
-func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
+func renderModuleReference(manifest *config.Manifest, mod SkillModule, flat bool) string {
 	cli := manifest.CLI.Name
 	specs := visibleSpecs(mod.Specs)
 	var b strings.Builder
@@ -221,10 +229,11 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
 		return b.String()
 	}
 	groups := groupSpecs(specs)
+	module := moduleName(mod)
 	for _, group := range sortedKeys(groups) {
 		fmt.Fprintf(&b, "## %s\n\n", group)
 		for _, spec := range groups[group] {
-			path := commandPath(cli, moduleName(mod), spec)
+			path := commandPath(cli, module, spec, flat)
 			fmt.Fprintf(&b, "### `%s`\n\n", strings.Join(path, " "))
 			if spec.Short != "" {
 				fmt.Fprintf(&b, "- Summary: %s\n", oneLine(spec.Short))
@@ -266,12 +275,31 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule) string {
 			}
 			writeOperationContext(&b, spec)
 			if spec.Example != "" {
-				writeExample(&b, spec.Example)
+				writeExample(&b, commandExample(spec.Example, cli, module, spec, flat))
 			}
 			b.WriteString("\n")
 		}
 	}
 	return b.String()
+}
+
+func commandExample(example, cli, module string, spec runtime.CommandSpec, flat bool) string {
+	newPath := strings.Join(commandPath(cli, module, spec, true), " ")
+	oldPaths := []string{strings.Join(legacyCommandPath(cli, module, spec, flat), " ")}
+	if !flat {
+		newPath = strings.Join(commandPath(cli, module, spec, false), " ")
+	} else {
+		oldPaths = append([]string{
+			strings.Join(commandPath(cli, module, spec, false), " "),
+			strings.Join(legacyCommandPath(cli, module, spec, false), " "),
+		}, oldPaths...)
+	}
+	for _, oldPath := range oldPaths {
+		if oldPath != newPath {
+			example = strings.ReplaceAll(example, oldPath, newPath)
+		}
+	}
+	return example
 }
 
 func writeOperationContext(b *strings.Builder, spec runtime.CommandSpec) {
@@ -393,8 +421,22 @@ func sourceInputs(src *sourceconfig.Source) []string {
 	}
 }
 
-func commandPath(cli, module string, spec runtime.CommandSpec) []string {
-	path := []string{cli, module}
+func commandPath(cli, module string, spec runtime.CommandSpec, flat bool) []string {
+	path := []string{cli}
+	if !flat {
+		path = append(path, module)
+	}
+	if group := rootCommandName(spec.Group); group != "" {
+		path = append(path, group)
+	}
+	return append(path, spec.Use)
+}
+
+func legacyCommandPath(cli, module string, spec runtime.CommandSpec, flat bool) []string {
+	path := []string{cli}
+	if !flat {
+		path = append(path, module)
+	}
 	if spec.Group != "" {
 		path = append(path, strings.ToLower(spec.Group))
 	}

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -105,7 +105,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Repository: https://example.com/acme.git",
 		"Resolved SHA: `abc123`",
 		"## Accounts",
-		"`acmectl users accounts create-user`",
+		"`acmectl accounts create-user`",
 		"Summary: Create a user",
 		"Auth: required; scopes: `users:write`",
 		"Body: required; media type `application/json`",
@@ -118,11 +118,14 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Find the cluster UUID first.",
 		"Known errors:",
 		"HTTP 400: missing start/end",
-		"Example: `acmectl users accounts create-user --set name=alice`",
+		"Example: `acmectl accounts create-user --set name=alice`",
 	} {
 		if !strings.Contains(module, want) {
 			t.Errorf("users.md missing %q", want)
 		}
+	}
+	if strings.Contains(module, "Example: `acmectl users accounts create-user") {
+		t.Fatalf("module reference kept stale namespaced example:\n%s", module)
 	}
 	if strings.Contains(module, "delete-user") || strings.Contains(module, "Raw summary") {
 		t.Fatalf("module reference leaked hidden command or raw overlay content:\n%s", module)
@@ -156,7 +159,7 @@ func TestRenderModuleReference_FormatsExamples(t *testing.T) {
 		},
 	}
 
-	got := renderModuleReference(manifest, module)
+	got := renderModuleReference(manifest, module, false)
 	for _, want := range []string{
 		"- Example: `acmectl users users get-user --id 123`",
 		"- Example:\n\n```\nEND=$(date +%s); START=$((END - 3600))\nacmectl users users query-logs \\\n  --start $START --end $END -o json\njq '.items[]'\n```",
@@ -164,6 +167,55 @@ func TestRenderModuleReference_FormatsExamples(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("module reference missing %q\nfull output:\n%s", want, got)
 		}
+	}
+
+	flat := renderModuleReference(manifest, module, true)
+	for _, want := range []string{
+		"- Example: `acmectl users get-user --id 123`",
+		"acmectl users query-logs \\\n  --start $START --end $END -o json",
+	} {
+		if !strings.Contains(flat, want) {
+			t.Fatalf("flat module reference missing %q\nfull output:\n%s", want, flat)
+		}
+	}
+	if strings.Contains(flat, "acmectl users users") {
+		t.Fatalf("flat module reference kept stale namespaced command:\n%s", flat)
+	}
+}
+
+func TestRenderModuleReference_NormalizesMultiWordGroupPaths(t *testing.T) {
+	manifest := &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}
+	module := SkillModule{
+		Source: &sourceconfig.Source{Name: "billing"},
+		Specs: []runtime.CommandSpec{{
+			Group:   "Payment API",
+			Use:     "list-payments",
+			Short:   "List payments",
+			Method:  "GET",
+			PathTpl: "/payments",
+			Example: "acmectl billing payment api list-payments -o json",
+		}},
+	}
+
+	namespaced := renderModuleReference(manifest, module, false)
+	if !strings.Contains(namespaced, "### `acmectl billing payment list-payments`") {
+		t.Fatalf("namespaced module reference should use Cobra command name:\n%s", namespaced)
+	}
+	if strings.Contains(namespaced, "payment api list-payments") {
+		t.Fatalf("namespaced module reference kept unnormalized group path:\n%s", namespaced)
+	}
+
+	flat := renderModuleReference(manifest, module, true)
+	for _, want := range []string{
+		"### `acmectl payment list-payments`",
+		"- Example: `acmectl payment list-payments -o json`",
+	} {
+		if !strings.Contains(flat, want) {
+			t.Fatalf("flat module reference missing %q\nfull output:\n%s", want, flat)
+		}
+	}
+	if strings.Contains(flat, "payment api list-payments") {
+		t.Fatalf("flat module reference kept unnormalized group path:\n%s", flat)
 	}
 }
 

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -148,26 +148,26 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 	}
 	syncRoot := filepath.Join(absRoot, specsync.SyncSubdir)
 
-	var manifest *config.Manifest
+	manifest, err := loadCodegenManifest(manifestPath)
+	if err != nil {
+		if skillRoot != "" || !os.IsNotExist(err) {
+			return err
+		}
+		manifest = &config.Manifest{CLI: config.CLIInfo{CommandPath: config.CommandPathAuto}}
+	}
+
 	var skillDir string
 	if skillRoot != "" {
-		data, err := os.ReadFile(manifestPath)
-		if err != nil {
-			return err
-		}
-		manifest, err = config.Load(data)
-		if err != nil {
-			return err
-		}
 		skillDir, err = skillOutputDir(skillRoot, manifest.CLI.Name)
 		if err != nil {
 			return err
 		}
 	}
 
-	var names []string
+	ordered := cfg.Ordered()
+	var mounts []render.ModuleMount
 	var skillModules []render.SkillModule
-	for _, src := range cfg.Ordered() {
+	for _, src := range ordered {
 		syncDir := filepath.Join(syncRoot, src.Name)
 		if err := specsync.VerifyState(syncDir, src.Name, src.Backend, src.PinnedTag); err != nil {
 			return err
@@ -188,23 +188,36 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 		if src.DisplayName != "" {
 			cliName = src.DisplayName
 		}
+		flat, err := render.ResolveFlatCommandPath(manifest.CLI.CommandPath, len(ordered), specs)
+		if err != nil {
+			return err
+		}
+		specs = render.RewriteCommandExamples(manifest.CLI.Name, cliName, specs, flat)
 		if err := render.RenderModule(src.Name, cliName, specs, nil); err != nil {
 			return err
 		}
-		names = append(names, src.Name)
-		if manifest != nil {
+		mounts = append(mounts, render.ModuleMount{Name: src.Name, Flat: flat})
+		if skillRoot != "" {
 			skillModules = append(skillModules, render.SkillModule{Source: src, State: state, Specs: specs})
 		}
 	}
-	if err := render.RenderModulesGen(names); err != nil {
+	if err := render.RenderModulesGen(mounts); err != nil {
 		return err
 	}
-	if manifest != nil {
+	if skillRoot != "" {
 		if err := render.RenderSkillDirectory(skillDir, manifest, skillModules); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func loadCodegenManifest(path string) (*config.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return config.Load(data)
 }
 
 func resolveCacheRoot(root string) (string, error) {

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -128,9 +128,38 @@ func TestRun_CodegenSubcommandGeneratesSkillDirectoryByDefault(t *testing.T) {
 	if !strings.Contains(skill, "acmectl search \"<intent>\" --json") {
 		t.Fatalf("skill missing search workflow:\n%s", skill)
 	}
+	modulesGen := readCodegenFile(t, "internal/generated/modules_gen.go")
+	if !strings.Contains(modulesGen, "acme.MountFlat(root)") {
+		t.Fatalf("single-module default should flat mount:\n%s", modulesGen)
+	}
 	module := readCodegenFile(t, "skills/acmectl/references/modules/acme.md")
 	if !strings.Contains(module, "Resolved SHA: `0000000000000000000000000000000000000000`") {
 		t.Fatalf("module reference missing resolved SHA:\n%s", module)
+	}
+	if !strings.Contains(module, "`acmectl users list`") {
+		t.Fatalf("module reference should use flat command path:\n%s", module)
+	}
+}
+
+func TestRunCodegen_CommandPathFlatRewritesGeneratedExamples(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "overlays/acme.yaml", `commands:
+  list:
+    example: "acmectl acme users list -o json"
+`)
+
+	if err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache", "-overlay", "overlays"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	generated := readCodegenFile(t, "internal/generated/acme/acme_gen.go")
+	if strings.Contains(generated, `"acmectl acme users list -o json"`) {
+		t.Fatalf("generated catalog example kept namespaced path:\n%s", generated)
+	}
+	if !strings.Contains(generated, `Example:     "acmectl users list -o json"`) {
+		t.Fatalf("generated catalog example should use flat path:\n%s", generated)
 	}
 }
 
@@ -202,6 +231,77 @@ func TestRunCodegen_SkillRootEmptyDisablesSkillGeneration(t *testing.T) {
 	}
 	if _, err := os.Stat("skills"); !os.IsNotExist(err) {
 		t.Fatalf("skills directory should not exist, stat err = %v", err)
+	}
+}
+
+func TestRunCodegen_CommandPathNamespacedKeepsModuleSegment(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", "cli:\n  name: acmectl\n  short: Acme CLI\n  command_path: namespaced\n")
+	writeCodegenFile(t, ".cache/specs-sync/acme/openapi.yaml", `openapi: "3.0.3"
+paths:
+  /payments:
+    get:
+      operationId: PaymentAPI_List
+      tags: ["Payment API"]
+      summary: List payments
+      responses:
+        "200":
+          description: OK
+`)
+	writeCodegenFile(t, "overlays/acme.yaml", `commands:
+  list:
+    example: "acmectl acme payment api list -o json"
+`)
+
+	if err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache", "-overlay", "overlays"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	modulesGen := readCodegenFile(t, "internal/generated/modules_gen.go")
+	if strings.Contains(modulesGen, "MountFlat") {
+		t.Fatalf("namespaced command_path should not flat mount:\n%s", modulesGen)
+	}
+	generated := readCodegenFile(t, "internal/generated/acme/acme_gen.go")
+	if strings.Contains(generated, `"acmectl acme payment api list -o json"`) {
+		t.Fatalf("generated catalog example kept unnormalized path:\n%s", generated)
+	}
+	if !strings.Contains(generated, `Example:     "acmectl acme payment list -o json"`) {
+		t.Fatalf("generated catalog example should use namespaced Cobra path:\n%s", generated)
+	}
+	module := readCodegenFile(t, "skills/acmectl/references/modules/acme.md")
+	if !strings.Contains(module, "`acmectl acme payment list`") {
+		t.Fatalf("module reference should keep module path:\n%s", module)
+	}
+	if strings.Contains(module, "payment api list") {
+		t.Fatalf("module reference kept unnormalized path:\n%s", module)
+	}
+}
+
+func TestRunCodegen_CommandPathFlatRejectsRootConflict(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", "cli:\n  name: acmectl\n  short: Acme CLI\n  command_path: flat\n")
+	writeCodegenFile(t, ".cache/specs-sync/acme/openapi.yaml", `openapi: "3.0.3"
+paths:
+  /query:
+    get:
+      operationId: Search_Query
+      tags: [Search]
+      summary: Query search
+      responses:
+        "200":
+          description: OK
+`)
+
+	err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected flat conflict error, got %v", err)
+	}
+	if _, err := os.Stat("internal/generated/acme/acme_gen.go"); !os.IsNotExist(err) {
+		t.Fatalf("conflicting flat config should fail before writing module output, stat err = %v", err)
 	}
 }
 

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -19,6 +19,7 @@ type CLIInfo struct {
 	ConfigDir    string `yaml:"config_dir"`
 	ConfigDirEnv string `yaml:"config_dir_env"`
 	HostEnv      string `yaml:"host_env"`
+	CommandPath  string `yaml:"command_path"`
 }
 
 type AuthInfo struct {
@@ -36,6 +37,12 @@ type AuthValidateDisplay struct {
 	FallbackField string `yaml:"fallback_field"`
 }
 
+const (
+	CommandPathAuto       = "auto"
+	CommandPathFlat       = "flat"
+	CommandPathNamespaced = "namespaced"
+)
+
 // Load parses raw cli.yaml bytes into a Manifest. The caller (typically main.go)
 // supplies the bytes — usually via //go:embed at the module root — so that
 // pkg/config stays free of a reverse import on the downstream repo root.
@@ -51,6 +58,15 @@ func Load(bytes []byte) (*Manifest, error) {
 	}
 	if m.CLI.Name == "" {
 		return nil, fmt.Errorf("cli.name is required")
+	}
+	m.CLI.CommandPath = strings.ToLower(strings.TrimSpace(m.CLI.CommandPath))
+	if m.CLI.CommandPath == "" {
+		m.CLI.CommandPath = CommandPathAuto
+	}
+	switch m.CLI.CommandPath {
+	case CommandPathAuto, CommandPathFlat, CommandPathNamespaced:
+	default:
+		return nil, fmt.Errorf("cli.command_path must be one of %q, %q, or %q", CommandPathAuto, CommandPathFlat, CommandPathNamespaced)
 	}
 	upper := strings.ToUpper(m.CLI.Name)
 	if m.CLI.ConfigDir == "" {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -102,6 +102,9 @@ func TestLoad_DerivesIdentityDefaults(t *testing.T) {
 	if got, want := m.CLI.HostEnv, "FOOBAR_HOST"; got != want {
 		t.Errorf("HostEnv: got %q, want %q", got, want)
 	}
+	if got, want := m.CLI.CommandPath, CommandPathAuto; got != want {
+		t.Errorf("CommandPath: got %q, want %q", got, want)
+	}
 }
 
 func TestLoad_PreservesExplicitIdentity(t *testing.T) {
@@ -117,6 +120,29 @@ cli:
 	}
 	if m.CLI.ConfigDir != "legacy" || m.CLI.ConfigDirEnv != "LEGACY_CONFIG" || m.CLI.HostEnv != "LEGACY_HOST" {
 		t.Errorf("explicit identity overridden: %+v", m.CLI)
+	}
+}
+
+func TestLoad_CommandPath(t *testing.T) {
+	m, err := Load([]byte(`
+cli:
+  name: foo
+  command_path: Namespaced
+`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got, want := m.CLI.CommandPath, CommandPathNamespaced; got != want {
+		t.Fatalf("CommandPath: got %q, want %q", got, want)
+	}
+
+	_, err = Load([]byte(`
+cli:
+  name: foo
+  command_path: short
+`))
+	if err == nil {
+		t.Fatal("expected invalid command_path error")
 	}
 }
 

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -30,20 +30,46 @@ func AssertSchema(generated int) error {
 // data, the execution path is a single function.
 func Build(root *cobra.Command, service string, specs []CommandSpec) {
 	svc := &cobra.Command{Use: service, Short: service + " API", GroupID: ModuleGroupID}
+	for _, group := range buildGroups(service, specs) {
+		svc.AddCommand(group)
+	}
+	root.AddCommand(svc)
+}
+
+func BuildFlat(root *cobra.Command, service string, specs []CommandSpec) error {
+	groups := buildGroups(service, specs)
+	seen := map[string]bool{}
+	for _, group := range groups {
+		group.GroupID = ModuleGroupID
+		name := group.Name()
+		if seen[name] {
+			return fmt.Errorf("flat mount command %q conflicts with another generated command", name)
+		}
+		seen[name] = true
+		if findChildCommand(root, name) != nil {
+			return fmt.Errorf("flat mount command %q conflicts with existing root command", name)
+		}
+	}
+	root.AddCommand(groups...)
+	return nil
+}
+
+func buildGroups(service string, specs []CommandSpec) []*cobra.Command {
 	groups := map[string]*cobra.Command{}
+	ordered := make([]*cobra.Command, 0)
 	for i := range specs {
 		s := specs[i]
 		g, ok := groups[s.Group]
 		if !ok {
 			g = &cobra.Command{Use: strings.ToLower(s.Group), Short: s.Group + " operations"}
 			groups[s.Group] = g
-			svc.AddCommand(g)
+			ordered = append(ordered, g)
 		}
 		c := buildCmd(s)
 		AttachCatalogCommand(c, service, s)
 		g.AddCommand(c)
 	}
-	root.AddCommand(svc)
+	return ordered
 }
 
 func buildCmd(s CommandSpec) *cobra.Command {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -103,6 +103,61 @@ func TestBuild_EmptySpecsMountsEmptyService(t *testing.T) {
 	}
 }
 
+func TestBuildFlat_PopulatesRootGroupTree(t *testing.T) {
+	specs := []CommandSpec{{
+		Group:   "Users",
+		Use:     "get-user",
+		Method:  "GET",
+		PathTpl: "/users/{id}",
+	}}
+
+	root := newRootWithModuleGroup()
+	if err := BuildFlat(root, "demo", specs); err != nil {
+		t.Fatalf("BuildFlat: %v", err)
+	}
+
+	users := mustFindChild(t, root, "users")
+	getUser := mustFindChild(t, users, "get-user")
+	entry, ok := catalogCommandFromAnnotation(getUser, []string{"users", "get-user"})
+	if !ok {
+		t.Fatal("missing catalog annotation")
+	}
+	if !reflect.DeepEqual(entry.Path, []string{"users", "get-user"}) {
+		t.Fatalf("path = %#v", entry.Path)
+	}
+	if entry.Service != "demo" {
+		t.Fatalf("service = %q, want demo", entry.Service)
+	}
+}
+
+func TestBuildFlat_RejectsRootCommandConflict(t *testing.T) {
+	root := newRootWithModuleGroup()
+	root.AddCommand(&cobra.Command{Use: "search"})
+
+	err := BuildFlat(root, "demo", []CommandSpec{{Group: "Search", Use: "query"}})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+	if len(mustFindChild(t, root, "search").Commands()) != 0 {
+		t.Fatal("conflicting generated group should not be attached")
+	}
+}
+
+func TestBuildFlat_RejectsGeneratedGroupNameConflict(t *testing.T) {
+	root := newRootWithModuleGroup()
+
+	err := BuildFlat(root, "demo", []CommandSpec{
+		{Group: "Users", Use: "list", Method: "GET", PathTpl: "/users"},
+		{Group: "Users API", Use: "get", Method: "GET", PathTpl: "/users/{id}"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected generated group conflict error, got %v", err)
+	}
+	if len(root.Commands()) != 0 {
+		t.Fatalf("conflicting generated groups should not be attached, got %v", cmdNames(root.Commands()))
+	}
+}
+
 func TestBuild_BodyFlagsAttachedWhenHasBody(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:       "Users",


### PR DESCRIPTION
## Summary

- add `cli.command_path` with `auto`, `flat`, and `namespaced` modes
- flat mount safe single-module generated CLIs at `<cli> <group> <operation>`
- keep namespaced paths for multi-module CLIs or flat root conflicts, and normalize generated catalog/Skill examples to executable Cobra paths

## Why

Single-source CLIs do not need to repeat the module segment. The previous generated shape forced paths like `<cli> <module> <group> <operation>` even when the module name is effectively the CLI name. This preserves the existing module mechanism while simplifying the default path only when codegen can prove it is safe.

## Validation

- `go test ./internal/codegen/render ./internal/lathecmd ./pkg/runtime -count=1`
- `git diff --check`
- `make check`
