### PR TITLE
feat(graphql): expand input object flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,10 @@ Grouping rules:
 
 GraphQL commands execute `POST /graphql` with a baked `{query, variables}`
 request envelope. Scalar and enum arguments become typed flags that merge under
-`variables`. Required non-scalar arguments fail codegen until they are modeled
-explicitly; optional non-scalar arguments stay query-declared and can be supplied
-with `--set` or `--file`.
+`variables`. Input-object arguments expand scalar and enum leaf fields into
+dotted variable flags such as `--input-name`; required fields that cannot be
+represented as flags fail codegen instead of publishing an incomplete command.
+Optional complex fields can still be supplied with `--set` or `--file`.
 
 ### Overlays
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -162,10 +162,10 @@ Optional GraphQL policy blocks tune the generated CLI contract:
 
 GraphQL commands execute `POST /graphql` with a baked JSON body template:
 `{"query": "...", "variables": {}}`. Scalar and enum arguments become typed CLI
-flags and merge under `variables`. Required non-scalar arguments fail codegen
-because they cannot be faithfully represented as simple flags yet; optional
-non-scalar arguments remain query-declared and can be supplied with `--set` or
-`--file`.
+flags and merge under `variables`. Input-object arguments expand scalar and enum
+leaf fields into dotted variable flags such as `--input-name`; required fields
+that cannot be faithfully represented as flags fail codegen. Optional complex
+fields remain query-declared and can be supplied with `--set` or `--file`.
 
 ## Generate Code
 

--- a/internal/codegen/backends/graphql/backend.go
+++ b/internal/codegen/backends/graphql/backend.go
@@ -86,23 +86,15 @@ type generator struct {
 func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.RawOperation, error) {
 	var varDefs, argList []string
 	var params []rawir.RawParameter
+	variableDefaults := map[string]any{}
 	for _, arg := range field.Arguments {
 		varDefs = append(varDefs, "$"+arg.Name+": "+arg.Type.String())
 		argList = append(argList, arg.Name+": $"+arg.Name)
-		def := g.schema.Types[arg.Type.Name()]
-		if def != nil && def.IsLeafType() {
-			params = append(params, rawir.RawParameter{
-				Name:        arg.Name,
-				In:          "variable",
-				Required:    arg.Type.NonNull,
-				Type:        rawType(arg.Type),
-				Description: arg.Description,
-			})
-			continue
+		argParams, err := g.variableParamsForArg(opType, field.Name, arg, variableDefaults)
+		if err != nil {
+			return rawir.RawOperation{}, err
 		}
-		if arg.Type.NonNull && arg.DefaultValue == nil {
-			return rawir.RawOperation{}, fmt.Errorf("%s %q: required argument %q of type %q is not a scalar and cannot be expressed as a CLI flag", opType, field.Name, arg.Name, arg.Type.String())
-		}
+		params = append(params, argParams...)
 	}
 
 	sel, err := g.selectionSet(field.Type.Name(), 1, map[string]bool{})
@@ -135,7 +127,7 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 	}
 	doc.WriteString(" }")
 
-	template, err := json.Marshal(map[string]any{"query": doc.String(), "variables": map[string]any{}})
+	template, err := json.Marshal(map[string]any{"query": doc.String(), "variables": variableDefaults})
 	if err != nil {
 		return rawir.RawOperation{}, err
 	}
@@ -154,6 +146,78 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 		},
 		Output: output,
 	}, nil
