### PR TITLE
[Refactor] Deduplicate test helpers

### DIFF
--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -1,10 +1,8 @@
 package openapi3
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
@@ -45,19 +43,7 @@ func TestParse_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Parse: %v", err)
 			}
-			sort.Slice(mod.Operations, func(i, j int) bool {
-				if mod.Operations[i].Path != mod.Operations[j].Path {
-					return mod.Operations[i].Path < mod.Operations[j].Path
-				}
-				return mod.Operations[i].Method < mod.Operations[j].Method
-			})
-
-			data, err := json.MarshalIndent(mod, "", "  ")
-			if err != nil {
-				t.Fatalf("marshal rawir: %v", err)
-			}
-			data = append(data, '\n')
-			testutil.AssertGolden(t, filepath.Join("testdata", tc.name+".golden.json"), data)
+			testutil.AssertRawModuleGolden(t, tc.name, mod)
 		})
 	}
 }

--- a/internal/codegen/backends/proto/backend_test.go
+++ b/internal/codegen/backends/proto/backend_test.go
@@ -1,10 +1,8 @@
 package proto
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -46,19 +44,7 @@ func TestParse_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Parse: %v", err)
 			}
-			sort.Slice(mod.Operations, func(i, j int) bool {
-				if mod.Operations[i].Path != mod.Operations[j].Path {
-					return mod.Operations[i].Path < mod.Operations[j].Path
-				}
-				return mod.Operations[i].Method < mod.Operations[j].Method
-			})
-
-			out, err := json.MarshalIndent(mod, "", "  ")
-			if err != nil {
-				t.Fatalf("marshal rawir: %v", err)
-			}
-			out = append(out, '\n')
-			testutil.AssertGolden(t, filepath.Join("testdata", tc.name+".golden.json"), out)
+			testutil.AssertRawModuleGolden(t, tc.name, mod)
 		})
 	}
 }

--- a/internal/codegen/backends/swagger/backend_test.go
+++ b/internal/codegen/backends/swagger/backend_test.go
@@ -1,10 +1,8 @@
 package swagger
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
@@ -42,19 +40,7 @@ func TestParse_Golden(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Parse: %v", err)
 			}
