### PR TITLE
feat(codegen): add -skill-include to append onto generated skill files

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -134,7 +134,17 @@ lathe specsync -source users
 lathe specsync -cache .cache
 lathe codegen -overlay internal/overlay
 lathe codegen -skill-root ""
+lathe codegen -skill-include internal/skill-include
 ```
+
+`-skill-include <dir>` points at a directory of hand-authored markdown that is
+appended onto the generated skill files after they are rendered. Each file is
+mapped by its relative path onto `skills/<cli-name>/<rel>`: when the target
+already exists the include is appended (after a blank line); otherwise it is
+created. Use it to add product-specific skill guidance without editing the
+generated files (which are overwritten on every run). Keep the include directory
+outside `skills/` (e.g. `internal/skill-include/`) so it is not wiped during
+regeneration. Omitting the flag leaves skill output unchanged.
 
 Generated outputs:
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -75,6 +75,19 @@ and multiple modules use `<cli> <module> <group> <operation>`. Set it to
 `namespaced` to always keep the module segment, or `flat` to require the single
 module flat path and fail codegen on root command conflicts.
 
+To customize generated Skill output, add an optional top-level `skill` block:
+
+```yaml
+skill:
+  root: skills
+  include: internal/skill-include
+```
+
+The optional `skill.root` value controls where generated Skill files are written;
+set it to `""` to disable Skill generation. The optional `skill.include` value
+points at repo-local Skill resources merged into generated Skill files. Keep the
+include directory outside `skill.root`.
+
 ## Pin API Specs
 
 Create `specs/sources.yaml`:
@@ -137,26 +150,29 @@ lathe codegen -skill-root ""
 lathe codegen -skill-include internal/skill-include
 ```
 
-`-skill-include <dir>` points at a directory of hand-authored markdown that is
-appended onto the generated skill files after they are rendered. Each file is
-mapped by its relative path onto `skills/<cli-name>/<rel>`: when the target
-already exists the include is appended (after a blank line); otherwise it is
-created. Use it to add product-specific skill guidance without editing the
-generated files (which are overwritten on every run). Keep the include directory
-outside `skills/` (e.g. `internal/skill-include/`) so it is not wiped during
-regeneration. Omitting the flag leaves skill output unchanged.
+`-skill-root` and `-skill-include` override the `skill.root` and `skill.include`
+values from `cli.yaml` for one run. Prefer `cli.yaml` for reproducible generated
+Skill output. When `skill.include` or `-skill-include` is set, the directory must
+already exist and must be outside `skill.root`. Files under the include directory
+are mapped by relative path onto `<skill.root>/<cli-name>/<rel>`. Include files
+may target `SKILL.md`, `references/`, `scripts/`, `assets/`, and `agents/`.
+`SKILL.md` and existing `references/**/*.md` targets are appended after a blank
+line. New files under the allowed Skill resource directories are created. Existing
+generated non-markdown files, such as `agents/openai.yaml`, are not overwritten
+or appended.
 
 Generated outputs:
 
 ```text
 internal/generated/
-skills/<cli-name>/
+<skill.root>/<cli-name>/
 ```
 
-`internal/generated/` contains generated Go command specs. `skills/<cli-name>/`
-contains the generated agent Skill guide and module references. These outputs
-are reproducible from `cli.yaml`, `specs/sources.yaml`, pinned specs, and
-overlays.
+`internal/generated/` contains generated Go command specs. `<skill.root>/<cli-name>/`
+contains the generated agent Skill guide and module references when Skill
+generation is enabled. These outputs are reproducible from `cli.yaml`,
+`specs/sources.yaml`, pinned specs, and overlays. Skill output also includes any
+resources declared by `skill.include`.
 
 ## Wire the Generated CLI
 

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -3,7 +3,6 @@ package render
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -68,28 +67,42 @@ func RenderSkillDirectory(root string, manifest *config.Manifest, modules []Skil
 	return nil
 }
 