+}
+
+func (g *generator) variableParamsForArg(opType string, operationName string, arg *ast.ArgumentDefinition, defaults map[string]any) ([]rawir.RawParameter, error) {
+	def := g.schema.Types[arg.Type.Name()]
+	if def != nil && def.IsLeafType() {
+		return []rawir.RawParameter{{
+			Name:        arg.Name,
+			In:          "variable",
+			Required:    arg.Type.NonNull,
+			Type:        rawType(arg.Type),
+			Description: arg.Description,
+			Enum:        enumValues(arg.Type, def),
+		}}, nil
+	}
+	if def != nil && def.Kind == ast.InputObject && arg.Type.Elem == nil {
+		return g.inputObjectParams(opType, operationName, arg.Name, arg.Type, arg.Type.NonNull && arg.DefaultValue == nil, defaults, map[string]bool{})
+	}
+	if arg.Type.NonNull && arg.DefaultValue == nil {
+		return nil, fmt.Errorf("%s %q: required argument %q of type %q is not a scalar and cannot be expressed as a CLI flag", opType, operationName, arg.Name, arg.Type.String())
+	}
+	return nil, nil
+}
+
+func (g *generator) inputObjectParams(opType string, operationName string, prefix string, typ *ast.Type, required bool, defaults map[string]any, onPath map[string]bool) ([]rawir.RawParameter, error) {
+	def := g.schema.Types[typ.Name()]
+	if def == nil || def.Kind != ast.InputObject || typ.Elem != nil {
+		if required {
+			return nil, fmt.Errorf("%s %q: required input field %q of type %q cannot be expressed as CLI flags", opType, operationName, prefix, typ.String())
+		}
+		return nil, nil
+	}
+	if onPath[def.Name] {
+		if required {
+			return nil, fmt.Errorf("%s %q: required input field %q creates an input object cycle through %q", opType, operationName, prefix, def.Name)
+		}
+		return nil, nil
+	}
+	if required {
+		setDefaultObject(defaults, prefix)
+	}
+
+	next := clonePath(onPath)
+	next[def.Name] = true
+	var params []rawir.RawParameter
+	for _, field := range def.Fields {
+		name := prefix + "." + field.Name
+		fieldRequired := required && field.Type.NonNull && field.DefaultValue == nil
+		fieldDef := g.schema.Types[field.Type.Name()]
+		if fieldDef != nil && fieldDef.IsLeafType() {
+			params = append(params, rawir.RawParameter{
+				Name:        name,
+				In:          "variable",
+				Required:    fieldRequired,
+				Type:        rawType(field.Type),
+				Description: field.Description,
+				Enum:        enumValues(field.Type, fieldDef),
+			})
+			continue
+		}
+		if fieldDef != nil && fieldDef.Kind == ast.InputObject && field.Type.Elem == nil {
+			child, err := g.inputObjectParams(opType, operationName, name, field.Type, fieldRequired, defaults, next)
+			if err != nil {
+				return nil, err
+			}
+			params = append(params, child...)
+			continue
+		}
+		if fieldRequired {
+			return nil, fmt.Errorf("%s %q: required input field %q of type %q cannot be expressed as CLI flags", opType, operationName, name, field.Type.String())
+		}
+	}
+	return params, nil
 }
 
 func (g *generator) selectionSet(typeName string, depth int, onPath map[string]bool) (string, error) {
@@ -313,5 +377,29 @@ func scalarType(t *ast.Type) string {
 		return "boolean"
 	default:
 		return "string"
+	}
+}
+
+func enumValues(typ *ast.Type, def *ast.Definition) []string {
+	if typ.Elem != nil || def == nil || def.Kind != ast.Enum {
+		return nil
+	}
+	values := make([]string, 0, len(def.EnumValues))
+	for _, v := range def.EnumValues {
+		values = append(values, v.Name)
+	}
+	return values
+}
+
+func setDefaultObject(root map[string]any, path string) {
+	current := root
+	parts := strings.Split(path, ".")
+	for _, part := range parts {
+		next, ok := current[part].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
 	}
 }

--- a/internal/codegen/backends/graphql/backend_test.go
+++ b/internal/codegen/backends/graphql/backend_test.go
@@ -396,19 +396,46 @@ type App { id: ID! }
 	}
 }
 
