### PR TITLE
feat(graphql): add policy-driven command polish

### DIFF
--- a/internal/codegen/backends/graphql/backend.go
+++ b/internal/codegen/backends/graphql/backend.go
@@ -15,11 +15,14 @@ import (
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
 )
 
-const maxSelectionDepth = 3
+const defaultMaxSelectionDepth = 3
 
 func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 	if src.GraphQL == nil {
 		return nil, fmt.Errorf("graphql backend requires a graphql config block")
+	}
+	if src.GraphQL.Expose == nil {
+		return nil, fmt.Errorf("graphql backend requires an expose policy")
 	}
 	rel := src.GraphQL.Schema
 	data, err := os.ReadFile(filepath.Join(syncDir, rel))
@@ -31,7 +34,7 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 		return nil, fmt.Errorf("parse schema %s: %w", rel, err)
 	}
 
-	g := &generator{schema: schema, module: src.Name}
+	g := &generator{schema: schema, module: src.Name, config: src.GraphQL}
 	var ops []rawir.RawOperation
 	seen := map[string]bool{}
 	roots := []struct {
@@ -77,6 +80,7 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 type generator struct {
 	schema *ast.Schema
 	module string
+	config *sourceconfig.GraphQLConfig
 }
 
 func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.RawOperation, error) {
@@ -105,6 +109,14 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 	if err != nil {
 		return rawir.RawOperation{}, fmt.Errorf("%s %q: %w", opType, field.Name, err)
 	}
+	group, err := g.groupFor(field.Name)
+	if err != nil {
+		return rawir.RawOperation{}, err
+	}
+	output, err := g.outputFor(field.Name)
+	if err != nil {
+		return rawir.RawOperation{}, err
+	}
 
 	var doc strings.Builder
 	doc.WriteString(opType)
@@ -128,7 +140,7 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 		return rawir.RawOperation{}, err
 	}
 	return rawir.RawOperation{
-		Group:       g.module,
+		Group:       group,
 		OperationID: g.module + "_" + field.Name,
 		Summary:     field.Description,
 		Method:      "POST",
@@ -140,6 +152,7 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 			Template:  string(template),
 			MergePath: "variables",
 		},
+		Output: output,
 	}, nil
 }
 