-			sort.Slice(mod.Operations, func(i, j int) bool {
-				if mod.Operations[i].Path != mod.Operations[j].Path {
-					return mod.Operations[i].Path < mod.Operations[j].Path
-				}
-				return mod.Operations[i].Method < mod.Operations[j].Method
-			})
-
-			data, err := json.MarshalIndent(mod, "", "  ")
-			if err != nil {
-				t.Fatalf("marshal rawir: %v", err)
-			}
-			data = append(data, '\n')
-			testutil.AssertGolden(t, filepath.Join("testdata", tc.name+".golden.json"), data)
+			testutil.AssertRawModuleGolden(t, tc.name, mod)
 		})
 	}
 }

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -1,8 +1,6 @@
 package normalize
 
 import (
-	"encoding/json"
-	"path/filepath"
 	"testing"
 
 	"github.com/lathe-cli/lathe/internal/codegen/rawir"
@@ -36,12 +34,7 @@ func TestNormalize_Golden(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			specs := Normalize(tc.input())
-			data, err := json.MarshalIndent(specs, "", "  ")
-			if err != nil {
-				t.Fatalf("marshal specs: %v", err)
-			}
-			data = append(data, '\n')
-			testutil.AssertGolden(t, filepath.Join("testdata", tc.name+".golden.json"), data)
+			testutil.AssertNamedJSONGolden(t, tc.name, specs)
 		})
 	}
 }

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -11,11 +11,42 @@ import (
 	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
-func TestRenderModule_AppliesOverlay(t *testing.T) {
+func chdirWithGoMod(t *testing.T) {
+	t.Helper()
 	t.Chdir(t.TempDir())
 	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func chdirWithGeneratedRoot(t *testing.T) {
+	t.Helper()
+	chdirWithGoMod(t)
+	if err := os.MkdirAll("internal/generated", 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func generatedModule(t *testing.T, name string) string {
+	t.Helper()
+	out, err := os.ReadFile(filepath.Join("internal/generated", name, name+"_gen.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func generatedModules(t *testing.T) string {
+	t.Helper()
+	out, err := os.ReadFile("internal/generated/modules_gen.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func TestRenderModule_AppliesOverlay(t *testing.T) {
+	chdirWithGoMod(t)
 
 	specs := []runtime.CommandSpec{
 		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/api/v1/addon", RequestBody: &runtime.RequestBody{Required: true, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}},
@@ -36,11 +67,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
-	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
-	if err != nil {
-		t.Fatalf("read output: %v", err)
-	}
-	got := string(out)
+	got := generatedModule(t, "demo")
 
 	for _, want := range []string{
 		`"OVERLAY SHORT"`,
@@ -76,10 +103,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 }
 
 func TestRenderModule_IgnoreDropsCommand(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGoMod(t)
 	specs := []runtime.CommandSpec{
 		{Group: "Addon", Use: "install-addon", Short: "install", Method: "POST", PathTpl: "/addon"},
 		{Group: "Addon", Use: "delete-addon", Short: "delete", Method: "DELETE", PathTpl: "/addon/{id}"},
@@ -90,11 +114,7 @@ func TestRenderModule_IgnoreDropsCommand(t *testing.T) {
 	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
-	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(out)
+	got := generatedModule(t, "demo")
 	if !strings.Contains(got, `"install-addon"`) {
 		t.Error("install-addon should be present")
 	}
@@ -104,10 +124,7 @@ func TestRenderModule_IgnoreDropsCommand(t *testing.T) {
 }
 
 func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGoMod(t)
 	hidden := true
 	specs := []runtime.CommandSpec{
 		{Group: "Default", Use: "get-item", Short: "get", Method: "GET", PathTpl: "/item"},
@@ -118,11 +135,7 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
-	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(out)
+	got := generatedModule(t, "demo")
 	if strings.Contains(got, `"Default"`) {
 		t.Error("group should be overridden; Default should not appear")
 	}
@@ -135,10 +148,7 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 }
 
 func TestRenderModule_ParamOverride(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGoMod(t)
 	specs := []runtime.CommandSpec{
 		{
 			Group: "Users", Use: "list-users", Short: "list", Method: "GET", PathTpl: "/users",
@@ -159,11 +169,7 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
 	}
-	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(out)
+	got := generatedModule(t, "demo")
 	if !strings.Contains(got, `"user-status"`) {
 		t.Error("flag should be renamed to user-status")
 	}
@@ -311,10 +317,7 @@ func TestMergeOverlayModule_BulkDefaultsDoNotReplaceSpecDefaults(t *testing.T) {
 }
 
 func TestRenderModule_NilOverrides(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGoMod(t)
 
 	specs := []runtime.CommandSpec{
 		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/x"},
@@ -322,11 +325,7 @@ func TestRenderModule_NilOverrides(t *testing.T) {
 	if err := RenderModule("demo", "", specs, nil); err != nil {
 		t.Fatalf("RenderModule nil overrides: %v", err)
 	}
-	out, err := os.ReadFile(filepath.Join("internal/generated/demo/demo_gen.go"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(out), `"raw short"`) {
+	if !strings.Contains(generatedModule(t, "demo"), `"raw short"`) {
 		t.Errorf("expected raw short preserved when overrides is nil")
 	}
 }
@@ -349,22 +348,12 @@ func paramDefault(t *testing.T, specs []runtime.CommandSpec, use string, name st
 }
 
 func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll("internal/generated", 0o755); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGeneratedRoot(t)
 
 	if err := RenderModulesGen([]ModuleMount{{Name: "alpha"}, {Name: "beta"}}); err != nil {
 		t.Fatalf("RenderModulesGen: %v", err)
 	}
-	out, err := os.ReadFile("internal/generated/modules_gen.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	got := string(out)
+	got := generatedModules(t)
 	for _, want := range []string{
 		`func MountModules(root *cobra.Command) error`,
 		`if err := alpha.Mount(root); err != nil`,
@@ -379,22 +368,12 @@ func TestRenderModulesGen_PropagatesMountErrors(t *testing.T) {
 }
 
 func TestRenderModulesGen_UsesFlatMount(t *testing.T) {
-	t.Chdir(t.TempDir())
-	if err := os.WriteFile("go.mod", []byte("module example.com/fake\n\ngo 1.25\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll("internal/generated", 0o755); err != nil {
-		t.Fatal(err)
-	}
+	chdirWithGeneratedRoot(t)
 
 	if err := RenderModulesGen([]ModuleMount{{Name: "alpha", Flat: true}}); err != nil {
 		t.Fatalf("RenderModulesGen: %v", err)
 	}
-	out, err := os.ReadFile("internal/generated/modules_gen.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := string(out); !strings.Contains(got, `if err := alpha.MountFlat(root); err != nil`) {
+	if got := generatedModules(t); !strings.Contains(got, `if err := alpha.MountFlat(root); err != nil`) {
 		t.Fatalf("output did not use MountFlat:\n%s", got)
 	}
 }

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -2,10 +2,14 @@ package testutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+
+	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 )
 
 var update = flag.Bool("update", false, "update golden files instead of asserting against them")
@@ -45,6 +49,33 @@ func AssertGolden(tb TB, goldenPath string, actual []byte) {
 	}
 
 	tb.Errorf("golden mismatch: %s\n%s", goldenPath, lineDiff(want, actual))
+}
+
+func AssertJSONGolden(tb TB, goldenPath string, actual any) {
+	tb.Helper()
+	data, err := json.MarshalIndent(actual, "", "  ")
+	if err != nil {
+		tb.Fatalf("marshal golden json: %v", err)
+		return
+	}
+	data = append(data, '\n')
+	AssertGolden(tb, goldenPath, data)
+}
+
+func AssertNamedJSONGolden(tb TB, name string, actual any) {
+	tb.Helper()
+	AssertJSONGolden(tb, filepath.Join("testdata", name+".golden.json"), actual)
+}
+
+func AssertRawModuleGolden(tb TB, name string, mod *rawir.RawModule) {
+	tb.Helper()
+	sort.Slice(mod.Operations, func(i, j int) bool {
+		if mod.Operations[i].Path != mod.Operations[j].Path {
+			return mod.Operations[i].Path < mod.Operations[j].Path
+		}
+		return mod.Operations[i].Method < mod.Operations[j].Method
+	})
+	AssertNamedJSONGolden(tb, name, mod)
 }
 
 func writeGolden(tb TB, path string, data []byte) {


### PR DESCRIPTION
## Summary

- Add shared JSON golden helpers in `internal/testutil` for formatted golden assertions and sorted `rawir.RawModule` output.
- Use those helpers in backend and normalize golden tests.
- Add local render test fixture helpers for temporary Go module setup and generated output reads.

## Verification

- `python3 /Users/x/.agents/skills/codex-review/scripts/run_codex_review.py --uncommitted`
- `make check`

## Compatibility

None. This is test-only cleanup and does not change generated command shape, catalog schema, auth/body/output behavior, or docs.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] No user-facing behavior changes.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.