### PR TITLE
feat(openapi3): parse OpenAPI 3.1 nullable type arrays

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -68,12 +68,77 @@ type response struct {
 
 type schemaNode struct {
 	Ref        string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	Type       string                 `json:"type,omitempty" yaml:"type,omitempty"`
+	Type       schemaType             `json:"type,omitempty" yaml:"type,omitempty"`
 	Format     string                 `json:"format,omitempty" yaml:"format,omitempty"`
 	Default    any                    `json:"default,omitempty" yaml:"default,omitempty"`
 	Enum       []any                  `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Properties map[string]*schemaNode `json:"properties,omitempty" yaml:"properties,omitempty"`
 	Items      *schemaNode            `json:"items,omitempty" yaml:"items,omitempty"`
+}
+
+type schemaType string
+
+func (t *schemaType) UnmarshalJSON(data []byte) error {
+	var single string
+	if err := json.Unmarshal(data, &single); err == nil {
+		*t = schemaType(single)
+		return nil
+	}
+
+	var many []string
+	if err := json.Unmarshal(data, &many); err != nil {
+		return fmt.Errorf("schema type must be string or string array: %w", err)
+	}
+	primary, err := primarySchemaType(many)
+	if err != nil {
+		return err
+	}
+	*t = schemaType(primary)
+	return nil
+}
+
+func (t *schemaType) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		*t = ""
+		return nil
+	}
+
+	var single string
+	if err := value.Decode(&single); err == nil {
+		*t = schemaType(single)
+		return nil
+	}
+
+	var many []string
+	if err := value.Decode(&many); err != nil {
+		return fmt.Errorf("schema type must be string or string array: %w", err)
+	}
+	primary, err := primarySchemaType(many)
+	if err != nil {
+		return err
+	}
+	*t = schemaType(primary)
+	return nil
+}
+
+func primarySchemaType(types []string) (string, error) {
+	if len(types) == 0 {
+		return "", fmt.Errorf("schema type array must not be empty")
+	}
+	primary := ""
+	for _, typ := range types {
+		if typ == "null" {
+			continue
+		}
+		if primary != "" {
+			return "", fmt.Errorf("unsupported schema type union %q", types)
+		}
+		primary = typ
+	}
+	if primary == "" {
+		return "null", nil
+	}
+	return primary, nil
 }
 
 const oas3RefPrefix = "#/components/schemas/"
@@ -278,7 +343,7 @@ func convertParam(p parameter) rawir.RawParameter {
 	var enum []string
 	if p.Schema != nil {
 		if p.Schema.Type != "" {
-			typ = p.Schema.Type
+			typ = string(p.Schema.Type)
 		}
 		format = p.Schema.Format
 		def = anyToString(p.Schema.Default)
@@ -320,7 +385,7 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 		return nil
 	}
 	out := &rawir.RawSchema{
-		Type: s.Type,
+		Type: string(s.Type),
 	}
 	if s.Ref != "" {
 		if strings.HasPrefix(s.Ref, oas3RefPrefix) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
@@ -45,6 +46,53 @@ func TestParse_Golden(t *testing.T) {
 			}
 			testutil.AssertRawModuleGolden(t, tc.name, mod)
 		})
+	}
+}
+
+func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
+	syncDir := t.TempDir()
+	inputPath := filepath.Join(syncDir, "openapi.json")
+	if err := os.WriteFile(inputPath, []byte(openapi31NullableTypeArrayJSON), 0o644); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+
+	src := &sourceconfig.Source{
+		Name: "demo",
+		OpenAPI3: &sourceconfig.OpenAPI3Config{
+			Files: []string{"openapi.json"},
+		},
+	}
+	mod, err := Parse(src, syncDir)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := mod.Operations[0].Parameters[0].Type; got != "boolean" {
+		t.Fatalf("parameter type = %q, want boolean", got)
+	}
+	if got := mod.Operations[0].Responses["200"].Schema.Properties["name"].Type; got != "string" {
+		t.Fatalf("property type = %q, want string", got)
+	}
+}
+
+func TestParse_RejectsOpenAPI31MultiTypeUnion(t *testing.T) {
+	syncDir := t.TempDir()
+	inputPath := filepath.Join(syncDir, "openapi.json")
+	if err := os.WriteFile(inputPath, []byte(openapi31MultiTypeUnionJSON), 0o644); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+
+	src := &sourceconfig.Source{
+		Name: "demo",
+		OpenAPI3: &sourceconfig.OpenAPI3Config{
+			Files: []string{"openapi.json"},
+		},
+	}
+	_, err := Parse(src, syncDir)
+	if err == nil {
+		t.Fatal("Parse succeeded, want unsupported union error")
+	}
+	if !strings.Contains(err.Error(), "unsupported schema type union") {
+		t.Fatalf("error = %v, want unsupported schema type union", err)
 	}
 }
 
@@ -254,6 +302,51 @@ const pathLevelParamsJSON = `{
           {"name": "org_id", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Override"}
         ],
         "requestBody": {"required": true},
+        "responses": {}
+      }
+    }
+  }
+}`
+
+const openapi31NullableTypeArrayJSON = `{
+  "openapi": "3.1.0",
+  "paths": {
+    "/threads": {
+      "get": {
+        "operationId": "Thread_List",
+        "tags": ["Threads"],
+        "parameters": [
+          {"name": "archived", "in": "query", "schema": {"type": ["boolean", "null"]}}
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "name": {"type": ["string", "null"]}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+const openapi31MultiTypeUnionJSON = `{
+  "openapi": "3.1.0",
+  "paths": {
+    "/threads": {
+      "get": {
+        "operationId": "Thread_List",
+        "tags": ["Threads"],
+        "parameters": [
+          {"name": "filter", "in": "query", "schema": {"type": ["string", "integer"]}}
+        ],
         "responses": {}
       }
     }


### PR DESCRIPTION
## Summary

Parse OpenAPI 3.1 schema `type` values as either a string (3.0-compatible) or a string array. Nullable unions such as `["boolean", "null"]` resolve to the primary non-null primitive; unsupported multi-primitive unions fail at parse time.

## Verification

```sh
go test ./internal/codegen/backends/openapi3/...
```

## Compatibility

None — codegen parsing only; no generated command shape, catalog schema, auth, body, or output behavior changes.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.

## Considered and deferred

- backend.go:124 [BOT-NIT]: only-null type array (`["null"]`) is not explicitly tested; normalize maps unknown types to string — acceptable for codegen-only nullable semantics.
- backend.go:81 [BOT-TASTE]: JSON and YAML unmarshal paths are parallel; a shared helper would be premature with two entry points.