@@ -156,7 +169,11 @@ func (g *generator) selectionSet(typeName string, depth int, onPath map[string]b
 	}
 	var fields []string
 	for _, f := range def.Fields {
-		if strings.HasPrefix(f.Name, "__") || hasRequiredArgs(f) {
+		pruned, err := g.pruned(def.Name, f.Name)
+		if err != nil {
+			return "", err
+		}
+		if strings.HasPrefix(f.Name, "__") || hasRequiredArgs(f) || pruned {
 			continue
 		}
 		childName := f.Type.Name()
@@ -168,7 +185,7 @@ func (g *generator) selectionSet(typeName string, depth int, onPath map[string]b
 			fields = append(fields, f.Name)
 			continue
 		}
-		if depth >= maxSelectionDepth || onPath[childName] {
+		if depth >= g.selectionMaxDepth() || onPath[childName] {
 			continue
 		}
 		next := clonePath(onPath)
@@ -180,9 +197,73 @@ func (g *generator) selectionSet(typeName string, depth int, onPath map[string]b
 		fields = append(fields, f.Name+" "+sub)
 	}
 	if len(fields) == 0 {
-		return "", fmt.Errorf("type %q has no selectable fields within depth %d", typeName, maxSelectionDepth)
+		return "", fmt.Errorf("type %q has no selectable fields within depth %d", typeName, g.selectionMaxDepth())
 	}
 	return "{ " + strings.Join(fields, " ") + " }", nil
+}
+
+func (g *generator) groupFor(fieldName string) (string, error) {
+	var group string
+	for _, rule := range g.config.Groups {
+		matched, err := matchAny(rule.Match, fieldName)
+		if err != nil {
+			return "", err
+		}
+		if matched {
+			if group != "" {
+				return "", fmt.Errorf("operation %q matches multiple graphql.groups rules", fieldName)
+			}
+			group = rule.Group
+		}
+	}
+	if group != "" {
+		return group, nil
+	}
+	return g.module, nil
+}
+
+func (g *generator) outputFor(fieldName string) (*rawir.RawOutputHints, error) {
+	var output *rawir.RawOutputHints
+	for _, rule := range g.config.Output {
+		matched, err := matchAny(rule.Match, fieldName)
+		if err != nil {
+			return nil, err
+		}
+		if matched {
+			if output != nil {
+				return nil, fmt.Errorf("operation %q matches multiple graphql.output rules", fieldName)
+			}
+			output = &rawir.RawOutputHints{
+				ListPath:       rule.ListPath,
+				DefaultColumns: append([]string(nil), rule.DefaultColumns...),
+			}
+		}
+	}
+	return output, nil
+}
+
+func (g *generator) selectionMaxDepth() int {
+	if g.config.Selection != nil && g.config.Selection.MaxDepth != nil {
+		return *g.config.Selection.MaxDepth
+	}
+	return defaultMaxSelectionDepth
+}
+
+func (g *generator) pruned(typeName string, fieldName string) (bool, error) {
+	if g.config.Selection == nil {
+		return false, nil
+	}
+	target := typeName + "." + fieldName
+	for _, pattern := range g.config.Selection.Prune {
+		matched, err := path.Match(pattern, target)
+		if err != nil {
+			return false, fmt.Errorf("invalid graphql.selection.prune pattern %q: %w", pattern, err)
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func hasRequiredArgs(f *ast.FieldDefinition) bool {

--- a/internal/codegen/backends/graphql/backend_test.go
+++ b/internal/codegen/backends/graphql/backend_test.go
@@ -43,6 +43,14 @@ type User {
 
 func parseSDL(t *testing.T, sdl string, queries, mutations []string) (*rawir.RawModule, error) {
 	t.Helper()
+	return parseSDLWithConfig(t, sdl, &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{Queries: queries, Mutations: mutations},
+	})
+}
+
+func parseSDLWithConfig(t *testing.T, sdl string, cfg *sourceconfig.GraphQLConfig) (*rawir.RawModule, error) {
+	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "schema.graphql"), []byte(sdl), 0o644); err != nil {
 		t.Fatal(err)
@@ -50,10 +58,7 @@ func parseSDL(t *testing.T, sdl string, queries, mutations []string) (*rawir.Raw
 	src := &sourceconfig.Source{
 		Name:    "console",
 		Backend: sourceconfig.BackendGraphQL,
-		GraphQL: &sourceconfig.GraphQLConfig{
-			Schema: "schema.graphql",
-			Expose: &sourceconfig.GraphQLExpose{Queries: queries, Mutations: mutations},
-		},
+		GraphQL: cfg,
 	}
 	return Parse(src, dir)
 }
@@ -64,6 +69,16 @@ func byID(ops []rawir.RawOperation) map[string]rawir.RawOperation {
 		m[op.OperationID] = op
 	}
 	return m
+}
+
+func queryDocument(t *testing.T, op rawir.RawOperation) string {
+	t.Helper()
+	var env map[string]any
+	if err := json.Unmarshal([]byte(op.RequestBody.Template), &env); err != nil {
+		t.Fatalf("template is not valid JSON: %v", err)
+	}
+	q, _ := env["query"].(string)
+	return q
 }
 
 func TestParse_ExposesOnlyPolicyMatchedOps(t *testing.T) {
@@ -192,6 +207,109 @@ func TestParse_NormalizesToDistinctCommands(t *testing.T) {
 	}
 }
 
+func TestParse_AppliesGraphQLGroupAndOutputPolicy(t *testing.T) {
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"apps"},
+		},
+		Groups: []sourceconfig.GraphQLGroupPolicy{
+			{Match: []string{"app*"}, Group: "Applications"},
+		},
+		Output: []sourceconfig.GraphQLOutputPolicy{
+			{Match: []string{"apps"}, ListPath: "data.apps.nodes", DefaultColumns: []string{"id", "name"}},
+		},
+	}
+	mod, err := parseSDLWithConfig(t, consoleSDL, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	apps := byID(mod.Operations)["console_apps"]
+	if apps.Group != "Applications" {
+		t.Fatalf("raw group = %q, want Applications", apps.Group)
+	}
+	if apps.Output == nil || apps.Output.ListPath != "data.apps.nodes" || strings.Join(apps.Output.DefaultColumns, ",") != "id,name" {
+		t.Fatalf("raw output = %+v", apps.Output)
+	}
+	specs := normalize.Normalize(mod)
+	if len(specs) != 1 {
+		t.Fatalf("specs = %d, want 1", len(specs))
+	}
+	if specs[0].Group != "Applications" {
+		t.Fatalf("normalized group = %q, want Applications", specs[0].Group)
+	}
+	if specs[0].Output.ListPath != "data.apps.nodes" || strings.Join(specs[0].Output.DefaultColumns, ",") != "id,name" {
+		t.Fatalf("normalized output = %+v", specs[0].Output)
+	}
+}
+
+func TestParse_AppliesGraphQLSelectionPolicy(t *testing.T) {
+	maxDepth := 1
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"apps"},
+		},
+		Selection: &sourceconfig.GraphQLSelectionPolicy{
+			MaxDepth: &maxDepth,
+			Prune:    []string{"App.name"},
+		},
+	}
+	mod, err := parseSDLWithConfig(t, consoleSDL, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := queryDocument(t, byID(mod.Operations)["console_apps"])
+	if !strings.Contains(q, "id") {
+		t.Fatalf("query should keep unpruned scalar field:\n%s", q)
+	}
+	for _, no := range []string{"name", "owner", "email"} {
+		if strings.Contains(q, no) {
+			t.Fatalf("query should not include %q under selection policy:\n%s", no, q)
+		}
+	}
+}
+
+func TestParse_FailsClosedOnAmbiguousGraphQLGroupPolicy(t *testing.T) {
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"apps"},
+		},
+		Groups: []sourceconfig.GraphQLGroupPolicy{
+			{Match: []string{"app*"}, Group: "Applications"},
+			{Match: []string{"apps"}, Group: "Apps"},
+		},
+	}
+	_, err := parseSDLWithConfig(t, consoleSDL, cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error for ambiguous group policy")
+	}
+	if !strings.Contains(err.Error(), "multiple graphql.groups") {
+		t.Errorf("error = %v, want to mention multiple graphql.groups rules", err)
+	}
+}
+
+func TestParse_FailsClosedOnAmbiguousGraphQLOutputPolicy(t *testing.T) {
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"apps"},
+		},
+		Output: []sourceconfig.GraphQLOutputPolicy{
+			{Match: []string{"app*"}, ListPath: "data.apps.nodes"},
+			{Match: []string{"apps"}, DefaultColumns: []string{"id"}},
+		},
+	}
+	_, err := parseSDLWithConfig(t, consoleSDL, cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error for ambiguous output policy")
+	}
+	if !strings.Contains(err.Error(), "multiple graphql.output") {
+		t.Errorf("error = %v, want to mention multiple graphql.output rules", err)
+	}
+}
+
 func TestParse_FailsClosedWhenNoSelectableFields(t *testing.T) {
 	const sdl = `
 type Query { thing: Thing }
@@ -200,6 +318,27 @@ type Thing { needsArg(x: ID!): String }
 	_, err := parseSDL(t, sdl, []string{"thing"}, nil)
 	if err == nil {
 		t.Fatal("expected fail-closed error: Thing has no auto-selectable fields")
+	}
+	if !strings.Contains(err.Error(), "no selectable fields") {
+		t.Errorf("error = %v, want to mention no selectable fields", err)
+	}
+}
+
+func TestParse_FailsClosedWhenSelectionPolicyPrunesAllFields(t *testing.T) {
+	const sdl = `
+type Query { app: App }
+type App { id: ID! }
+`
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"app"},
+		},
+		Selection: &sourceconfig.GraphQLSelectionPolicy{Prune: []string{"App.id"}},
+	}
+	_, err := parseSDLWithConfig(t, sdl, cfg)
+	if err == nil {
+		t.Fatal("expected fail-closed error after selection policy prunes every field")
 	}
 	if !strings.Contains(err.Error(), "no selectable fields") {
 		t.Errorf("error = %v, want to mention no selectable fields", err)

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -59,6 +59,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 		spec.Output.ResponseMediaType = deriveResponseMediaType(op)
 		spec.Output.Pagination = derivePagination(op)
 		spec.Output.Streaming = deriveStreaming(op)
+		applyRawOutputHints(&spec, op.Output)
 		spec.Security = deriveSecurity(op)
 		specs = append(specs, spec)
 	}
@@ -72,6 +73,21 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 		return specs[i].OperationID < specs[j].OperationID
 	})
 	return specs
+}
+
+func applyRawOutputHints(spec *runtime.CommandSpec, hints *rawir.RawOutputHints) {
+	if hints == nil {
+		return
+	}
+	if hints.ListPath != "" {
+		spec.Output.ListPath = hints.ListPath
+	}
+	if len(hints.DefaultColumns) > 0 {
+		spec.Output.DefaultColumns = append([]string(nil), hints.DefaultColumns...)
+	}
+	if hints.ResponseMediaType != "" {
+		spec.Output.ResponseMediaType = hints.ResponseMediaType
+	}
 }
 
 func group(op rawir.RawOperation) string {

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -18,6 +18,7 @@ type RawOperation struct {
 	Responses   map[string]*RawResponse
 	Produces    []string
 	Security    []RawSecurityReq
+	Output      *RawOutputHints `json:",omitempty"`
 }
 
 type RawSecurityReq struct {
@@ -48,6 +49,12 @@ type RawRequestBody struct {
 type RawResponse struct {
 	Schema    *RawSchema
 	MediaType string
+}
+
+type RawOutputHints struct {
+	ListPath          string   `json:",omitempty"`
+	DefaultColumns    []string `json:",omitempty"`
+	ResponseMediaType string   `json:",omitempty"`
 }
 
 type RawSchema struct {

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -527,6 +527,38 @@ func sourceInputs(src *sourceconfig.Source) []string {
 			lines = append(lines, fmt.Sprintf("Staging entries: `%d`", len(src.Proto.Staging)))
 		}
 		return lines
+	case sourceconfig.BackendGraphQL:
+		if src.GraphQL == nil {
+			return nil
+		}
+		lines := []string{"Schema: `" + src.GraphQL.Schema + "`"}
+		if src.GraphQL.Expose != nil {
+			if len(src.GraphQL.Expose.Queries) > 0 {
+				lines = append(lines, "Expose queries: `"+strings.Join(src.GraphQL.Expose.Queries, "`, `")+"`")
+			}
+			if len(src.GraphQL.Expose.Mutations) > 0 {
+				lines = append(lines, "Expose mutations: `"+strings.Join(src.GraphQL.Expose.Mutations, "`, `")+"`")
+			}
+		}
+		if len(src.GraphQL.Groups) > 0 {
+			lines = append(lines, fmt.Sprintf("Group policies: `%d`", len(src.GraphQL.Groups)))
+		}
+		if len(src.GraphQL.Output) > 0 {
+			lines = append(lines, fmt.Sprintf("Output policies: `%d`", len(src.GraphQL.Output)))
+		}
+		if src.GraphQL.Selection != nil {
+			parts := make([]string, 0, 2)
+			if src.GraphQL.Selection.MaxDepth != nil {
+				parts = append(parts, fmt.Sprintf("max depth `%d`", *src.GraphQL.Selection.MaxDepth))
+			}
+			if len(src.GraphQL.Selection.Prune) > 0 {
+				parts = append(parts, fmt.Sprintf("prune rules `%d`", len(src.GraphQL.Selection.Prune)))
+			}
+			if len(parts) > 0 {
+				lines = append(lines, "Selection policy: "+strings.Join(parts, "; "))
+			}
+		}
+		return lines
 	default:
 		return nil
 	}

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -238,6 +238,70 @@ func TestRenderModuleReference_NormalizesMultiWordGroupPaths(t *testing.T) {
 	}
 }
 
+func TestRenderModuleReference_GraphQLSourceSummary(t *testing.T) {
+	manifest := &config.Manifest{CLI: config.CLIInfo{Name: "consolectl"}}
+	maxDepth := 2
+	module := SkillModule{
+		Source: &sourceconfig.Source{
+			Name:      "console",
+			RepoURL:   "https://example.com/console.git",
+			PinnedTag: "v3.0.0",
+			Backend:   sourceconfig.BackendGraphQL,
+			GraphQL: &sourceconfig.GraphQLConfig{
+				Schema: "schema.graphql",
+				Expose: &sourceconfig.GraphQLExpose{
+					Queries:   []string{"app*"},
+					Mutations: []string{"createApp"},
+				},
+				Groups: []sourceconfig.GraphQLGroupPolicy{
+					{Match: []string{"app*"}, Group: "Applications"},
+				},
+				Output: []sourceconfig.GraphQLOutputPolicy{
+					{Match: []string{"apps"}, ListPath: "data.apps.nodes", DefaultColumns: []string{"id", "name"}},
+				},
+				Selection: &sourceconfig.GraphQLSelectionPolicy{
+					MaxDepth: &maxDepth,
+					Prune:    []string{"App.secret"},
+				},
+			},
+		},
+		Specs: []runtime.CommandSpec{{
+			Group:   "Applications",
+			Use:     "apps",
+			Short:   "List apps",
+			Method:  "POST",
+			PathTpl: "/graphql",
+			RequestBody: &runtime.RequestBody{
+				Required:  true,
+				MediaType: "application/json",
+				Template:  `{"query":"query apps { apps { id } }","variables":{}}`,
+				MergePath: "variables",
+			},
+			Output: runtime.OutputHints{
+				ListPath:       "data.apps.nodes",
+				DefaultColumns: []string{"id", "name"},
+			},
+		}},
+	}
+
+	got := renderModuleReference(manifest, module, true)
+	for _, want := range []string{
+		"Backend: `graphql`",
+		"Schema: `schema.graphql`",
+		"Expose queries: `app*`",
+		"Expose mutations: `createApp`",
+		"Group policies: `1`",
+		"Output policies: `1`",
+		"Selection policy: max depth `2`; prune rules `1`",
+		"Body: required; templated body, set inputs under `variables`",
+		"Output: list path `data.apps.nodes`; columns `id`, `name`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("graphql module reference missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderSkillDirectory_RejectsUnsafeRoot(t *testing.T) {
 	err := RenderSkillDirectory("", &config.Manifest{CLI: config.CLIInfo{Name: "x"}}, nil)
 	if err == nil {

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -3,6 +3,7 @@ package sourceconfig
 import (
 	"fmt"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -47,13 +48,32 @@ type OpenAPI3Config struct {
 }
 
 type GraphQLConfig struct {
-	Schema string         `yaml:"schema"`
-	Expose *GraphQLExpose `yaml:"expose,omitempty"`
+	Schema    string                  `yaml:"schema"`
+	Expose    *GraphQLExpose          `yaml:"expose,omitempty"`
+	Groups    []GraphQLGroupPolicy    `yaml:"groups,omitempty"`
+	Output    []GraphQLOutputPolicy   `yaml:"output,omitempty"`
+	Selection *GraphQLSelectionPolicy `yaml:"selection,omitempty"`
 }
 
 type GraphQLExpose struct {
 	Queries   []string `yaml:"queries,omitempty"`
 	Mutations []string `yaml:"mutations,omitempty"`
+}
+
+type GraphQLGroupPolicy struct {
+	Match []string `yaml:"match"`
+	Group string   `yaml:"group"`
+}
+
+type GraphQLOutputPolicy struct {
+	Match          []string `yaml:"match"`
+	ListPath       string   `yaml:"list_path,omitempty"`
+	DefaultColumns []string `yaml:"default_columns,omitempty"`
+}
+
+type GraphQLSelectionPolicy struct {
+	MaxDepth *int     `yaml:"max_depth,omitempty"`
+	Prune    []string `yaml:"prune,omitempty"`
 }
 
 type StagingEntry struct {
@@ -128,6 +148,9 @@ func validate(s *Source) error {
 		if s.GraphQL.Expose == nil || (len(s.GraphQL.Expose.Queries) == 0 && len(s.GraphQL.Expose.Mutations) == 0) {
 			return fmt.Errorf("backend=graphql requires an explicit graphql.expose policy (queries and/or mutations); refusing to expose the whole schema")
 		}
+		if err := validateGraphQLPolicy(s.GraphQL); err != nil {
+			return err
+		}
 	case "":
 		return fmt.Errorf("missing backend")
 	default:
@@ -149,6 +172,86 @@ func rejectForeignBlocks(s *Source) error {
 	for _, b := range blocks {
 		if b.backend != s.Backend && b.set {
 			return fmt.Errorf("backend=%s must not set %s block", s.Backend, b.backend)
+		}
+	}
+	return nil
+}
+
+func validateGraphQLPolicy(g *GraphQLConfig) error {
+	if err := validateGraphQLPatterns("graphql.expose.queries", g.Expose.Queries); err != nil {
+		return err
+	}
+	if err := validateGraphQLPatterns("graphql.expose.mutations", g.Expose.Mutations); err != nil {
+		return err
+	}
+	for i, rule := range g.Groups {
+		if strings.TrimSpace(rule.Group) == "" {
+			return fmt.Errorf("graphql.groups[%d] requires group", i)
+		}
+		if len(rule.Match) == 0 {
+			return fmt.Errorf("graphql.groups[%d] requires non-empty match", i)
+		}
+		if err := validateGraphQLPatterns(fmt.Sprintf("graphql.groups[%d].match", i), rule.Match); err != nil {
+			return err
+		}
+	}
+	for i, rule := range g.Output {
+		if len(rule.Match) == 0 {
+			return fmt.Errorf("graphql.output[%d] requires non-empty match", i)
+		}
+		if rule.ListPath == "" && len(rule.DefaultColumns) == 0 {
+			return fmt.Errorf("graphql.output[%d] requires list_path or default_columns", i)
+		}
+		if err := validateGraphQLDottedPath(fmt.Sprintf("graphql.output[%d].list_path", i), rule.ListPath); err != nil {
+			return err
+		}
+		for j, column := range rule.DefaultColumns {
+			if strings.TrimSpace(column) == "" {
+				return fmt.Errorf("graphql.output[%d].default_columns[%d] contains an empty path segment", i, j)
+			}
+			if err := validateGraphQLDottedPath(fmt.Sprintf("graphql.output[%d].default_columns[%d]", i, j), column); err != nil {
+				return err
+			}
+		}
+		if err := validateGraphQLPatterns(fmt.Sprintf("graphql.output[%d].match", i), rule.Match); err != nil {
+			return err
+		}
+	}
+	if g.Selection != nil {
+		if g.Selection.MaxDepth != nil && *g.Selection.MaxDepth <= 0 {
+			return fmt.Errorf("graphql.selection.max_depth must be > 0")
+		}
+		for _, p := range g.Selection.Prune {
+			if _, err := path.Match(p, "Type.field"); err != nil {
+				return fmt.Errorf("invalid graphql.selection.prune pattern %q: %w", p, err)
+			}
+			if !strings.Contains(p, ".") {
+				return fmt.Errorf("graphql.selection.prune pattern %q must be Type.field", p)
+			}
+		}
+	}
+	return nil
+}
+
+func validateGraphQLPatterns(label string, patterns []string) error {
+	for _, p := range patterns {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("%s contains an empty pattern", label)
+		}
+		if _, err := path.Match(p, "sample"); err != nil {
+			return fmt.Errorf("invalid %s pattern %q: %w", label, p, err)
+		}
+	}
+	return nil
+}
+
+func validateGraphQLDottedPath(label string, p string) error {
+	if p == "" {
+		return nil
+	}
+	for _, part := range strings.Split(p, ".") {
+		if strings.TrimSpace(part) == "" {
+			return fmt.Errorf("%s contains an empty path segment", label)
 		}
 	}
 	return nil

--- a/internal/sourceconfig/sources_test.go
+++ b/internal/sourceconfig/sources_test.go
@@ -187,6 +187,16 @@ func TestLoad_AcceptsGraphQL(t *testing.T) {
       expose:
         queries: ["apps", "app"]
         mutations: ["createApp"]
+      groups:
+        - match: ["app*"]
+          group: Applications
+      output:
+        - match: ["apps"]
+          list_path: data.apps.nodes
+          default_columns: ["id", "name"]
+      selection:
+        max_depth: 2
+        prune: ["App.secret"]
 `
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("seed yaml: %v", err)
@@ -204,6 +214,15 @@ func TestLoad_AcceptsGraphQL(t *testing.T) {
 	}
 	if src.GraphQL.Expose == nil || len(src.GraphQL.Expose.Queries) != 2 || len(src.GraphQL.Expose.Mutations) != 1 {
 		t.Fatalf("expose = %+v", src.GraphQL.Expose)
+	}
+	if len(src.GraphQL.Groups) != 1 || src.GraphQL.Groups[0].Group != "Applications" {
+		t.Fatalf("groups = %+v", src.GraphQL.Groups)
+	}
+	if len(src.GraphQL.Output) != 1 || src.GraphQL.Output[0].ListPath != "data.apps.nodes" || len(src.GraphQL.Output[0].DefaultColumns) != 2 {
+		t.Fatalf("output = %+v", src.GraphQL.Output)
+	}
+	if src.GraphQL.Selection == nil || src.GraphQL.Selection.MaxDepth == nil || *src.GraphQL.Selection.MaxDepth != 2 || len(src.GraphQL.Selection.Prune) != 1 {
+		t.Fatalf("selection = %+v", src.GraphQL.Selection)
 	}
 }
 
