### PR TITLE
feat: support auth login aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Defines CLI identity and optional auth validation behavior.
 | `cli.name` | Binary and command name, for example `acmectl`. |
 | `cli.short` | Root command summary. |
 | `auth.validate` | Optional endpoint used by `auth status` to display the logged-in user. |
+| `auth.login_aliases` | Optional root shortcuts such as `login` for the built-in `auth login` command. These shortcuts are not generated API commands and are not configured through overlays. |
 
 ### `specs/sources.yaml`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -231,6 +231,7 @@ go run ./cmd/lathe codegen -skill-root ""
 | `cli.name` | 二进制和命令名称，例如 `acmectl`。 |
 | `cli.short` | 根命令摘要。 |
 | `auth.validate` | 可选端点，供 `auth status` 展示已登录用户。 |
+| `auth.login_aliases` | 可选根级快捷入口，例如用 `login` 指向内置 `auth login`。这些快捷入口不是生成的 API 命令，也不通过 overlay 配置。 |
 
 ### `specs/sources.yaml`
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -60,6 +60,7 @@ cli:
   short: "Command-line tool for Acme services"
 
 auth:
+  login_aliases: [login]
   validate:
     method: GET
     path: /api/v1/whoami
@@ -74,6 +75,15 @@ The `cli.name` value becomes the generated binary name and root command name.
 and multiple modules use `<cli> <module> <group> <operation>`. Set it to
 `namespaced` to always keep the module segment, or `flat` to require the single
 module flat path and fail codegen on root command conflicts.
+
+The optional `auth.login_aliases` list adds root-level shortcuts for the
+built-in auth login command. For example, `login_aliases: [login]` makes
+`acmectl login` execute the same code path as `acmectl auth login`, including
+hostname handling, token storage, validation, `--insecure`, and
+`--skip-validate`. These aliases are built-in auth shortcuts, not generated API
+commands: they do not appear in `search`, `commands --json`, or `commands show`.
+Use overlays only for generated API commands; overlays cannot add or modify
+built-in auth shortcuts.
 
 To customize generated Skill output, add an optional top-level `skill` block:
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -20,7 +20,7 @@ func NewCommand(m *config.Manifest) *cobra.Command {
 		Use:   "auth",
 		Short: fmt.Sprintf("Authenticate %s with a host", m.CLI.Name),
 	}
-	cmd.AddCommand(newLogin(m), newStatus(), newLogout())
+	cmd.AddCommand(LoginCommand(m, "login"), newStatus(), newLogout())
 	return cmd
 }
 
@@ -34,14 +34,19 @@ func rootBool(cmd *cobra.Command, name string) bool {
 	return v
 }
 