-func TestParse_FailsClosedOnRequiredNonLeafArg(t *testing.T) {
+func TestParse_ExpandsRequiredInputObjectLeafArgs(t *testing.T) {
 	const sdl = `
-input CreateAppInput { name: String! }
+input CreateAppInput { name: String!, region: String }
 type Query { ping: String }
 type Mutation { createApp(input: CreateAppInput!): App! }
 type App { id: ID! }
 `
-	_, err := parseSDL(t, sdl, nil, []string{"createApp"})
-	if err == nil {
-		t.Fatal("expected fail-closed error for a required non-scalar argument")
+	mod, err := parseSDL(t, sdl, nil, []string{"createApp"})
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "createApp") || !strings.Contains(err.Error(), "input") {
-		t.Errorf("error = %v, want to name the operation and argument", err)
+	create := byID(mod.Operations)["console_createApp"]
+	got := map[string]rawir.RawParameter{}
+	for _, p := range create.Parameters {
+		got[p.Name] = p
+	}
+	if p := got["input.name"]; p.In != "variable" || !p.Required || p.Type != "string" {
+		t.Fatalf("input.name variable = %+v", p)
+	}
+	if p := got["input.region"]; p.In != "variable" || p.Required || p.Type != "string" {
+		t.Fatalf("input.region variable = %+v", p)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(create.RequestBody.Template), &env); err != nil {
+		t.Fatal(err)
+	}
+	vars, _ := env["variables"].(map[string]any)
+	if _, ok := vars["input"].(map[string]any); !ok {
+		t.Fatalf("required input object default missing: %#v", env["variables"])
+	}
+	specs := normalize.Normalize(mod)
+	if len(specs) != 1 {
+		t.Fatalf("specs = %d, want 1", len(specs))
+	}
+	flags := map[string]string{}
+	for _, p := range specs[0].Params {
+		flags[p.Name] = p.Flag
+	}
+	if flags["input.name"] != "input-name" || flags["input.region"] != "input-region" {
+		t.Fatalf("flags = %#v", flags)
 	}
 }
 
@@ -423,8 +450,11 @@ type App { id: ID! }
 		t.Fatalf("optional non-scalar argument should be allowed: %v", err)
 	}
 	apps := byID(mod.Operations)["console_apps"]
-	if len(apps.Parameters) != 0 {
-		t.Errorf("optional non-scalar argument should not be a flag: %+v", apps.Parameters)
+	if len(apps.Parameters) != 1 {
+		t.Fatalf("apps params = %+v, want 1", apps.Parameters)
+	}
+	if p := apps.Parameters[0]; p.Name != "filter.name" || p.Required || p.Type != "string" {
+		t.Fatalf("filter.name variable = %+v", p)
 	}
 	var env map[string]any
 	if err := json.Unmarshal([]byte(apps.RequestBody.Template), &env); err != nil {
@@ -432,6 +462,23 @@ type App { id: ID! }
 	}
 	if q, _ := env["query"].(string); !strings.Contains(q, "$filter: AppFilter") {
 		t.Errorf("optional argument should remain query-declared: %s", q)
+	}
+}
+
+func TestParse_FailsClosedOnRequiredUnsupportedInputField(t *testing.T) {
+	const sdl = `
+input MemberInput { email: String! }
+input CreateAppInput { members: [MemberInput!]! }
+type Query { ping: String }
+type Mutation { createApp(input: CreateAppInput!): App! }
+type App { id: ID! }
+`
+	_, err := parseSDL(t, sdl, nil, []string{"createApp"})
+	if err == nil {
+		t.Fatal("expected fail-closed error for a required unsupported input field")
+	}
+	if !strings.Contains(err.Error(), "createApp") || !strings.Contains(err.Error(), "input.members") {
+		t.Errorf("error = %v, want to name the operation and field", err)
 	}
 }
 

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -184,7 +184,7 @@ func queryParam(p rawir.RawParameter) runtime.ParamSpec {
 func variableParam(p rawir.RawParameter) runtime.ParamSpec {
 	ps := runtime.ParamSpec{
 		Name:       p.Name,
-		Flag:       camelToKebab(p.Name),
+		Flag:       variableFlagName(p.Name),
 		In:         runtime.InVariable,
 		Help:       helpText(p),
 		Required:   p.Required,
@@ -212,6 +212,10 @@ func variableParam(p rawir.RawParameter) runtime.ParamSpec {
 		ps.GoType = "string"
 	}
 	return ps
+}
+
+func variableFlagName(name string) string {
+	return strings.ReplaceAll(camelToKebab(name), ".", "-")
 }
 
 func headerParam(p rawir.RawParameter) runtime.ParamSpec {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -260,12 +260,12 @@ func TestBuild_VariableFlagsMergeIntoEnvelope(t *testing.T) {
 		Method:  "POST",
 		PathTpl: "/graphql",
 		Params: []ParamSpec{
-			{Name: "name", Flag: "name", In: InVariable, GoType: "string", Required: true, Help: "name"},
+			{Name: "input.name", Flag: "input-name", In: InVariable, GoType: "string", Required: true, Help: "name"},
 		},
 		RequestBody: &RequestBody{
 			Required:  true,
 			MediaType: "application/json",
-			Template:  `{"query":"mutation createApp($name: String!) { createApp(name: $name) { id } }","variables":{}}`,
+			Template:  `{"query":"mutation createApp($input: CreateAppInput!) { createApp(input: $input) { id } }","variables":{"input":{}}}`,
 			MergePath: "variables",
 		},
 		Security: &SecurityHint{Public: true},
@@ -275,7 +275,7 @@ func TestBuild_VariableFlagsMergeIntoEnvelope(t *testing.T) {
 	root.PersistentFlags().String("hostname", "", "")
 	root.PersistentFlags().StringP("output", "o", "raw", "")
 	Build(root, "demo", specs)
-	root.SetArgs([]string{"--hostname", srv.URL, "demo", "apps", "create-app", "--name", "demo"})
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "apps", "create-app", "--input-name", "demo"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -287,8 +287,10 @@ func TestBuild_VariableFlagsMergeIntoEnvelope(t *testing.T) {
 	if q, _ := got["query"].(string); !strings.Contains(q, "mutation createApp") {
 		t.Errorf("query missing baked document: %#v", got["query"])
 	}
-	if vars, _ := got["variables"].(map[string]any); vars["name"] != "demo" {
-		t.Errorf("variables = %#v, want name=demo", got["variables"])
+	vars, _ := got["variables"].(map[string]any)
+	input, _ := vars["input"].(map[string]any)
+	if input["name"] != "demo" {
+		t.Errorf("variables = %#v, want input.name=demo", got["variables"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Expands GraphQL input-object scalar and enum leaf fields into generated variable flags. Dotted variable names now become CLI flags such as `--input-name`, required input objects get an empty default object in the baked variables envelope, and required unsupported input fields still fail codegen instead of publishing incomplete commands.

Updates the GraphQL docs to describe the input-object flag behavior.

## Verification

- `go test ./internal/codegen/backends/graphql ./internal/codegen/normalize ./pkg/runtime`
- `make check`
- `go test -race ./internal/codegen/backends/graphql ./internal/codegen/normalize ./pkg/runtime`
- `git diff --check HEAD~1..HEAD`

## Compatibility

GraphQL generated command shape changes for supported input-object arguments: scalar and enum leaf fields now appear as typed variable flags and merge into `body.merge_path=variables` using dotted paths. Required unsupported input fields remain fail-closed. Catalog schema and runtime schema versions are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>` directories is not committed.
- [x] Commits are signed off when this is ready to merge.