@@ -278,6 +297,100 @@ func TestLoad_RejectsGraphQLWithSwaggerBlock(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must not set swagger block") {
 		t.Errorf("error = %v, want to mention swagger block", err)
+	}
+}
+
+func TestLoad_RejectsInvalidGraphQLPolicy(t *testing.T) {
+	cases := []struct {
+		name   string
+		policy string
+		want   string
+	}{
+		{
+			name: "group missing match",
+			policy: `      groups:
+        - group: Applications
+`,
+			want: "requires non-empty match",
+		},
+		{
+			name: "group missing group",
+			policy: `      groups:
+        - match: ["apps"]
+`,
+			want: "requires group",
+		},
+		{
+			name: "output missing shape",
+			policy: `      output:
+        - match: ["apps"]
+`,
+			want: "requires list_path or default_columns",
+		},
+		{
+			name: "output invalid list path",
+			policy: `      output:
+        - match: ["apps"]
+          list_path: data..nodes
+`,
+			want: "empty path segment",
+		},
+		{
+			name: "output invalid default column",
+			policy: `      output:
+        - match: ["apps"]
+          default_columns: [""]
+`,
+			want: "empty path segment",
+		},
+		{
+			name: "selection negative depth",
+			policy: `      selection:
+        max_depth: -1
+`,
+			want: "must be > 0",
+		},
+		{
+			name: "selection zero depth",
+			policy: `      selection:
+        max_depth: 0
+`,
+			want: "must be > 0",
+		},
+		{
+			name: "selection prune missing type",
+			policy: `      selection:
+        prune: ["owner"]
+`,
+			want: "must be Type.field",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sources.yaml")
+			body := `sources:
+  console:
+    repo_url: https://example.com/repo.git
+    pinned_tag: v3.0.0
+    backend: graphql
+    graphql:
+      schema: schema.graphql
+      expose:
+        queries: ["apps"]
+` + tc.policy
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatalf("seed yaml: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load accepted invalid graphql policy %q", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/runtime/body.go
+++ b/pkg/runtime/body.go
@@ -138,6 +138,37 @@ func setNestedPath(m map[string]any, path string, v any) error {
 	return setNestedSegs(m, parsePath(path), v)
 }
 
+func getNestedPath(v any, path string) (any, bool) {
+	if path == "" {
+		return v, true
+	}
+	return getNestedSegs(v, parsePath(path))
+}
+
+func getNestedSegs(v any, segs []pathSegment) (any, bool) {
+	if len(segs) == 0 {
+		return v, true
+	}
+	seg := segs[0]
+	rest := segs[1:]
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	next, ok := m[seg.key]
+	if !ok {
+		return nil, false
+	}
+	if seg.idx >= 0 {
+		arr, ok := next.([]any)
+		if !ok || seg.idx >= len(arr) {
+			return nil, false
+		}
+		next = arr[seg.idx]
+	}
+	return getNestedSegs(next, rest)
+}
+
 func setNestedSegs(m map[string]any, segs []pathSegment, v any) error {
 	if len(segs) == 0 {
 		return nil

--- a/pkg/runtime/formatter_test.go
+++ b/pkg/runtime/formatter_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +53,24 @@ func TestFormatOutput_UnknownFormat(t *testing.T) {
 	err := FormatOutput([]byte("x"), "csv", io.Discard, OutputHints{})
 	if err == nil {
 		t.Fatal("expected error for unknown format")
+	}
+}
+
+func TestFormatOutput_TableUsesNestedListPath(t *testing.T) {
+	var buf bytes.Buffer
+	data := []byte(`{"data":{"sessionList":{"nodes":[{"id":"s1","name":"alpha"},{"id":"s2","name":"beta"}]}}}`)
+	err := FormatOutput(data, "table", &buf, OutputHints{
+		ListPath:       "data.sessionList.nodes",
+		DefaultColumns: []string{"id", "name"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"ID", "NAME", "s1", "alpha", "s2", "beta"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table output missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/pkg/runtime/paginate.go
+++ b/pkg/runtime/paginate.go
@@ -66,7 +66,11 @@ func extractItemsRaw(data []byte, listPath string) []json.RawMessage {
 		if !ok {
 			return nil
 		}
-		arr, ok = obj[listPath].([]any)
+		raw, ok := getNestedPath(obj, listPath)
+		if !ok {
+			return nil
+		}
+		arr, ok = raw.([]any)
 		if !ok {
 			return nil
 		}
@@ -86,18 +90,15 @@ func extractJSONString(data []byte, field string) string {
 	if field == "" {
 		return ""
 	}
-	var obj map[string]json.RawMessage
+	var obj map[string]any
 	if err := json.Unmarshal(data, &obj); err != nil {
 		return ""
 	}
-	raw, ok := obj[field]
+	raw, ok := getNestedPath(obj, field)
 	if !ok {
 		return ""
 	}
-	var s string
-	if err := json.Unmarshal(raw, &s); err != nil {
-		return ""
-	}
+	s, _ := raw.(string)
 	return s
 }
 
@@ -128,8 +129,9 @@ func buildMergedJSON(items []json.RawMessage, listPath string) ([]byte, error) {
 	if listPath == "" {
 		return json.Marshal(items)
 	}
-	envelope := map[string]any{
-		listPath: items,
+	envelope := map[string]any{}
+	if err := setNestedPath(envelope, listPath, items); err != nil {
+		return nil, err
 	}
 	return json.Marshal(envelope)
 }

--- a/pkg/runtime/paginate_test.go
+++ b/pkg/runtime/paginate_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,6 +44,54 @@ func TestPaginateAll_Cursor(t *testing.T) {
 	}
 	if atomic.LoadInt32(&call) != 2 {
 		t.Errorf("made %d requests, want 2", atomic.LoadInt32(&call))
+	}
+}
+
+func TestPaginateAll_CursorNestedPaths(t *testing.T) {
+	pages := []map[string]any{
+		{"data": map[string]any{"sessionList": map[string]any{
+			"nodes":    []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}},
+			"pageInfo": map[string]any{"endCursor": "tok2"},
+		}}},
+		{"data": map[string]any{"sessionList": map[string]any{
+			"nodes":    []any{map[string]any{"id": "3"}},
+			"pageInfo": map[string]any{"endCursor": ""},
+		}}},
+	}
+	var call int32
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.String())
+		idx := int(atomic.LoadInt32(&call))
+		if idx >= len(pages) {
+			idx = len(pages) - 1
+		}
+		atomic.AddInt32(&call, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pages[idx])
+	}))
+	defer srv.Close()
+
+	hint := PaginationHint{Strategy: "cursor", TokenParam: "after", TokenField: "data.sessionList.pageInfo.endCursor"}
+	data, err := PaginateAll(context.Background(), srv.URL, "GET", "/sessions?first=2", nil, ClientOptions{Timeout: 5 * time.Second}, hint, "data.sessionList.nodes", 10)
+	if err != nil {
+		t.Fatalf("PaginateAll: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	raw, ok := getNestedPath(result, "data.sessionList.nodes")
+	if !ok {
+		t.Fatalf("merged result missing nested list path: %s", string(data))
+	}
+	items, ok := raw.([]any)
+	if !ok || len(items) != 3 {
+		t.Fatalf("nested items = %#v, want 3 items", raw)
+	}
+	if len(paths) != 2 || !strings.Contains(paths[1], "after=tok2") {
+		t.Fatalf("request paths = %v, want second request to carry cursor", paths)
 	}
 }
 
@@ -123,9 +172,12 @@ func TestSetQueryParam(t *testing.T) {
 }
 
 func TestExtractJSONString(t *testing.T) {
-	data := []byte(`{"next_page_token": "abc123", "count": 42}`)
+	data := []byte(`{"next_page_token": "abc123", "count": 42, "data": {"pageInfo": {"endCursor": "nested"}}}`)
 	if got := extractJSONString(data, "next_page_token"); got != "abc123" {
 		t.Errorf("got %q, want abc123", got)
+	}
+	if got := extractJSONString(data, "data.pageInfo.endCursor"); got != "nested" {
+		t.Errorf("got %q, want nested", got)
 	}
 	if got := extractJSONString(data, "missing"); got != "" {
 		t.Errorf("got %q for missing field, want empty", got)

--- a/pkg/runtime/table.go
+++ b/pkg/runtime/table.go
@@ -73,9 +73,14 @@ func extractRows(v any, listPath string) []map[string]any {
 	switch m := v.(type) {
 	case map[string]any:
 		if listPath != "" {
-			if arr, ok := m[listPath].([]any); ok {
+			if raw, ok := getNestedPath(m, listPath); ok {
+				arr, ok := raw.([]any)
+				if !ok {
+					return nil
+				}
 				return itemsToRows(arr)
 			}
+			return nil
 		}
 		if items, ok := m["items"].([]any); ok {
 			return itemsToRows(items)


### PR DESCRIPTION
## Summary

- Add GraphQL policy fields for grouping, output hints, and selection control in `sources.yaml`.
- Apply GraphQL policy during codegen, including fail-closed handling for ambiguous group/output matches and invalid selection depth.
- Carry policy output hints through normalize into runtime command specs, and support dotted list/token paths in table output and pagination helpers.
- Surface GraphQL schema, exposure policy, selection policy, templated body, and output hints in generated Skill module references.

## Verification

- `go test ./internal/sourceconfig ./internal/codegen/backends/graphql ./internal/codegen/normalize ./internal/codegen/render ./pkg/runtime`
- `make check`
- `go test -race ./internal/sourceconfig ./internal/codegen/backends/graphql ./internal/codegen/normalize ./internal/codegen/render ./pkg/runtime`
- `go test -race ./internal/sourceconfig ./internal/codegen/backends/graphql ./internal/codegen/render`

## Compatibility

- Adds optional GraphQL `groups`, `output`, and `selection` policy fields to source config.
- Fails closed for invalid GraphQL policy, ambiguous policy matches, and explicit `graphql.selection.max_depth <= 0`.
- Dotted output paths now work for table rendering and pagination helpers.
- No catalog schema bump and no generated output committed.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.