### PR TITLE
feat(graphql): add relay-style body-cursor pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ request envelope. Scalar and enum arguments become typed flags that merge under
 dotted variable flags such as `--input-name`; required fields that cannot be
 represented as flags fail codegen instead of publishing an incomplete command.
 Optional complex fields can still be supplied with `--set` or `--file`.
+Relay-style outputs with `list_path: data.<operation>.nodes` or `.edges`,
+`pageInfo.endCursor`, `pageInfo.hasNextPage`, and an `after` argument get
+`--all`; subsequent pages write the cursor back under `variables.after`.
 
 ### Overlays
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -166,6 +166,9 @@ flags and merge under `variables`. Input-object arguments expand scalar and enum
 leaf fields into dotted variable flags such as `--input-name`; required fields
 that cannot be faithfully represented as flags fail codegen. Optional complex
 fields remain query-declared and can be supplied with `--set` or `--file`.
+Relay-style outputs with `list_path: data.<operation>.nodes` or `.edges`,
+`pageInfo.endCursor`, `pageInfo.hasNextPage`, and an `after` argument get
+`--all`; subsequent pages write the cursor back under `variables.after`.
 
 ## Generate Code
 

--- a/internal/codegen/backends/graphql/backend.go
+++ b/internal/codegen/backends/graphql/backend.go
@@ -105,7 +105,7 @@ func (g *generator) operation(opType string, field *ast.FieldDefinition) (rawir.
 	if err != nil {
 		return rawir.RawOperation{}, err
 	}
-	output, err := g.outputFor(field.Name)
+	output, err := g.outputFor(field)
 	if err != nil {
 		return rawir.RawOperation{}, err
 	}
@@ -286,7 +286,8 @@ func (g *generator) groupFor(fieldName string) (string, error) {
 	return g.module, nil
 }
 
-func (g *generator) outputFor(fieldName string) (*rawir.RawOutputHints, error) {
+func (g *generator) outputFor(field *ast.FieldDefinition) (*rawir.RawOutputHints, error) {
+	fieldName := field.Name
 	var output *rawir.RawOutputHints
 	for _, rule := range g.config.Output {
 		matched, err := matchAny(rule.Match, fieldName)
@@ -303,7 +304,62 @@ func (g *generator) outputFor(fieldName string) (*rawir.RawOutputHints, error) {
 			}
 		}
 	}
+	if output != nil {
+		pagination, err := g.relayPaginationFor(field, output.ListPath)
+		if err != nil {
+			return nil, err
+		}
+		output.Pagination = pagination
+	}
 	return output, nil
+}
+
+func (g *generator) relayPaginationFor(field *ast.FieldDefinition, listPath string) (*rawir.RawPaginationHint, error) {
+	if listPath == "" {
+		return nil, nil
+	}
+	wantPrefix := "data." + field.Name + "."
+	if listPath != wantPrefix+"nodes" && listPath != wantPrefix+"edges" {
+		return nil, nil
+	}
+	if !hasArg(field, "after") {
+		return nil, nil
+	}
+	if g.selectionMaxDepth() <= 1 {
+		return nil, nil
+	}
+	connection := g.schema.Types[field.Type.Name()]
+	if connection == nil {
+		return nil, nil
+	}
+	pruned, err := g.pruned(connection.Name, "pageInfo")
+	if err != nil || pruned {
+		return nil, err
+	}
+	pageInfoField := fieldByName(connection.Fields, "pageInfo")
+	if pageInfoField == nil {
+		return nil, nil
+	}
+	pageInfo := g.schema.Types[pageInfoField.Type.Name()]
+	if pageInfo == nil {
+		return nil, nil
+	}
+	for _, fieldName := range []string{"endCursor", "hasNextPage"} {
+		pruned, err := g.pruned(pageInfo.Name, fieldName)
+		if err != nil || pruned || fieldByName(pageInfo.Fields, fieldName) == nil {
+			return nil, err
+		}
+	}
+	limitParam := ""
+	if hasArg(field, "first") {
+		limitParam = "variables.first"
+	}
+	return &rawir.RawPaginationHint{
+		Strategy:   "body-cursor",
+		TokenParam: "variables.after",
+		TokenField: wantPrefix + "pageInfo.endCursor",
+		LimitParam: limitParam,
+	}, nil
 }
 
 func (g *generator) selectionMaxDepth() int {
@@ -358,6 +414,24 @@ func matchAny(patterns []string, name string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func fieldByName(fields ast.FieldList, name string) *ast.FieldDefinition {
+	for _, f := range fields {
+		if f.Name == name {
+			return f
+		}
+	}
+	return nil
+}
+
+func hasArg(field *ast.FieldDefinition, name string) bool {
+	for _, arg := range field.Arguments {
+		if arg.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func rawType(t *ast.Type) string {

--- a/internal/codegen/backends/graphql/backend_test.go
+++ b/internal/codegen/backends/graphql/backend_test.go
@@ -243,6 +243,42 @@ func TestParse_AppliesGraphQLGroupAndOutputPolicy(t *testing.T) {
 	}
 }
 
+func TestParse_DerivesRelayBodyCursorPagination(t *testing.T) {
+	const sdl = `
+type Query { listApps(first: Int, after: String): AppConnection! }
+type AppConnection { nodes: [App!]!, pageInfo: PageInfo! }
+type PageInfo { endCursor: String, hasNextPage: Boolean! }
+type App { id: ID!, name: String! }
+`
+	cfg := &sourceconfig.GraphQLConfig{
+		Schema: "schema.graphql",
+		Expose: &sourceconfig.GraphQLExpose{
+			Queries: []string{"listApps"},
+		},
+		Output: []sourceconfig.GraphQLOutputPolicy{
+			{Match: []string{"listApps"}, ListPath: "data.listApps.nodes", DefaultColumns: []string{"id", "name"}},
+		},
+	}
+	mod, err := parseSDLWithConfig(t, sdl, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	op := byID(mod.Operations)["console_listApps"]
+	if op.Output == nil || op.Output.Pagination == nil {
+		t.Fatalf("raw output pagination = %+v", op.Output)
+	}
+	if got := *op.Output.Pagination; got.Strategy != "body-cursor" || got.TokenParam != "variables.after" || got.TokenField != "data.listApps.pageInfo.endCursor" || got.LimitParam != "variables.first" {
+		t.Fatalf("raw pagination = %+v", got)
+	}
+	specs := normalize.Normalize(mod)
+	if len(specs) != 1 || specs[0].Output.Pagination == nil {
+		t.Fatalf("normalized pagination missing: %+v", specs)
+	}
+	if got := *specs[0].Output.Pagination; got.Strategy != "body-cursor" || got.TokenParam != "variables.after" || got.TokenField != "data.listApps.pageInfo.endCursor" || got.LimitParam != "variables.first" {
+		t.Fatalf("normalized pagination = %+v", got)
+	}
+}
+
 func TestParse_AppliesGraphQLSelectionPolicy(t *testing.T) {
 	maxDepth := 1
 	cfg := &sourceconfig.GraphQLConfig{

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -88,6 +88,14 @@ func applyRawOutputHints(spec *runtime.CommandSpec, hints *rawir.RawOutputHints)
 	if hints.ResponseMediaType != "" {
 		spec.Output.ResponseMediaType = hints.ResponseMediaType
 	}
+	if hints.Pagination != nil {
+		spec.Output.Pagination = &runtime.PaginationHint{
+			Strategy:   hints.Pagination.Strategy,
+			TokenParam: hints.Pagination.TokenParam,
+			TokenField: hints.Pagination.TokenField,
+			LimitParam: hints.Pagination.LimitParam,
+		}
+	}
 }
 
 func group(op rawir.RawOperation) string {

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -55,6 +55,14 @@ type RawOutputHints struct {
 	ListPath          string   `json:",omitempty"`
 	DefaultColumns    []string `json:",omitempty"`
 	ResponseMediaType string   `json:",omitempty"`
+	Pagination        *RawPaginationHint
+}
+
+type RawPaginationHint struct {
+	Strategy   string
+	TokenParam string
+	TokenField string
+	LimitParam string
 }
 
 type RawSchema struct {

--- a/pkg/runtime/paginate.go
+++ b/pkg/runtime/paginate.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 const DefaultMaxPages = 100
@@ -38,6 +39,19 @@ func PaginateAll(ctx context.Context, hostname, method, basePath string, body an
 				goto done
 			}
 			currentPath = setQueryParam(basePath, hint.TokenParam, token)
+		case "body-cursor":
+			if hasNext, ok := extractJSONBool(data, relayHasNextPath(hint.TokenField)); ok && !hasNext {
+				goto done
+			}
+			token := extractJSONString(data, hint.TokenField)
+			if token == "" {
+				goto done
+			}
+			nextBody, berr := setBodyParam(body, hint.TokenParam, token)
+			if berr != nil {
+				return nil, berr
+			}
+			body = nextBody
 		case "offset":
 			offset += len(items)
 			currentPath = setQueryParam(basePath, hint.TokenParam, strconv.Itoa(offset))
@@ -47,6 +61,31 @@ func PaginateAll(ctx context.Context, hostname, method, basePath string, body an
 	}
 done:
 	return buildMergedJSON(allItems, listPath)
+}
+
+func setBodyParam(body any, path string, value string) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("pagination token body path is empty")
+	}
+	var root map[string]any
+	switch v := body.(type) {
+	case []byte:
+		if err := json.Unmarshal(v, &root); err != nil {
+			return nil, fmt.Errorf("pagination body is not JSON: %w", err)
+		}
+	case json.RawMessage:
+		if err := json.Unmarshal(v, &root); err != nil {
+			return nil, fmt.Errorf("pagination body is not JSON: %w", err)
+		}
+	case map[string]any:
+		root = v
+	default:
+		return nil, fmt.Errorf("pagination body must be JSON")
+	}
+	if err := setNestedPath(root, path, value); err != nil {
+		return nil, err
+	}
+	return json.Marshal(root)
 }
 
 func extractItemsRaw(data []byte, listPath string) []json.RawMessage {
@@ -100,6 +139,26 @@ func extractJSONString(data []byte, field string) string {
 	}
 	s, _ := raw.(string)
 	return s
+}
+
+func extractJSONBool(data []byte, field string) (bool, bool) {
+	if field == "" {
+		return false, false
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return false, false
+	}
+	raw, ok := getNestedPath(obj, field)
+	if !ok {
+		return false, false
+	}
+	b, ok := raw.(bool)
+	return b, ok
+}
+
+func relayHasNextPath(tokenField string) string {
+	return strings.TrimSuffix(tokenField, ".endCursor") + ".hasNextPage"
 }
 
 func setQueryParam(basePath, key, value string) string {

--- a/pkg/runtime/paginate_test.go
+++ b/pkg/runtime/paginate_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,6 +46,83 @@ func TestPaginateAll_Cursor(t *testing.T) {
 	}
 	if atomic.LoadInt32(&call) != 2 {
 		t.Errorf("made %d requests, want 2", atomic.LoadInt32(&call))
+	}
+}
+
+func TestPaginateAll_BodyCursor(t *testing.T) {
+	pages := []map[string]any{
+		{
+			"data": map[string]any{
+				"listApps": map[string]any{
+					"nodes": []any{map[string]any{"id": "1"}},
+					"pageInfo": map[string]any{
+						"endCursor":   "cursor-2",
+						"hasNextPage": true,
+					},
+				},
+			},
+		},
+		{
+			"data": map[string]any{
+				"listApps": map[string]any{
+					"nodes": []any{map[string]any{"id": "2"}},
+					"pageInfo": map[string]any{
+						"endCursor":   "cursor-3",
+						"hasNextPage": false,
+					},
+				},
+			},
+		},
+	}
+	var bodies []map[string]any
+	var bodiesMu sync.Mutex
+	var call int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body map[string]any
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("request body is not JSON: %v", err)
+		}
+		bodiesMu.Lock()
+		bodies = append(bodies, body)
+		bodiesMu.Unlock()
+		idx := int(atomic.LoadInt32(&call))
+		if idx >= len(pages) {
+			idx = len(pages) - 1
+		}
+		atomic.AddInt32(&call, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pages[idx])
+	}))
+	defer srv.Close()
+
+	body := []byte(`{"query":"query listApps($first: Int, $after: String) { listApps(first: $first, after: $after) { nodes { id } pageInfo { endCursor hasNextPage } } }","variables":{"first":1}}`)
+	hint := PaginationHint{Strategy: "body-cursor", TokenParam: "variables.after", TokenField: "data.listApps.pageInfo.endCursor", LimitParam: "variables.first"}
+	data, err := PaginateAll(context.Background(), srv.URL, "POST", "/graphql", body, ClientOptions{Timeout: 5 * time.Second}, hint, "data.listApps.nodes", 10)
+	if err != nil {
+		t.Fatalf("PaginateAll: %v", err)
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items := result["data"].(map[string]any)["listApps"].(map[string]any)["nodes"].([]any)
+	if len(items) != 2 {
+		t.Errorf("got %d items, want 2", len(items))
+	}
+	if atomic.LoadInt32(&call) != 2 {
+		t.Errorf("made %d requests, want 2", atomic.LoadInt32(&call))
+	}
+	bodiesMu.Lock()
+	defer bodiesMu.Unlock()
+	firstVars := bodies[0]["variables"].(map[string]any)
+	if _, ok := firstVars["after"]; ok {
+		t.Fatalf("first request after = %#v, want absent", firstVars["after"])
+	}
+	secondVars := bodies[1]["variables"].(map[string]any)
+	if secondVars["after"] != "cursor-2" {
+		t.Fatalf("second request after = %#v, want cursor-2", secondVars["after"])
 	}
 }
 


### PR DESCRIPTION
### What's changed?

- GraphQL codegen derives `body-cursor` pagination hints when Relay connection outputs match `data.<operation>.nodes` or `.edges`, expose `pageInfo.endCursor` / `pageInfo.hasNextPage`, and declare an `after` argument.
- Normalization copies raw pagination hints into `CommandSpec` output metadata.
- Runtime `--all` pagination adds a `body-cursor` strategy that writes the next cursor into `variables.after` on subsequent GraphQL requests.
- README and CLI usage docs describe the Relay pagination behavior.

### Why

- GraphQL list operations commonly use Relay cursor pagination in the request body (`variables.after`), not query parameters. Generated CLIs need `--all` to follow those cursors without manual per-page flag wiring.

### Verification

```sh
go test ./internal/codegen/backends/graphql/... ./internal/codegen/normalize/... ./pkg/runtime/...
```

All three packages pass.