-// ApplySkillIncludes appends hand-authored markdown from includeRoot onto the
-// generated skill files under skillDir. Each file in includeRoot is mapped by
-// its relative path onto skillDir/<rel>: if the target already exists the
-// include is appended after a blank-line separator; otherwise the target is
-// created. An empty or non-existent includeRoot is a no-op. This must run after
-// RenderSkillDirectory (which wipes and rewrites skillDir), so includeRoot must
-// live outside skillDir.
-func ApplySkillIncludes(skillDir, includeRoot string) error {
+func ValidateSkillIncludeRoot(skillRoot, includeRoot string) error {
 	if includeRoot == "" {
 		return nil
 	}
 	info, err := os.Stat(includeRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil
+			return fmt.Errorf("skill include root %q does not exist", includeRoot)
 		}
 		return err
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("skill include root %q is not a directory", includeRoot)
 	}
-	return filepath.WalkDir(includeRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	absRoot, err := filepath.Abs(skillRoot)
+	if err != nil {
+		return err
+	}
+	absInclude, err := filepath.Abs(includeRoot)
+	if err != nil {
+		return err
+	}
+	if pathContains(absRoot, absInclude) || pathContains(absInclude, absRoot) {
+		return fmt.Errorf("skill include root %q must be outside skill root %q", includeRoot, skillRoot)
+	}
+	return nil
+}
+
+func ApplySkillIncludes(skillDir, includeRoot string) error {
+	if includeRoot == "" {
+		return nil
+	}
+	if err := ValidateSkillIncludeRoot(filepath.Dir(skillDir), includeRoot); err != nil {
+		return err
+	}
+	return filepath.WalkDir(includeRoot, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
@@ -99,6 +112,18 @@ func ApplySkillIncludes(skillDir, includeRoot string) error {
 		rel, err := filepath.Rel(includeRoot, path)
 		if err != nil {
 			return err
+		}
+		rel = filepath.Clean(rel)
+		canAppend, err := skillIncludeFileCanAppend(rel)
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("skill include file %q is not a regular file", path)
 		}
 		add, err := os.ReadFile(path)
 		if err != nil {
@@ -112,10 +137,13 @@ func ApplySkillIncludes(skillDir, includeRoot string) error {
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}
+		if len(existing) > 0 && !canAppend {
+			return fmt.Errorf("skill include file %q targets an existing non-appendable generated file", rel)
+		}
 		var merged []byte
 		if len(existing) > 0 {
 			merged = append(merged, existing...)
-			if !strings.HasSuffix(string(existing), "\n") {
+			if existing[len(existing)-1] != '\n' {
 				merged = append(merged, '\n')
 			}
 			merged = append(merged, '\n')
@@ -123,6 +151,31 @@ func ApplySkillIncludes(skillDir, includeRoot string) error {
 		merged = append(merged, add...)
 		return os.WriteFile(target, merged, 0o644)
 	})
+}
+
+func skillIncludeFileCanAppend(rel string) (bool, error) {
+	slash := filepath.ToSlash(rel)
+	switch {
+	case slash == "SKILL.md":
+		return true, nil
+	case strings.HasPrefix(slash, "references/") && strings.HasSuffix(slash, ".md"):
+		return true, nil
+	case strings.HasPrefix(slash, "agents/"),
+		strings.HasPrefix(slash, "assets/"),
+		strings.HasPrefix(slash, "references/"),
+		strings.HasPrefix(slash, "scripts/"):
+		return false, nil
+	default:
+		return false, fmt.Errorf("skill include file %q must target SKILL.md, agents/, assets/, references/, or scripts/", rel)
+	}
+}
+
+func pathContains(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return filepath.IsLocal(rel)
 }
 
 func verifySkillDirectoryOwned(root string) error {

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -3,6 +3,7 @@ package render
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -65,6 +66,63 @@ func RenderSkillDirectory(root string, manifest *config.Manifest, modules []Skil
 	}
 	fmt.Fprintf(os.Stderr, "wrote %s: %d modules\n", clean, len(refs))
 	return nil
+}
+
+// ApplySkillIncludes appends hand-authored markdown from includeRoot onto the
+// generated skill files under skillDir. Each file in includeRoot is mapped by
+// its relative path onto skillDir/<rel>: if the target already exists the
+// include is appended after a blank-line separator; otherwise the target is
+// created. An empty or non-existent includeRoot is a no-op. This must run after
+// RenderSkillDirectory (which wipes and rewrites skillDir), so includeRoot must
+// live outside skillDir.
+func ApplySkillIncludes(skillDir, includeRoot string) error {
+	if includeRoot == "" {
+		return nil
+	}
+	info, err := os.Stat(includeRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("skill include root %q is not a directory", includeRoot)
+	}
+	return filepath.WalkDir(includeRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(includeRoot, path)
+		if err != nil {
+			return err
+		}
+		add, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(skillDir, rel)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		existing, err := os.ReadFile(target)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		var merged []byte
+		if len(existing) > 0 {
+			merged = append(merged, existing...)
+			if !strings.HasSuffix(string(existing), "\n") {
+				merged = append(merged, '\n')
+			}
+			merged = append(merged, '\n')
+		}
+		merged = append(merged, add...)
+		return os.WriteFile(target, merged, 0o644)
+	})
 }
 
 func verifySkillDirectoryOwned(root string) error {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -303,15 +303,14 @@ func TestApplySkillIncludes_AppendsAndCreates(t *testing.T) {
 	before := readFile(t, dir, "skills/acmectl/SKILL.md")
 
 	include := filepath.Join(dir, "include")
-	if err := os.MkdirAll(filepath.Join(include, "references"), 0o755); err != nil {
-		t.Fatal(err)
+	includeFiles := map[string]string{
+		"SKILL.md":             "## Module availability\n\nExtra guidance.\n",
+		"references/extra.md":  "# Extra\n",
+		"scripts/helper.py":    "print('ok')\n",
+		"assets/template.html": "<main></main>\n",
+		"agents/metadata.yaml": "policy: {}\n",
 	}
-	if err := os.WriteFile(filepath.Join(include, "SKILL.md"), []byte("## Module availability\n\nExtra guidance.\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(include, "references", "extra.md"), []byte("# Extra\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeFiles(t, include, includeFiles)
 
 	if err := ApplySkillIncludes(skillDir, include); err != nil {
 		t.Fatalf("ApplySkillIncludes: %v", err)
@@ -324,12 +323,18 @@ func TestApplySkillIncludes_AppendsAndCreates(t *testing.T) {
 	if !strings.Contains(got, "## Module availability") || !strings.Contains(got, "Extra guidance.") {
 		t.Errorf("SKILL.md missing appended include content:\n%s", got)
 	}
-	if created := readFile(t, dir, "skills/acmectl/references/extra.md"); !strings.Contains(created, "# Extra") {
-		t.Errorf("new reference file not created from include: %q", created)
+	for path, body := range includeFiles {
+		if path == "SKILL.md" {
+			continue
+		}
+		target := filepath.Join("skills/acmectl", path)
+		if got := readFile(t, dir, target); got != body {
+			t.Errorf("included skill resource %s = %q, want %q", target, got, body)
+		}
 	}
 }
 
-func TestApplySkillIncludes_EmptyOrMissingIsNoOp(t *testing.T) {
+func TestApplySkillIncludes_EmptyIsNoOp(t *testing.T) {
 	dir := t.TempDir()
 	skillDir := filepath.Join(dir, "skills", "acmectl")
 	if err := RenderSkillDirectory(skillDir, &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}, nil); err != nil {
@@ -340,11 +345,39 @@ func TestApplySkillIncludes_EmptyOrMissingIsNoOp(t *testing.T) {
 	if err := ApplySkillIncludes(skillDir, ""); err != nil {
 		t.Fatalf("ApplySkillIncludes empty: %v", err)
 	}
-	if err := ApplySkillIncludes(skillDir, filepath.Join(dir, "does-not-exist")); err != nil {
-		t.Fatalf("ApplySkillIncludes missing: %v", err)
-	}
 	if after := readFile(t, dir, "skills/acmectl/SKILL.md"); after != before {
 		t.Errorf("SKILL.md changed by no-op include:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestApplySkillIncludes_MissingRootFails(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "acmectl")
+
+	err := ApplySkillIncludes(skillDir, filepath.Join(dir, "does-not-exist"))
+	if err == nil {
+		t.Fatal("expected missing include root error")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestApplySkillIncludes_RejectsExistingNonAppendableGeneratedTargets(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "acmectl")
+	if err := RenderSkillDirectory(skillDir, &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}, nil); err != nil {
+		t.Fatalf("RenderSkillDirectory: %v", err)
+	}
+	include := filepath.Join(dir, "include")
+	writeFiles(t, include, map[string]string{"agents/openai.yaml": "blocked\n"})
+
+	err := ApplySkillIncludes(skillDir, include)
+	if err == nil {
+		t.Fatal("expected protected target error")
+	}
+	if !strings.Contains(err.Error(), "existing non-appendable generated file") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -355,4 +388,17 @@ func readFile(t *testing.T, root string, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(data)
+}
+
+func writeFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for path, body := range files {
+		full := filepath.Join(root, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 }

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -294,6 +294,60 @@ func TestRenderSkillDirectory_RegeneratesOwnedDirectory(t *testing.T) {
 	}
 }
 
+func TestApplySkillIncludes_AppendsAndCreates(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "acmectl")
+	if err := RenderSkillDirectory(skillDir, &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}, nil); err != nil {
+		t.Fatalf("RenderSkillDirectory: %v", err)
+	}
+	before := readFile(t, dir, "skills/acmectl/SKILL.md")
+
+	include := filepath.Join(dir, "include")
+	if err := os.MkdirAll(filepath.Join(include, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(include, "SKILL.md"), []byte("## Module availability\n\nExtra guidance.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(include, "references", "extra.md"), []byte("# Extra\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ApplySkillIncludes(skillDir, include); err != nil {
+		t.Fatalf("ApplySkillIncludes: %v", err)
+	}
+
+	got := readFile(t, dir, "skills/acmectl/SKILL.md")
+	if !strings.HasPrefix(got, before) {
+		t.Errorf("existing SKILL.md content should be preserved as a prefix")
+	}
+	if !strings.Contains(got, "## Module availability") || !strings.Contains(got, "Extra guidance.") {
+		t.Errorf("SKILL.md missing appended include content:\n%s", got)
+	}
+	if created := readFile(t, dir, "skills/acmectl/references/extra.md"); !strings.Contains(created, "# Extra") {
+		t.Errorf("new reference file not created from include: %q", created)
+	}
+}
+
+func TestApplySkillIncludes_EmptyOrMissingIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "skills", "acmectl")
+	if err := RenderSkillDirectory(skillDir, &config.Manifest{CLI: config.CLIInfo{Name: "acmectl"}}, nil); err != nil {
+		t.Fatalf("RenderSkillDirectory: %v", err)
+	}
+	before := readFile(t, dir, "skills/acmectl/SKILL.md")
+
+	if err := ApplySkillIncludes(skillDir, ""); err != nil {
+		t.Fatalf("ApplySkillIncludes empty: %v", err)
+	}
+	if err := ApplySkillIncludes(skillDir, filepath.Join(dir, "does-not-exist")); err != nil {
+		t.Fatalf("ApplySkillIncludes missing: %v", err)
+	}
+	if after := readFile(t, dir, "skills/acmectl/SKILL.md"); after != before {
+		t.Errorf("SKILL.md changed by no-op include:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
 func readFile(t *testing.T, root string, path string) string {
 	t.Helper()
 	data, err := os.ReadFile(filepath.Join(root, path))

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/lathe-cli/lathe/internal/codegen/backends/openapi3"
 	"github.com/lathe-cli/lathe/internal/codegen/backends/proto"
@@ -19,7 +18,15 @@ import (
 	"github.com/lathe-cli/lathe/internal/specsync"
 	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/lathe"
+	"gopkg.in/yaml.v3"
 )
+
+type skillFlagOptions struct {
+	Root       string
+	RootSet    bool
+	Include    string
+	IncludeSet bool
+}
 
 func Run(args []string) error {
 	return runWithOutputs(args, os.Stdout, os.Stderr)
@@ -85,11 +92,11 @@ func RunCodegen(args []string, output io.Writer) error {
 	cacheRoot := fs.String("cache", "", "cache root (default $LATHE_SPECS_CACHE or .cache)")
 	overlayDir := fs.String("overlay", "", "directory containing <module>.yaml overlay files (optional)")
 	skillRoot := fs.String("skill-root", "skills", "skill output root, or empty to disable skill generation")
-	skillInclude := fs.String("skill-include", "", "directory of markdown appended onto generated skill files (optional)")
+	skillInclude := fs.String("skill-include", "", "directory of Skill resources merged into generated skill files (optional)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	return runCodegen(*sourcesPath, *manifestPath, *cacheRoot, *overlayDir, *skillRoot, *skillInclude)
+	return runCodegen(*sourcesPath, *manifestPath, *cacheRoot, *overlayDir, skillFlagsFrom(fs, skillRoot, skillInclude))
 }
 
 func RunBootstrap(args []string, output io.Writer) error {
@@ -100,7 +107,7 @@ func RunBootstrap(args []string, output io.Writer) error {
 	cacheRoot := fs.String("cache", "", "cache root (default $LATHE_SPECS_CACHE or .cache)")
 	overlayDir := fs.String("overlay", "", "directory containing <module>.yaml overlay files (optional)")
 	skillRoot := fs.String("skill-root", "skills", "skill output root, or empty to disable skill generation")
-	skillInclude := fs.String("skill-include", "", "directory of markdown appended onto generated skill files (optional)")
+	skillInclude := fs.String("skill-include", "", "directory of Skill resources merged into generated skill files (optional)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -116,7 +123,7 @@ func RunBootstrap(args []string, output io.Writer) error {
 	if err := specsync.Sync(cfg, specsync.Options{CacheRoot: absRoot}); err != nil {
 		return err
 	}
-	return runCodegen(*sourcesPath, *manifestPath, absRoot, *overlayDir, *skillRoot, *skillInclude)
+	return runCodegen(*sourcesPath, *manifestPath, absRoot, *overlayDir, skillFlagsFrom(fs, skillRoot, skillInclude))
 }
 
 func printRootUsage(output io.Writer) {
@@ -133,7 +140,7 @@ Run "lathe <command> -h" for command-specific flags.
 `)
 }
 
-func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overlayDir string, skillRoot string, skillInclude string) error {
+func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overlayDir string, skillFlags skillFlagOptions) error {
 	cfg, err := sourceconfig.Load(sourcesPath)
 	if err != nil {
 		return err
@@ -150,20 +157,9 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 	}
 	syncRoot := filepath.Join(absRoot, specsync.SyncSubdir)
 
-	manifest, err := loadCodegenManifest(manifestPath)
+	manifest, skillDir, skillInclude, err := resolveSkillOutput(manifestPath, skillFlags)
 	if err != nil {
-		if skillRoot != "" || !os.IsNotExist(err) {
-			return err
-		}
-		manifest = &config.Manifest{CLI: config.CLIInfo{CommandPath: config.CommandPathAuto}}
-	}
-
-	var skillDir string
-	if skillRoot != "" {
-		skillDir, err = skillOutputDir(skillRoot, manifest.CLI.Name)
-		if err != nil {
-			return err
-		}
+		return err
 	}
 
 	ordered := cfg.Ordered()
@@ -199,14 +195,14 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 			return err
 		}
 		mounts = append(mounts, render.ModuleMount{Name: src.Name, Flat: flat})
-		if skillRoot != "" {
+		if skillDir != "" {
 			skillModules = append(skillModules, render.SkillModule{Source: src, State: state, Specs: specs})
 		}
 	}
 	if err := render.RenderModulesGen(mounts); err != nil {
 		return err
 	}
-	if skillRoot != "" {
+	if skillDir != "" {
 		if err := render.RenderSkillDirectory(skillDir, manifest, skillModules); err != nil {
 			return err
 		}
@@ -217,12 +213,88 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 	return nil
 }
 
-func loadCodegenManifest(path string) (*config.Manifest, error) {
+func resolveSkillOutput(manifestPath string, flags skillFlagOptions) (*config.Manifest, string, string, error) {
+	manifest, rootConfig, include, err := loadCodegenManifest(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) && flags.RootSet && flags.Root == "" && (!flags.IncludeSet || flags.Include == "") {
+			return &config.Manifest{CLI: config.CLIInfo{CommandPath: config.CommandPathAuto}}, "", "", nil
+		}
+		return nil, "", "", err
+	}
+
+	if flags.RootSet && flags.Root == "" {
+		if flags.IncludeSet && flags.Include != "" {
+			return nil, "", "", fmt.Errorf("skill include requires skill generation")
+		}
+		return manifest, "", "", nil
+	}
+
+	root := "skills"
+	if rootConfig != nil {
+		root = *rootConfig
+	}
+	if flags.RootSet {
+		root = flags.Root
+	}
+
+	if flags.IncludeSet {
+		include = flags.Include
+	}
+
+	if root == "" {
+		if include != "" {
+			return nil, "", "", fmt.Errorf("skill include requires skill generation")
+		}
+		return manifest, "", "", nil
+	}
+
+	skillDir, err := skillOutputDir(root, manifest.CLI.Name)
+	if err != nil {
+		return nil, "", "", err
+	}
+	if err := render.ValidateSkillIncludeRoot(root, include); err != nil {
+		return nil, "", "", err
+	}
+	return manifest, skillDir, include, nil
+}
+
+func skillFlagsFrom(fs *flag.FlagSet, root, include *string) skillFlagOptions {
+	var rootSet, includeSet bool
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "skill-root":
+			rootSet = true
+		case "skill-include":
+			includeSet = true
+		}
+	})
+	return skillFlagOptions{
+		Root:       *root,
+		RootSet:    rootSet,
+		Include:    *include,
+		IncludeSet: includeSet,
+	}
+}
+
+func loadCodegenManifest(path string) (*config.Manifest, *string, string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, "", err
 	}
-	return config.Load(data)
+	manifest, err := config.Load(data)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	var codegen struct {
+		Skill struct {
+			Root    *string `yaml:"root"`
+			Include string  `yaml:"include"`
+		} `yaml:"skill"`
+	}
+	if err := yaml.Unmarshal(data, &codegen); err != nil {
+		return nil, nil, "", fmt.Errorf("parse cli.yaml: %w", err)
+	}
+	return manifest, codegen.Skill.Root, codegen.Skill.Include, nil
 }
 
 func resolveCacheRoot(root string) (string, error) {
@@ -250,32 +322,8 @@ func parseSource(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, er
 
 func skillOutputDir(root string, cliName string) (string, error) {
 	clean := filepath.Clean(root)
-	if root == "" || clean == "." || clean == ".." || clean == string(filepath.Separator) || hasParentTraversal(clean) {
+	if clean == "." || !filepath.IsLocal(clean) {
 		return "", fmt.Errorf("invalid skill root %q", root)
 	}
-	absRoot, err := filepath.Abs(clean)
-	if err != nil {
-		return "", err
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	absCWD, err := filepath.Abs(cwd)
-	if err != nil {
-		return "", err
-	}
-	if absRoot == absCWD {
-		return "", fmt.Errorf("invalid skill root %q: must not be the current project root", root)
-	}
 	return filepath.Join(clean, render.SkillDirName(cliName)), nil
-}
-
-func hasParentTraversal(path string) bool {
-	for _, part := range strings.Split(path, string(filepath.Separator)) {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -85,10 +85,11 @@ func RunCodegen(args []string, output io.Writer) error {
 	cacheRoot := fs.String("cache", "", "cache root (default $LATHE_SPECS_CACHE or .cache)")
 	overlayDir := fs.String("overlay", "", "directory containing <module>.yaml overlay files (optional)")
 	skillRoot := fs.String("skill-root", "skills", "skill output root, or empty to disable skill generation")
+	skillInclude := fs.String("skill-include", "", "directory of markdown appended onto generated skill files (optional)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	return runCodegen(*sourcesPath, *manifestPath, *cacheRoot, *overlayDir, *skillRoot)
+	return runCodegen(*sourcesPath, *manifestPath, *cacheRoot, *overlayDir, *skillRoot, *skillInclude)
 }
 
 func RunBootstrap(args []string, output io.Writer) error {
@@ -99,6 +100,7 @@ func RunBootstrap(args []string, output io.Writer) error {
 	cacheRoot := fs.String("cache", "", "cache root (default $LATHE_SPECS_CACHE or .cache)")
 	overlayDir := fs.String("overlay", "", "directory containing <module>.yaml overlay files (optional)")
 	skillRoot := fs.String("skill-root", "skills", "skill output root, or empty to disable skill generation")
+	skillInclude := fs.String("skill-include", "", "directory of markdown appended onto generated skill files (optional)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -114,7 +116,7 @@ func RunBootstrap(args []string, output io.Writer) error {
 	if err := specsync.Sync(cfg, specsync.Options{CacheRoot: absRoot}); err != nil {
 		return err
 	}
-	return runCodegen(*sourcesPath, *manifestPath, absRoot, *overlayDir, *skillRoot)
+	return runCodegen(*sourcesPath, *manifestPath, absRoot, *overlayDir, *skillRoot, *skillInclude)
 }
 
 func printRootUsage(output io.Writer) {
@@ -131,7 +133,7 @@ Run "lathe <command> -h" for command-specific flags.
 `)
 }
 
-func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overlayDir string, skillRoot string) error {
+func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overlayDir string, skillRoot string, skillInclude string) error {
 	cfg, err := sourceconfig.Load(sourcesPath)
 	if err != nil {
 		return err
@@ -206,6 +208,9 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 	}
 	if skillRoot != "" {
 		if err := render.RenderSkillDirectory(skillDir, manifest, skillModules); err != nil {
+			return err
+		}
+		if err := render.ApplySkillIncludes(skillDir, skillInclude); err != nil {
 			return err
 		}
 	}

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -56,7 +56,7 @@ func TestRunWithOutput_CodegenHelpPrintsUsage(t *testing.T) {
 		t.Fatalf("expected flag.ErrHelp, got %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"Usage of lathe codegen:", "-manifest", "-skill-root"} {
+	for _, want := range []string{"Usage of lathe codegen:", "-manifest", "-skill-root", "-skill-include"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help output missing %q:\n%s", want, got)
 		}
@@ -84,7 +84,7 @@ func TestRunWithOutput_BootstrapHelpPrintsUsage(t *testing.T) {
 		t.Fatalf("expected flag.ErrHelp, got %v", err)
 	}
 	got := out.String()
-	for _, want := range []string{"Usage of lathe bootstrap:", "-manifest", "-skill-root"} {
+	for _, want := range []string{"Usage of lathe bootstrap:", "-manifest", "-skill-root", "-skill-include"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help output missing %q:\n%s", want, got)
 		}

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -163,6 +163,109 @@ func TestRunCodegen_CommandPathFlatRewritesGeneratedExamples(t *testing.T) {
 	}
 }
 
+func TestRunCodegen_UsesSkillConfigFromManifest(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", `cli:
+  name: acmectl
+  short: Acme CLI
+skill:
+  root: agent-skills
+  include: internal/skill-include
+`)
+	writeCodegenFile(t, "internal/skill-include/SKILL.md", "## Local guidance\n\nUse the team runbook.\n")
+
+	if err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	skill := readCodegenFile(t, "agent-skills/acmectl/SKILL.md")
+	if !strings.Contains(skill, "Use the team runbook.") {
+		t.Fatalf("skill missing include guidance:\n%s", skill)
+	}
+	if _, err := os.Stat("skills"); !os.IsNotExist(err) {
+		t.Fatalf("default skills directory should not be used, stat err = %v", err)
+	}
+}
+
+func TestRunCodegen_SkillFlagsOverrideManifestConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", `cli:
+  name: acmectl
+  short: Acme CLI
+skill:
+  root: yaml-skills
+  include: internal/missing-yaml-include
+`)
+	writeCodegenFile(t, "internal/flag-include/SKILL.md", "## Flag guidance\n\nUse the flag include.\n")
+
+	err := RunCodegen([]string{
+		"-sources", "specs/sources.yaml",
+		"-cache", ".cache",
+		"-skill-root", "flag-skills",
+		"-skill-include", "internal/flag-include",
+	}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	skill := readCodegenFile(t, "flag-skills/acmectl/SKILL.md")
+	if !strings.Contains(skill, "Use the flag include.") {
+		t.Fatalf("skill missing flag include guidance:\n%s", skill)
+	}
+	if _, err := os.Stat("yaml-skills"); !os.IsNotExist(err) {
+		t.Fatalf("yaml skill root should not be used, stat err = %v", err)
+	}
+}
+
+func TestRunCodegen_MissingSkillIncludeFailsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", `cli:
+  name: acmectl
+  short: Acme CLI
+skill:
+  include: internal/does-not-exist
+`)
+
+	err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected missing skill include error")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat("internal/generated"); !os.IsNotExist(err) {
+		t.Fatalf("codegen should fail before writing generated code, stat err = %v", err)
+	}
+}
+
+func TestRunCodegen_RejectsSkillIncludeInsideSkillRootBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "skills/include/SKILL.md", "blocked\n")
+
+	err := RunCodegen([]string{
+		"-sources", "specs/sources.yaml",
+		"-cache", ".cache",
+		"-skill-include", "skills/include",
+	}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected skill include overlap error")
+	}
+	if !strings.Contains(err.Error(), "must be outside skill root") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat("internal/generated"); !os.IsNotExist(err) {
+		t.Fatalf("codegen should fail before writing generated code, stat err = %v", err)
+	}
+}
+
 func TestRunBootstrapSyncsAndGenerates(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is required for bootstrap")


### PR DESCRIPTION
Skill files (SKILL.md, references/*) are fully generated and the skill directory is wiped (os.RemoveAll) on every codegen, so downstream CLIs have no way to add product-specific guidance without forking the hardcoded render templates — which would leak product-specific content into this generic framework.

Add a generic ApplySkillIncludes mechanism: a new -skill-include directory is walked after RenderSkillDirectory and each file is mapped by relative path onto the skill dir — appended after a blank-line separator when the target exists, created otherwise. Absent/empty include root is a no-op, so output is byte-identical for CLIs that don't use it.

Product-specific skill prose can now live as real markdown in the downstream repo (committed codegen input) instead of being hardcoded here.

## Summary

<!-- What changed and why? Keep it focused. -->

## Verification

<!-- Paste exact commands run, for example `make test` or `make check`. -->

## Compatibility

<!-- Note generated command shape, catalog schema, auth/body/output behavior, or docs changes. Write "None" if not applicable. -->

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
