### PR TITLE
feat: add GraphQL request envelope groundwork

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -11,89 +11,65 @@ import (
 )
 
 func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
-	paths := collectPaths(mod)
-	sort.Strings(paths)
-	byPath := groupByPath(mod)
-
 	var specs []runtime.CommandSpec
-	for _, p := range paths {
-		ops := byPath[p]
-		for _, m := range []string{"GET", "POST", "PUT", "DELETE", "PATCH"} {
-			op, ok := ops[m]
-			if !ok || op.OperationID == "" {
-				continue
-			}
-			useName := camelToKebab(opNameFromID(op.OperationID))
-			if useName == "" {
-				continue
-			}
-			spec := runtime.CommandSpec{
-				Group:       group(op),
-				Use:         useName,
-				Short:       pickShort(op),
-				OperationID: op.OperationID,
-				Method:      op.Method,
-				PathTpl:     op.Path,
-			}
-			for _, pp := range op.Parameters {
-				switch pp.In {
-				case "path":
-					spec.Params = append(spec.Params, pathParam(pp))
-				case "query":
-					spec.Params = append(spec.Params, queryParam(pp))
-				case "header":
-					spec.Params = append(spec.Params, headerParam(pp))
-				case "formData":
-					spec.Params = append(spec.Params, formDataParam(pp))
-				}
-			}
-			if op.RequestBody != nil {
-				spec.RequestBody = &runtime.RequestBody{Required: op.RequestBody.Required, MediaType: op.RequestBody.MediaType, Schema: runtimeSchema(op.RequestBody.Schema, mod.Schemas, map[string]bool{})}
-			}
-			lp, itemRef := deriveList(op, mod.Schemas)
-			spec.Output.ListPath = lp
-			if itemRef != "" {
-				spec.Output.DefaultColumns = defaultColumns(itemRef, mod.Schemas)
-			}
-			spec.Output.ResponseMediaType = deriveResponseMediaType(op)
-			spec.Output.Pagination = derivePagination(op)
-			spec.Output.Streaming = deriveStreaming(op)
-			spec.Security = deriveSecurity(op)
-			specs = append(specs, spec)
+	for _, op := range mod.Operations {
+		if op.OperationID == "" {
+			continue
 		}
+		useName := camelToKebab(opNameFromID(op.OperationID))
+		if useName == "" {
+			continue
+		}
+		spec := runtime.CommandSpec{
+			Group:       group(op),
+			Use:         useName,
+			Short:       pickShort(op),
+			OperationID: op.OperationID,
+			Method:      op.Method,
+			PathTpl:     op.Path,
+		}
+		for _, pp := range op.Parameters {
+			switch pp.In {
+			case "path":
+				spec.Params = append(spec.Params, pathParam(pp))
+			case "query":
+				spec.Params = append(spec.Params, queryParam(pp))
+			case "header":
+				spec.Params = append(spec.Params, headerParam(pp))
+			case "formData":
+				spec.Params = append(spec.Params, formDataParam(pp))
+			}
+		}
+		if op.RequestBody != nil {
+			spec.RequestBody = &runtime.RequestBody{
+				Required:  op.RequestBody.Required,
+				MediaType: op.RequestBody.MediaType,
+				Schema:    runtimeSchema(op.RequestBody.Schema, mod.Schemas, map[string]bool{}),
+				Template:  op.RequestBody.Template,
+				MergePath: op.RequestBody.MergePath,
+			}
+		}
+		lp, itemRef := deriveList(op, mod.Schemas)
+		spec.Output.ListPath = lp
+		if itemRef != "" {
+			spec.Output.DefaultColumns = defaultColumns(itemRef, mod.Schemas)
+		}
+		spec.Output.ResponseMediaType = deriveResponseMediaType(op)
+		spec.Output.Pagination = derivePagination(op)
+		spec.Output.Streaming = deriveStreaming(op)
+		spec.Security = deriveSecurity(op)
+		specs = append(specs, spec)
 	}
 	sort.Slice(specs, func(i, j int) bool {
 		if specs[i].Group != specs[j].Group {
 			return specs[i].Group < specs[j].Group
 		}
-		return specs[i].Use < specs[j].Use
+		if specs[i].Use != specs[j].Use {
+			return specs[i].Use < specs[j].Use
+		}
+		return specs[i].OperationID < specs[j].OperationID
 	})
 	return specs
-}
-
-func collectPaths(mod *rawir.RawModule) []string {
-	seen := map[string]bool{}
-	for _, op := range mod.Operations {
-		seen[op.Path] = true
-	}
-	out := make([]string, 0, len(seen))
-	for p := range seen {
-		out = append(out, p)
-	}
-	return out
-}
-
-func groupByPath(mod *rawir.RawModule) map[string]map[string]rawir.RawOperation {
-	out := map[string]map[string]rawir.RawOperation{}
-	for _, op := range mod.Operations {
-		bucket, ok := out[op.Path]
-		if !ok {
-			bucket = map[string]rawir.RawOperation{}
-			out[op.Path] = bucket
-		}
-		bucket[op.Method] = op
-	}
-	return out
 }
 
 func group(op rawir.RawOperation) string {

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -21,6 +21,8 @@ func TestNormalize_Golden(t *testing.T) {
 		{"list-response", listResponse},
 		{"no-op-id", noOpID},
 		{"multiple-methods-same-path", multipleMethodsSamePath},
+		{"shared-endpoint-envelope", sharedEndpointEnvelope},
+		{"request-body-envelope", requestBodyEnvelope},
 		{"param-in-header", paramInHeader},
 		{"param-in-form-data", paramInFormData},
 		{"pagination-cursor", paginationCursor},
@@ -175,6 +177,62 @@ func multipleMethodsSamePath() *rawir.RawModule {
 				Path:        "/resources",
 				RequestBody: &rawir.RawRequestBody{Required: true},
 				Responses:   map[string]*rawir.RawResponse{},
+			},
+		},
+	}
+}
+
+func requestBodyEnvelope() *rawir.RawModule {
+	return &rawir.RawModule{
+		Name: "demo",
+		Operations: []rawir.RawOperation{{
+			Group:       "Apps",
+			OperationID: "Apps_CreateApp",
+			Summary:     "Create an app.",
+			Method:      "POST",
+			Path:        "/graphql",
+			RequestBody: &rawir.RawRequestBody{
+				Required:  true,
+				MediaType: "application/json",
+				Template:  `{"query":"mutation CreateApp($name:String!){createApp(name:$name){id}}","variables":{}}`,
+				MergePath: "variables",
+			},
+			Responses: map[string]*rawir.RawResponse{},
+		}},
+	}
+}
+
+func sharedEndpointEnvelope() *rawir.RawModule {
+	return &rawir.RawModule{
+		Name: "demo",
+		Operations: []rawir.RawOperation{
+			{
+				Group:       "Apps",
+				OperationID: "Apps_CreateApp",
+				Summary:     "Create an app.",
+				Method:      "POST",
+				Path:        "/graphql",
+				RequestBody: &rawir.RawRequestBody{
+					Required:  true,
+					MediaType: "application/json",
+					Template:  `{"query":"mutation CreateApp{createApp{id}}","variables":{}}`,
+					MergePath: "variables",
+				},
+				Responses: map[string]*rawir.RawResponse{},
+			},
+			{
+				Group:       "Apps",
+				OperationID: "Apps_ListApps",
+				Summary:     "List apps.",
+				Method:      "POST",
+				Path:        "/graphql",
+				RequestBody: &rawir.RawRequestBody{
+					Required:  true,
+					MediaType: "application/json",
+					Template:  `{"query":"query ListApps{apps{id}}","variables":{}}`,
+					MergePath: "variables",
+				},
+				Responses: map[string]*rawir.RawResponse{},
 			},
 		},
 	}

--- a/internal/codegen/normalize/testdata/request-body-envelope.golden.json
+++ b/internal/codegen/normalize/testdata/request-body-envelope.golden.json
@@ -1,0 +1,30 @@
+[
+  {
+    "Group": "Apps",
+    "Use": "create-app",
+    "Aliases": null,
+    "Short": "Create an app.",
+    "Long": "",
+    "Example": "",
+    "OperationID": "Apps_CreateApp",
+    "Hidden": false,
+    "Deprecated": false,
+    "Method": "POST",
+    "PathTpl": "/graphql",
+    "Params": null,
+    "RequestBody": {
+      "Required": true,
+      "MediaType": "application/json",
+      "Template": "{\"query\":\"mutation CreateApp($name:String!){createApp(name:$name){id}}\",\"variables\":{}}",
+      "MergePath": "variables"
+    },
+    "Output": {
+      "ListPath": "",
+      "DefaultColumns": null,
+      "ResponseMediaType": "",
+      "Pagination": null,
+      "Streaming": null
+    },
+    "Security": null
+  }
+]

--- a/internal/codegen/normalize/testdata/shared-endpoint-envelope.golden.json
+++ b/internal/codegen/normalize/testdata/shared-endpoint-envelope.golden.json
@@ -1,0 +1,58 @@
+[
+  {
+    "Group": "Apps",
+    "Use": "create-app",
+    "Aliases": null,
+    "Short": "Create an app.",
+    "Long": "",
+    "Example": "",
+    "OperationID": "Apps_CreateApp",
+    "Hidden": false,
+    "Deprecated": false,
+    "Method": "POST",
+    "PathTpl": "/graphql",
+    "Params": null,
+    "RequestBody": {
+      "Required": true,
+      "MediaType": "application/json",
+      "Template": "{\"query\":\"mutation CreateApp{createApp{id}}\",\"variables\":{}}",
+      "MergePath": "variables"
+    },
+    "Output": {
+      "ListPath": "",
+      "DefaultColumns": null,
+      "ResponseMediaType": "",
+      "Pagination": null,
+      "Streaming": null
+    },
+    "Security": null
+  },
+  {
+    "Group": "Apps",
+    "Use": "list-apps",
+    "Aliases": null,
+    "Short": "List apps.",
+    "Long": "",
+    "Example": "",
+    "OperationID": "Apps_ListApps",
+    "Hidden": false,
+    "Deprecated": false,
+    "Method": "POST",
+    "PathTpl": "/graphql",
+    "Params": null,
+    "RequestBody": {
+      "Required": true,
+      "MediaType": "application/json",
+      "Template": "{\"query\":\"query ListApps{apps{id}}\",\"variables\":{}}",
+      "MergePath": "variables"
+    },
+    "Output": {
+      "ListPath": "",
+      "DefaultColumns": null,
+      "ResponseMediaType": "",
+      "Pagination": null,
+      "Streaming": null
+    },
+    "Security": null
+  }
+]

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -40,6 +40,9 @@ type RawRequestBody struct {
 	Required  bool
 	MediaType string     `json:",omitempty"`
 	Schema    *RawSchema `json:",omitempty"`
+
+	Template  string `json:",omitempty"`
+	MergePath string `json:",omitempty"`
 }
 
 type RawResponse struct {

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -430,6 +430,12 @@ var Specs = []runtime.CommandSpec{
 				{{- if $op.RequestBody.Schema}}
 				Schema: {{schemaLiteral $op.RequestBody.Schema}},
 				{{- end}}
+				{{- if $op.RequestBody.Template}}
+				Template: {{printf "%q" $op.RequestBody.Template}},
+				{{- end}}
+				{{- if $op.RequestBody.MergePath}}
+				MergePath: {{printf "%q" $op.RequestBody.MergePath}},
+				{{- end}}
 			},
 			{{- end}}
 		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -102,6 +102,35 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	}
 }
 
