### PR TITLE
feat(runtime): add per-source default hostname

### DIFF
--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -414,6 +414,9 @@ var Specs = []runtime.CommandSpec{
 		{{- end}}
 		Method:      {{printf "%q" $op.Method}},
 		PathTpl:     {{printf "%q" $op.PathTpl}},
+		{{- if $op.DefaultHostname}}
+		DefaultHostname: {{printf "%q" $op.DefaultHostname}},
+		{{- end}}
 		{{- if $op.Params}}
 		Params: []runtime.ParamSpec{
 			{{- range $op.Params}}

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -253,7 +253,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("## Workflow\n\n")
 	fmt.Fprintf(&b, "1. Search for candidates with `%s search \"<intent>\" --json`; use `--limit` when needed. Search is only candidate discovery.\n", cli)
 	fmt.Fprintf(&b, "2. Inspect the exact command with `%s commands show <path...> --json` before executing an unfamiliar command.\n", cli)
-	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --hostname <host>` before execution. If it is not logged in, stop and ask the user to authenticate.\n", cli)
+	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`.\n", cli, manifest.CLI.HostEnv)
 	fmt.Fprintf(&b, "4. Execute only after flags, body, auth, HTTP path, and output hints are clear from `commands show`.\n\n")
 	b.WriteString("## General Commands\n\n")
 	fmt.Fprintf(&b, "- `%s commands --json`: full generated command catalog.\n", cli)
@@ -296,6 +296,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("Key fields:\n\n")
 	b.WriteString("- `path`: command path to pass to `commands show` or execute after the CLI name.\n")
 	b.WriteString("- `http`: HTTP method and path template.\n")
+	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, and help.\n")
 	b.WriteString("- `body`: request body requirement and media type.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
@@ -313,7 +314,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("## Output\n\n")
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`.\n\n")
 	b.WriteString("## Auth\n\n")
-	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. If no matching host is logged in, stop and ask the user to authenticate.\n", cli)
+	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	return b.String()
 }
 
@@ -325,6 +326,9 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule, flat bool
 	b.WriteString("## Source\n\n")
 	if mod.Source != nil {
 		fmt.Fprintf(&b, "- Backend: `%s`\n", mod.Source.Backend)
+		if mod.Source.DefaultHostname != nil {
+			fmt.Fprintf(&b, "- Default hostname: `%s`\n", *mod.Source.DefaultHostname)
+		}
 		fmt.Fprintf(&b, "- Repository: %s\n", valueOrUnknown(mod.Source.RepoURL))
 		fmt.Fprintf(&b, "- Pinned tag: `%s`\n", valueOrUnknown(mod.Source.PinnedTag))
 		for _, line := range sourceInputs(mod.Source) {

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -183,6 +183,11 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 
 		specs := normalize.Normalize(mod)
 		specs = render.MergeOverlayModule(specs, overlays[src.Name])
+		if src.DefaultHostname != nil {
+			for i := range specs {
+				specs[i].DefaultHostname = *src.DefaultHostname
+			}
+		}
 		cliName := src.Name
 		if src.DisplayName != "" {
 			cliName = src.DisplayName

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	latheconfig "github.com/lathe-cli/lathe/pkg/config"
 	"gopkg.in/yaml.v3"
 )
 
@@ -22,15 +23,16 @@ type Config struct {
 }
 
 type Source struct {
-	Name        string          `yaml:"-"`
-	DisplayName string          `yaml:"display_name,omitempty"`
-	RepoURL     string          `yaml:"repo_url"`
-	PinnedTag   string          `yaml:"pinned_tag"`
-	Backend     string          `yaml:"backend"`
-	Swagger     *SwaggerConfig  `yaml:"swagger,omitempty"`
-	Proto       *ProtoConfig    `yaml:"proto,omitempty"`
-	OpenAPI3    *OpenAPI3Config `yaml:"openapi3,omitempty"`
-	GraphQL     *GraphQLConfig  `yaml:"graphql,omitempty"`
+	Name            string          `yaml:"-"`
+	DisplayName     string          `yaml:"display_name,omitempty"`
+	DefaultHostname *string         `yaml:"default_hostname,omitempty"`
+	RepoURL         string          `yaml:"repo_url"`
+	PinnedTag       string          `yaml:"pinned_tag"`
+	Backend         string          `yaml:"backend"`
+	Swagger         *SwaggerConfig  `yaml:"swagger,omitempty"`
+	Proto           *ProtoConfig    `yaml:"proto,omitempty"`
+	OpenAPI3        *OpenAPI3Config `yaml:"openapi3,omitempty"`
+	GraphQL         *GraphQLConfig  `yaml:"graphql,omitempty"`
 }
 
 type SwaggerConfig struct {
@@ -116,6 +118,13 @@ func (c *Config) Ordered() []*Source {
 }
 
 func validate(s *Source) error {
+	if s.DefaultHostname != nil {
+		hostname := latheconfig.NormalizeHostname(*s.DefaultHostname)
+		if hostname == "" {
+			return fmt.Errorf("default_hostname must not be empty")
+		}
+		*s.DefaultHostname = hostname
+	}
 	if s.RepoURL == "" {
 		return fmt.Errorf("missing repo_url")
 	}

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -92,9 +92,9 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			var clientOpts ClientOptions
 			var err error
 			if s.Security != nil && s.Security.Public {
-				hostname, clientOpts, err = TryLoadHostOptions(cmd)
+				hostname, clientOpts, err = tryLoadHostOptions(cmd, s.DefaultHostname)
 			} else {
-				hostname, clientOpts, err = LoadHostOptions(cmd)
+				hostname, clientOpts, err = loadHostOptions(cmd, s.DefaultHostname)
 			}
 			if err != nil {
 				return err

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 4
+const CatalogSchemaVersion = 5
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -65,8 +65,9 @@ type CatalogCommand struct {
 }
 
 type CatalogHTTP struct {
-	Method       string `json:"method"`
-	PathTemplate string `json:"path_template"`
+	Method          string `json:"method"`
+	PathTemplate    string `json:"path_template"`
+	DefaultHostname string `json:"default_hostname,omitempty"`
 }
 
 type CatalogAuth struct {
@@ -262,7 +263,7 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 		Description: spec.Long,
 		Example:     spec.Example,
 		OperationID: spec.OperationID,
-		HTTP:        CatalogHTTP{Method: spec.Method, PathTemplate: spec.PathTpl},
+		HTTP:        CatalogHTTP{Method: spec.Method, PathTemplate: spec.PathTpl, DefaultHostname: spec.DefaultHostname},
 		Auth:        catalogAuth(spec.Security),
 		Flags:       flags,
 		Output: CatalogOutput{

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -24,6 +24,10 @@ func NewNotAuthenticatedError() error {
 }
 
 func ResolveHost(cmd *cobra.Command) (string, error) {
+	return resolveHost(cmd, "")
+}
+
+func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
 	cli := config.Active().CLI
 	h, _ := cmd.Root().PersistentFlags().GetString("hostname")
 	if h == "" {
@@ -31,6 +35,9 @@ func ResolveHost(cmd *cobra.Command) (string, error) {
 	}
 	if h != "" {
 		return config.NormalizeHostname(h), nil
+	}
+	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
+		return defaultHostname, nil
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
@@ -52,7 +59,11 @@ func ResolveHost(cmd *cobra.Command) (string, error) {
 // insecure when set; otherwise the host record's persisted Insecure value
 // applies.
 func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	hostname, err := ResolveHost(cmd)
+	return loadHostOptions(cmd, "")
+}
+
+func loadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+	hostname, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
 		return "", ClientOptions{}, err
 	}
@@ -62,8 +73,7 @@ func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
 	}
 	e, ok := hosts.Get(hostname)
 	if !ok {
-		name := config.Active().CLI.Name
-		return "", ClientOptions{}, fmt.Errorf("not authenticated to %s (run: %s auth login --hostname %s)", hostname, name, hostname)
+		return "", ClientOptions{}, notAuthenticatedToHost(hostname)
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
@@ -80,7 +90,11 @@ func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
 }
 
 func TryLoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	hostname, err := ResolveHost(cmd)
+	return tryLoadHostOptions(cmd, "")
+}
+
+func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+	hostname, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
 		return "", ClientOptions{}, err
 	}
@@ -108,4 +122,9 @@ func TryLoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
 		opts.Insecure = true
 	}
 	return hostname, opts, nil
+}
+
+func notAuthenticatedToHost(hostname string) error {
+	name := config.Active().CLI.Name
+	return fmt.Errorf("not authenticated to %s (run: %s auth login --hostname %s)", hostname, name, hostname)
 }

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -3,24 +3,25 @@ package runtime
 const SchemaVersion = 6
 
 type CommandSpec struct {
-	Group         string
-	Use           string
-	Aliases       []string
-	Short         string
-	Long          string
-	Example       string
-	OperationID   string
-	Hidden        bool
-	Deprecated    bool
-	Method        string
-	PathTpl       string
-	Params        []ParamSpec
-	RequestBody   *RequestBody
-	Output        OutputHints
-	Security      *SecurityHint
-	Notes         []string     `json:",omitempty"`
-	Prerequisites []string     `json:",omitempty"`
-	KnownErrors   []KnownError `json:",omitempty"`
+	Group           string
+	Use             string
+	Aliases         []string
+	Short           string
+	Long            string
+	Example         string
+	OperationID     string
+	Hidden          bool
+	Deprecated      bool
+	Method          string
+	PathTpl         string
+	DefaultHostname string `json:",omitempty"`
+	Params          []ParamSpec
+	RequestBody     *RequestBody
+	Output          OutputHints
+	Security        *SecurityHint
+	Notes           []string     `json:",omitempty"`
+	Prerequisites   []string     `json:",omitempty"`
+	KnownErrors     []KnownError `json:",omitempty"`
 }
 
 type ParamSpec struct {


### PR DESCRIPTION
### What's changed?

- Add optional `default_hostname` in `sources.yaml` with validation and normalization at load time
- Propagate the value through codegen into `CommandSpec` and the runtime catalog as `http.default_hostname`
- Update host resolution to prefer `--hostname` and `$HOST_ENV`, then the source default, then the single-host `hosts.yml` fallback
- Bump `CatalogSchemaVersion` to 5
- Update generated Skill guidance so agents use `http.default_hostname` when inspecting auth

### Why

- Multi-source generated CLIs need per-source host defaults without requiring `--hostname` on every command

### Verification

```sh
go test ./pkg/runtime/... ./internal/sourceconfig/... ./internal/codegen/render/...
go vet ./pkg/runtime/... ./internal/sourceconfig/... ./internal/lathecmd/...
```

## Considered and deferred

- pkg/runtime/ctx.go:39 [BOT-NIT]: No unit test for defaultHostname resolution path; existing ResolveHost tests still pass.
- internal/sourceconfig/sources.go:121 [BOT-NIT]: No dedicated test for default_hostname validation/normalization in sources config.