### PR TITLE
[Fix] runtime: redact sensitive fields in debug HTTP logs

### DIFF
--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
@@ -23,16 +24,12 @@ type debugTransport struct {
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, req.URL)
 	for k, vs := range req.Header {
-		v := strings.Join(vs, ", ")
-		if strings.EqualFold(k, "authorization") {
-			v = "***"
-		}
-		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, v)
+		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", ")))
 	}
 	if req.Body != nil && isTextContent(req.Header.Get("Content-Type")) {
 		body, restored := peekBody(req.Body, maxDebugReqBody)
 		req.Body = restored
-		dumpBody(os.Stderr, ">", body, maxDebugReqBody)
+		dumpBody(os.Stderr, ">", redactDebugBody(req.Header.Get("Content-Type"), body), maxDebugReqBody)
 	}
 	fmt.Fprintln(os.Stderr)
 
@@ -47,12 +44,12 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	fmt.Fprintf(os.Stderr, "< %s (%s)\n", resp.Status, elapsed)
 	for k, vs := range resp.Header {
-		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, strings.Join(vs, ", "))
+		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", ")))
 	}
 	if isTextContent(resp.Header.Get("Content-Type")) {
 		body, restored := peekBody(resp.Body, maxDebugRespBody)
 		resp.Body = restored
-		dumpBody(os.Stderr, "<", body, maxDebugRespBody)
+		dumpBody(os.Stderr, "<", redactDebugBody(resp.Header.Get("Content-Type"), body), maxDebugRespBody)
 	}
 	fmt.Fprintln(os.Stderr)
 
@@ -76,6 +73,88 @@ func isTextContent(ct string) bool {
 		return true
 	}
 	return false
+}
+
+func redactDebugHeader(name, value string) string {
+	if isSensitiveDebugName(name) {
+		return "***"
+	}
+	return value
+}
+
+func isSensitiveDebugName(name string) bool {
+	n := strings.ToLower(name)
+	switch n {
+	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key":
+		return true
+	}
+	for _, marker := range []string{"token", "key", "secret", "password", "credential"} {
+		if strings.Contains(n, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactDebugBody(contentType string, body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	mt, _, _ := mime.ParseMediaType(contentType)
+	if mt == "application/json" {
+		var v any
+		if err := json.Unmarshal(body, &v); err == nil {
+			if redactDebugJSON(v) {
+				redacted, err := json.Marshal(v)
+				if err == nil {
+					return redacted
+				}
+			}
+		}
+	}
+	return []byte(redactDebugText(string(body)))
+}
+
+func redactDebugJSON(v any) bool {
+	switch tv := v.(type) {
+	case map[string]any:
+		changed := false
+		for k, child := range tv {
+			if isSensitiveDebugName(k) {
+				tv[k] = "***"
+				changed = true
+				continue
+			}
+			if redactDebugJSON(child) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, child := range tv {
+			if redactDebugJSON(child) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
+}
+
+func redactDebugText(s string) string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return r == '&' || r == ';' || r == '\n' || r == '\r'
+	})
+	for _, field := range fields {
+		name, value, ok := strings.Cut(field, "=")
+		if !ok || !isSensitiveDebugName(strings.TrimSpace(name)) || value == "" {
+			continue
+		}
+		s = strings.ReplaceAll(s, field, name+"=***")
+	}
+	return s
 }
 
 func peekBody(body io.ReadCloser, max int) ([]byte, io.ReadCloser) {

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -64,6 +64,72 @@ func TestDebugTransport_LogsJSONBody(t *testing.T) {
 	}
 }
 
+func TestDebugTransport_RedactsSensitiveHeaders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Set-Cookie", "session=response-secret")
+		w.Header().Set("X-Api-Key", "response-key")
+		w.Write([]byte(`ok`))
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer request-token")
+	req.Header.Set("Cookie", "session=request-secret")
+	req.Header.Set("X-API-Key", "request-key")
+	req.Header.Set("X-Trace-Token", "trace-secret")
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	for _, leaked := range []string{"request-token", "request-secret", "request-key", "trace-secret", "response-secret", "response-key"} {
+		if strings.Contains(out, leaked) {
+			t.Fatalf("debug output leaked %q:\n%s", leaked, out)
+		}
+	}
+	if strings.Count(out, "***") < 6 {
+		t.Fatalf("debug output did not redact expected headers:\n%s", out)
+	}
+}
+
+func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"result":"ok","token":"response-token","nested":{"apiKey":"response-key"}}`))
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+
+	dt := &debugTransport{inner: http.DefaultTransport}
+	body := strings.NewReader(`{"name":"test","secret":"request-secret","nested":{"password":"request-password"}}`)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	for _, leaked := range []string{"request-secret", "request-password", "response-token", "response-key"} {
+		if strings.Contains(out, leaked) {
+			t.Fatalf("debug body leaked %q:\n%s", leaked, out)
+		}
+	}
+	if !strings.Contains(out, `"name":"test"`) || !strings.Contains(out, `"result":"ok"`) {
+		t.Fatalf("debug output lost non-sensitive fields:\n%s", out)
+	}
+	if strings.Count(out, "***") < 4 {
+		t.Fatalf("debug output did not redact expected body fields:\n%s", out)
+	}
+}
+
 func TestDebugTransport_TruncatesLargeBody(t *testing.T) {
 	large := strings.Repeat("x", 5000)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### What's changed?

- Extend debug transport logging to redact sensitive request/response headers beyond `Authorization` (cookies, API keys, token-like header names).
- Redact sensitive fields in JSON and form-like text bodies before dumping debug output.
- Add tests ensuring secrets do not appear on stderr while non-sensitive fields remain visible.

### Why

- Debug mode is meant for troubleshooting, but it must not leak credentials into logs or agent-visible stderr output.