+func TestRenderModule_EmitsRequestBodyEnvelope(t *testing.T) {
+	chdirWithGoMod(t)
+
+	specs := []runtime.CommandSpec{{
+		Group: "Apps", Use: "create-app", Short: "Create an app.", Method: "POST", PathTpl: "/graphql",
+		RequestBody: &runtime.RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			Template:  `{"query":"mutation CreateApp($name:String!){createApp(name:$name){id}}","variables":{}}`,
+			MergePath: "variables",
+		},
+	}}
+
+	if err := RenderModule("demo", "", specs, nil); err != nil {
+		t.Fatalf("RenderModule: %v", err)
+	}
+	got := generatedModule(t, "demo")
+
+	for _, want := range []string{
+		`Template:`,
+		`createApp(name:$name)`,
+		`MergePath: "variables"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q", want)
+		}
+	}
+}
+
 func TestRenderModule_IgnoreDropsCommand(t *testing.T) {
 	chdirWithGoMod(t)
 	specs := []runtime.CommandSpec{

--- a/pkg/lathe/catalog_test.go
+++ b/pkg/lathe/catalog_test.go
@@ -85,6 +85,40 @@ func TestCommandsShowAndSearchJSON(t *testing.T) {
 	}
 }
 
+func TestCommandsShow_EnvelopeBody(t *testing.T) {
+	root := NewApp(testManifest())
+	const tmpl = `{"query":"mutation CreateApp($name:String!){createApp(name:$name){id}}","variables":{}}`
+	runtime.Build(root, "demo", []runtime.CommandSpec{{
+		Group:       "Apps",
+		Use:         "create-app",
+		Short:       "Create an app",
+		OperationID: "Apps_CreateApp",
+		Method:      "POST",
+		PathTpl:     "/graphql",
+		RequestBody: &runtime.RequestBody{Required: true, MediaType: "application/json", Template: tmpl, MergePath: "variables"},
+	}})
+
+	out, err := execute(root, "commands", "show", "demo", "apps", "create-app", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry runtime.CatalogCommand
+	if err := json.Unmarshal([]byte(out), &entry); err != nil {
+		t.Fatal(err)
+	}
+	if entry.Body == nil || entry.Body.Template != tmpl || entry.Body.MergePath != "variables" {
+		t.Fatalf("envelope body = %+v", entry.Body)
+	}
+	if entry.HTTP.Method != "POST" || entry.HTTP.PathTemplate != "/graphql" {
+		t.Fatalf("http = %+v", entry.HTTP)
+	}
+	for _, want := range []string{`"template"`, `"merge_path"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("show output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestCommandsShow_NotFound(t *testing.T) {
 	root := NewApp(testManifest())
 	_, err := execute(root, "commands", "show", "demo", "users", "missing")

--- a/pkg/runtime/body.go
+++ b/pkg/runtime/body.go
@@ -49,6 +49,53 @@ func buildBodyFromSet(sets []string, stringSets []string) ([]byte, error) {
 	return json.Marshal(out)
 }
 
+func buildEnvelopeBody(template, mergePath string, sets, stringSets []string, fileData []byte, hasFile bool) ([]byte, error) {
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(template), &envelope); err != nil {
+		return nil, fmt.Errorf("invalid request body template: %w", err)
+	}
+	if hasFile {
+		if mergePath == "" {
+			return nil, fmt.Errorf("--file is not supported for this command's body template")
+		}
+		var v any
+		if len(strings.TrimSpace(string(fileData))) > 0 {
+			if err := json.Unmarshal(fileData, &v); err != nil {
+				return nil, fmt.Errorf("invalid --file JSON: %w", err)
+			}
+		}
+		if err := setNestedPath(envelope, mergePath, v); err != nil {
+			return nil, err
+		}
+	}
+	for _, kv := range sets {
+		path, value, err := parseSet(kv, "--set")
+		if err != nil {
+			return nil, err
+		}
+		if err := setNestedPath(envelope, joinBodyPath(mergePath, path), inferValue(value)); err != nil {
+			return nil, err
+		}
+	}
+	for _, kv := range stringSets {
+		path, value, err := parseSet(kv, "--set-str")
+		if err != nil {
+			return nil, err
+		}
+		if err := setNestedPath(envelope, joinBodyPath(mergePath, path), value); err != nil {
+			return nil, err
+		}
+	}
+	return json.Marshal(envelope)
+}
+
+func joinBodyPath(prefix, path string) string {
+	if prefix == "" {
+		return path
+	}
+	return prefix + "." + path
+}
+
 func parseSet(kv string, flag string) (string, string, error) {
 	eq := strings.Index(kv, "=")
 	if eq < 0 {

--- a/pkg/runtime/body_test.go
+++ b/pkg/runtime/body_test.go
@@ -48,6 +48,68 @@ func TestBuildBodyFromSet(t *testing.T) {
 	}
 }
 
+func TestBuildEnvelopeBody(t *testing.T) {
+	const tmpl = `{"query":"mutation($name:String!){createApp(name:$name){id}}","variables":{}}`
+
+	t.Run("merges --set under merge path, keeps baked query", func(t *testing.T) {
+		raw, err := buildEnvelopeBody(tmpl, "variables", []string{"name=demo", "replicas=3"}, nil, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		want := map[string]any{
+			"query":     "mutation($name:String!){createApp(name:$name){id}}",
+			"variables": map[string]any{"name": "demo", "replicas": float64(3)},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("no user input sends template unchanged", func(t *testing.T) {
+		raw, err := buildEnvelopeBody(tmpl, "variables", nil, nil, nil, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if !reflect.DeepEqual(got["variables"], map[string]any{}) {
+			t.Errorf("variables = %#v, want empty object", got["variables"])
+		}
+	})
+
+	t.Run("--file replaces merge target", func(t *testing.T) {
+		raw, err := buildEnvelopeBody(tmpl, "variables", nil, nil, []byte(`{"name":"from-file"}`), true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+		if !reflect.DeepEqual(got["variables"], map[string]any{"name": "from-file"}) {
+			t.Errorf("variables = %#v", got["variables"])
+		}
+	})
+
+	t.Run("--file with empty merge path is rejected", func(t *testing.T) {
+		if _, err := buildEnvelopeBody(tmpl, "", nil, nil, []byte(`{}`), true); err == nil {
+			t.Fatal("expected error for --file with empty merge path")
+		}
+	})
+
+	t.Run("invalid template is reported", func(t *testing.T) {
+		if _, err := buildEnvelopeBody(`{not json`, "variables", nil, nil, nil, false); err == nil {
+			t.Fatal("expected error for invalid template")
+		}
+	})
+}
+
 func TestBuildBodyFromSet_SetStrKeepsStrings(t *testing.T) {
 	raw, err := buildBodyFromSet(
 		[]string{"spec.replicas=3", "spec.enabled=true"},

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -171,6 +171,21 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			var body any
 			if len(form) > 0 {
 				body = form
+			} else if s.RequestBody != nil && s.RequestBody.Template != "" {
+				hasFile := cmd.Flags().Changed("file")
+				var fileData []byte
+				if hasFile {
+					fd, rerr := ReadBody(bodyFile)
+					if rerr != nil {
+						return rerr
+					}
+					fileData = fd
+				}
+				raw, berr := buildEnvelopeBody(s.RequestBody.Template, s.RequestBody.MergePath, bodySets, bodyStringSets, fileData, hasFile)
+				if berr != nil {
+					return berr
+				}
+				body = raw
 			} else if s.RequestBody != nil {
 				switch {
 				case cmd.Flags().Changed("set") || cmd.Flags().Changed("set-str"):

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 3
+const CatalogSchemaVersion = 4
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -78,6 +78,8 @@ type CatalogBody struct {
 	Required  bool        `json:"required"`
 	MediaType string      `json:"media_type,omitempty"`
 	Schema    *SchemaSpec `json:"schema,omitempty"`
+	Template  string      `json:"template,omitempty"`
+	MergePath string      `json:"merge_path,omitempty"`
 }
 
 type CatalogFlag struct {
@@ -277,7 +279,13 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 		KnownErrors:   append([]KnownError(nil), spec.KnownErrors...),
 	}
 	if spec.RequestBody != nil {
-		cmd.Body = &CatalogBody{Required: spec.RequestBody.Required, MediaType: spec.RequestBody.MediaType, Schema: spec.RequestBody.Schema}
+		cmd.Body = &CatalogBody{
+			Required:  spec.RequestBody.Required,
+			MediaType: spec.RequestBody.MediaType,
+			Schema:    spec.RequestBody.Schema,
+			Template:  spec.RequestBody.Template,
+			MergePath: spec.RequestBody.MergePath,
+		}
 	}
 	return cmd
 }

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -108,6 +109,47 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if !reflect.DeepEqual(roundTrip.Commands[0].KnownErrors, cmd.KnownErrors) {
 		t.Fatalf("round-trip known errors = %#v", roundTrip.Commands[0].KnownErrors)
+	}
+}
+
+func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
+	root := newRootWithModuleGroup()
+	const tmpl = `{"query":"mutation CreateApp($name:String!){createApp(name:$name){id}}","variables":{}}`
+	Build(root, "demo", []CommandSpec{{
+		Group:       "Apps",
+		Use:         "create-app",
+		Short:       "Create an app",
+		OperationID: "Apps_CreateApp",
+		Method:      "POST",
+		PathTpl:     "/graphql",
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json", Template: tmpl, MergePath: "variables"},
+	}})
+
+	catalog := BuildCatalog(root, CatalogOptions{CLIName: "myctl"})
+	if len(catalog.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(catalog.Commands))
+	}
+	body := catalog.Commands[0].Body
+	if body == nil || body.Template != tmpl || body.MergePath != "variables" {
+		t.Fatalf("catalog body envelope = %+v", body)
+	}
+
+	raw, err := json.Marshal(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"template":`, `"merge_path":"variables"`, `createApp(name:$name)`} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("catalog JSON missing %q:\n%s", want, raw)
+		}
+	}
+	var roundTrip Catalog
+	if err := json.Unmarshal(raw, &roundTrip); err != nil {
+		t.Fatal(err)
+	}
+	rt := roundTrip.Commands[0].Body
+	if rt == nil || rt.Template != tmpl || rt.MergePath != "variables" {
+		t.Fatalf("round-trip body envelope = %+v", rt)
 	}
 }
 

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -1,6 +1,6 @@
 package runtime
 
-const SchemaVersion = 5
+const SchemaVersion = 6
 
 type CommandSpec struct {
 	Group         string
@@ -47,6 +47,9 @@ type RequestBody struct {
 	Required  bool
 	MediaType string      `json:",omitempty"`
 	Schema    *SchemaSpec `json:",omitempty"`
+
+	Template  string `json:",omitempty"`
+	MergePath string `json:",omitempty"`
 }
 
 type SchemaSpec struct {


### PR DESCRIPTION
## Summary

- Refactor normalization to preserve per-operation identity instead of collapsing by HTTP path/method.
- Add a generic request-body envelope contract with static templates and merge paths for future GraphQL commands.
- Expose envelope metadata through generated code and command catalog JSON, with focused runtime/catalog/render tests.

## Why

This is PR1 groundwork for #50. Multiple GraphQL operations share `POST /graphql`, so Lathe needs operation identity and a transport-agnostic body envelope before adding the GraphQL backend.

## Validation

- `make check`