-func newLogin(m *config.Manifest) *cobra.Command {
+// LoginCommand builds the auth login command under either `auth login` or a
+// root-level shortcut. The execution path stays identical for both forms.
+func LoginCommand(m *config.Manifest, use string) *cobra.Command {
+	if use == "" {
+		use = "login"
+	}
 	var (
 		authType     string
 		withToken    bool
 		skipValidate bool
 	)
 	cmd := &cobra.Command{
-		Use:   "login",
+		Use:   use,
 		Short: "Authenticate with a host",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := rootString(cmd, "hostname")

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -52,7 +52,7 @@ func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides m
 	return renderModuleSpecs(name, cliName, merged)
 }
 
-func ResolveFlatCommandPath(policy string, moduleCount int, specs []runtime.CommandSpec) (bool, error) {
+func ResolveFlatCommandPath(policy string, moduleCount int, specs []runtime.CommandSpec, extraReservedRootCommands ...string) (bool, error) {
 	if policy == "" {
 		policy = config.CommandPathAuto
 	}
@@ -66,12 +66,12 @@ func ResolveFlatCommandPath(policy string, moduleCount int, specs []runtime.Comm
 	case config.CommandPathNamespaced:
 		return false, nil
 	case config.CommandPathFlat:
-		if conflict, ok := flatPathConflict(specs); ok {
+		if conflict, ok := flatPathConflict(specs, extraReservedRootCommands); ok {
 			return false, fmt.Errorf("cli.command_path=flat conflicts with command %q", conflict)
 		}
 		return true, nil
 	case config.CommandPathAuto:
-		_, conflict := flatPathConflict(specs)
+		_, conflict := flatPathConflict(specs, extraReservedRootCommands)
 		return !conflict, nil
 	default:
 		return false, fmt.Errorf("unknown cli.command_path %q", policy)
@@ -93,14 +93,24 @@ func RewriteCommandExamples(cli, module string, specs []runtime.CommandSpec, fla
 	return rewritten
 }
 
-func flatPathConflict(specs []runtime.CommandSpec) (string, bool) {
+func flatPathConflict(specs []runtime.CommandSpec, extraReservedRootCommands []string) (string, bool) {
 	seen := map[string]string{}
+	reserved := map[string]bool{}
+	for name := range reservedRootCommands {
+		reserved[name] = true
+	}
+	for _, name := range extraReservedRootCommands {
+		if name == "" {
+			continue
+		}
+		reserved[rootCommandName(name)] = true
+	}
 	for _, spec := range specs {
 		name := rootCommandName(spec.Group)
 		if name == "" {
 			continue
 		}
-		if reservedRootCommands[name] {
+		if reserved[name] {
 			return name, true
 		}
 		if group, ok := seen[name]; ok && group != spec.Group {

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -452,6 +452,14 @@ func TestResolveFlatCommandPath(t *testing.T) {
 		t.Fatal("auto should keep Cobra-normalized root command conflicts namespaced")
 	}
 
+	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{{Group: "Login", Use: "create-session"}}, "login")
+	if err != nil {
+		t.Fatalf("ResolveFlatCommandPath: %v", err)
+	}
+	if flat {
+		t.Fatal("auto should keep configured auth login alias conflicts namespaced")
+	}
+
 	flat, err = ResolveFlatCommandPath("auto", 1, []runtime.CommandSpec{
 		{Group: "Users", Use: "list-users"},
 		{Group: "Users API", Use: "get-user"},
@@ -471,6 +479,11 @@ func TestResolveFlatCommandPath(t *testing.T) {
 	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{{Group: "Search API", Use: "query"}})
 	if err == nil || !strings.Contains(err.Error(), "conflicts") {
 		t.Fatalf("expected Cobra-normalized flat conflict error, got %v", err)
+	}
+
+	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{{Group: "Login", Use: "create-session"}}, "login")
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected configured auth login alias conflict error, got %v", err)
 	}
 
 	_, err = ResolveFlatCommandPath("flat", 1, []runtime.CommandSpec{

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/lathe-cli/lathe/internal/codegen/backends/graphql"
 	"github.com/lathe-cli/lathe/internal/codegen/backends/openapi3"
@@ -192,9 +193,14 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 		if src.DisplayName != "" {
 			cliName = src.DisplayName
 		}
-		flat, err := render.ResolveFlatCommandPath(manifest.CLI.CommandPath, len(ordered), specs)
+		flat, err := render.ResolveFlatCommandPath(manifest.CLI.CommandPath, len(ordered), specs, manifest.Auth.LoginAliases...)
 		if err != nil {
 			return err
+		}
+		if !flat {
+			if alias := conflictingAuthLoginAlias(cliName, manifest.Auth.LoginAliases); alias != "" {
+				return fmt.Errorf("auth.login_aliases command %q conflicts with source module %q", alias, cliName)
+			}
 		}
 		specs = render.RewriteCommandExamples(manifest.CLI.Name, cliName, specs, flat)
 		if err := render.RenderModule(src.Name, cliName, specs, nil); err != nil {
@@ -217,6 +223,27 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 		}
 	}
 	return nil
+}
+
+func conflictingAuthLoginAlias(moduleName string, aliases []string) string {
+	moduleRoot := rootCommandName(moduleName)
+	if moduleRoot == "" {
+		return ""
+	}
+	for _, alias := range aliases {
+		if rootCommandName(alias) == moduleRoot {
+			return alias
+		}
+	}
+	return ""
+}
+
+func rootCommandName(use string) string {
+	fields := strings.Fields(strings.ToLower(use))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 func resolveSkillOutput(manifestPath string, flags skillFlagOptions) (*config.Manifest, string, string, error) {

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -408,6 +408,30 @@ paths:
 	}
 }
 
+func TestRunCodegen_RejectsAuthLoginAliasModuleConflict(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "cli.yaml", "cli:\n  name: acmectl\n  short: Acme CLI\n  command_path: namespaced\nauth:\n  login_aliases: [login]\n")
+	writeCodegenFile(t, "specs/sources.yaml", `sources:
+  acme:
+    display_name: login
+    repo_url: https://example.com/acme.git
+    pinned_tag: v1.0.0
+    backend: openapi3
+    openapi3:
+      files: [openapi.yaml]
+`)
+
+	err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), `auth.login_aliases command "login" conflicts with source module "login"`) {
+		t.Fatalf("expected auth login alias module conflict error, got %v", err)
+	}
+	if _, err := os.Stat("internal/generated/acme/acme_gen.go"); !os.IsNotExist(err) {
+		t.Fatalf("conflicting alias should fail before writing module output, stat err = %v", err)
+	}
+}
+
 func TestRunCodegen_MissingManifestFailsWhenSkillEnabled(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -23,7 +23,8 @@ type CLIInfo struct {
 }
 
 type AuthInfo struct {
-	Validate *AuthValidate `yaml:"validate,omitempty"`
+	Validate     *AuthValidate `yaml:"validate,omitempty"`
+	LoginAliases []string      `yaml:"login_aliases,omitempty"`
 }
 
 type AuthValidate struct {
@@ -59,6 +60,11 @@ func Load(bytes []byte) (*Manifest, error) {
 	if m.CLI.Name == "" {
 		return nil, fmt.Errorf("cli.name is required")
 	}
+	aliases, err := normalizeAuthLoginAliases(m.Auth.LoginAliases)
+	if err != nil {
+		return nil, err
+	}
+	m.Auth.LoginAliases = aliases
 	m.CLI.CommandPath = strings.ToLower(strings.TrimSpace(m.CLI.CommandPath))
 	if m.CLI.CommandPath == "" {
 		m.CLI.CommandPath = CommandPathAuto
@@ -79,6 +85,41 @@ func Load(bytes []byte) (*Manifest, error) {
 		m.CLI.HostEnv = upper + "_HOST"
 	}
 	return &m, nil
+}
+
+func normalizeAuthLoginAliases(aliases []string) ([]string, error) {
+	if len(aliases) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(aliases))
+	seen := map[string]bool{}
+	for _, raw := range aliases {
+		alias := strings.ToLower(strings.TrimSpace(raw))
+		if alias == "" {
+			return nil, fmt.Errorf("auth.login_aliases cannot contain empty aliases")
+		}
+		if len(strings.Fields(alias)) != 1 {
+			return nil, fmt.Errorf("auth.login_aliases entries must be single command names: %q", raw)
+		}
+		if reservedAuthLoginAlias(alias) {
+			return nil, fmt.Errorf("auth.login_aliases cannot use reserved root command %q", alias)
+		}
+		if seen[alias] {
+			return nil, fmt.Errorf("auth.login_aliases contains duplicate alias %q", alias)
+		}
+		seen[alias] = true
+		out = append(out, alias)
+	}
+	return out, nil
+}
+
+func reservedAuthLoginAlias(alias string) bool {
+	switch alias {
+	case "auth", "commands", "completion", "help", "search", "version":
+		return true
+	default:
+		return false
+	}
 }
 
 var (

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestLoad_FullSpec(t *testing.T) {
 	data := []byte(`
@@ -8,6 +11,7 @@ cli:
   name: demo
   short: "demo CLI"
 auth:
+  login_aliases: [Login]
   validate:
     method: POST
     path: /whoami
@@ -24,6 +28,9 @@ auth:
 	}
 	if m.Auth.Validate == nil {
 		t.Fatal("expected Auth.Validate non-nil")
+	}
+	if len(m.Auth.LoginAliases) != 1 || m.Auth.LoginAliases[0] != "login" {
+		t.Fatalf("unexpected Auth.LoginAliases: %#v", m.Auth.LoginAliases)
 	}
 	if m.Auth.Validate.Method != "POST" || m.Auth.Validate.Path != "/whoami" {
 		t.Errorf("unexpected AuthValidate: %+v", m.Auth.Validate)
@@ -143,6 +150,46 @@ cli:
 `))
 	if err == nil {
 		t.Fatal("expected invalid command_path error")
+	}
+}
+
+func TestLoad_RejectsInvalidAuthLoginAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "empty",
+			data: "cli:\n  name: foo\nauth:\n  login_aliases: ['']\n",
+			want: "empty aliases",
+		},
+		{
+			name: "path",
+			data: "cli:\n  name: foo\nauth:\n  login_aliases: ['auth login']\n",
+			want: "single command names",
+		},
+		{
+			name: "reserved",
+			data: "cli:\n  name: foo\nauth:\n  login_aliases: [search]\n",
+			want: "reserved root command",
+		},
+		{
+			name: "duplicate",
+			data: "cli:\n  name: foo\nauth:\n  login_aliases: [login, Login]\n",
+			want: "duplicate alias",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load([]byte(tc.data))
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -39,6 +39,12 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	authCmd := auth.NewCommand(m)
 	authCmd.GroupID = authGroupID
 	cmd.AddCommand(authCmd)
+	for _, alias := range m.Auth.LoginAliases {
+		aliasCmd := auth.LoginCommand(m, alias)
+		aliasCmd.Short = "Shortcut for auth login"
+		aliasCmd.GroupID = authGroupID
+		cmd.AddCommand(aliasCmd)
+	}
 	cmd.AddCommand(commandsCmd(m))
 	cmd.AddCommand(searchCmd(m))
 	cmd.AddCommand(versionCmd())

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -2,7 +2,9 @@ package lathe
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,6 +40,69 @@ func TestNewAppBindsManifest(t *testing.T) {
 	}
 	if got := config.Active(); got != m {
 		t.Fatalf("bound manifest = %p, want %p", got, m)
+	}
+}
+
+func TestNewAppAuthLoginAliasUsesBuiltinLoginPath(t *testing.T) {
+	m, err := config.Load([]byte(`
+cli:
+  name: myctl
+  short: test cli
+auth:
+  login_aliases: [login]
+`))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	root := NewApp(m)
+	if child := findChild(root, "login"); child == nil {
+		t.Fatal("root missing login alias")
+	} else if child.Short != "Shortcut for auth login" {
+		t.Fatalf("alias short = %q", child.Short)
+	}
+
+	restoreStdin := replaceStdin(t, "secret-token\n")
+	defer restoreStdin()
+	if _, err := execute(root, "login", "--hostname", "https://api.example.com", "--with-token", "--skip-validate"); err != nil {
+		t.Fatalf("login alias execute: %v", err)
+	}
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	entry, ok := hosts.Get("api.example.com")
+	if !ok {
+		t.Fatal("expected saved host")
+	}
+	if entry.OAuthToken != "secret-token" {
+		t.Fatalf("OAuthToken = %q, want secret-token", entry.OAuthToken)
+	}
+
+	root = NewApp(m)
+	out, err := execute(root, "commands", "--json")
+	if err != nil {
+		t.Fatalf("commands: %v", err)
+	}
+	var catalog runtime.Catalog
+	if err := json.Unmarshal([]byte(out), &catalog); err != nil {
+		t.Fatalf("unmarshal catalog: %v", err)
+	}
+	if len(catalog.Commands) != 0 {
+		t.Fatalf("alias should not appear in generated catalog: %+v", catalog.Commands)
+	}
+
+	out, err = execute(root, "search", "login", "--json")
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	var results []runtime.SearchResult
+	if err := json.Unmarshal([]byte(out), &results); err != nil {
+		t.Fatalf("unmarshal search: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("alias should not appear in generated search: %+v", results)
 	}
 }
 
@@ -139,5 +204,35 @@ func TestRunUsesRuntimeExecuteErrors(t *testing.T) {
 	}, []string{"needs-auth"}, &stdout, &stderr)
 	if code != runtime.ExitNotAuthenticated {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitNotAuthenticated)
+	}
+}
+
+func findChild(parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	return nil
+}
+
+func replaceStdin(t *testing.T, content string) func() {
+	t.Helper()
+
+	old := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	if _, err := w.WriteString(content); err != nil {
+		t.Fatalf("write stdin pipe: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin pipe writer: %v", err)
+	}
+	os.Stdin = r
+	return func() {
+		os.Stdin = old
+		_ = r.Close()
 	}
 }


### PR DESCRIPTION
## Summary
- add `auth.login_aliases` to `cli.yaml` so generated CLIs can expose root-level shortcuts like `myctl login`
- wire each shortcut to the same built-in auth login command path as `myctl auth login`, preserving hostname handling, credential storage, validation, `--insecure`, and `--skip-validate`
- keep shortcuts out of generated command catalog/search and add codegen conflict checks for flat paths and module names

## Use case
Downstream generated CLIs often want `myctl login` as a discoverable shortcut to `myctl auth login` without forking or duplicating Lathe auth behavior. This keeps the shortcut as a built-in auth command, not an overlay-generated API command.

## Verification
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgsign GIT_CONFIG_VALUE_0=false go test ./pkg/config ./pkg/lathe ./internal/codegen/render ./internal/lathecmd`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgsign GIT_CONFIG_VALUE_0=false go test ./...`
- `PATH="$PWD/.tools:$PATH" GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgsign GIT_CONFIG_VALUE_0=false make check`

Note: this machine has global `tag.gpgsign=true`, so the `GIT_CONFIG_*` override disables tag signing only for test fixture git commands. `golangci-lint` was installed temporarily under `.tools/` to satisfy the Makefile lint target and was not committed.