### PR TITLE
feat(specsync): support local source specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ life keeping those commands from drifting.
 
 Lathe makes the API spec the source of truth.
 
-You pin upstream specs, declare the CLI identity, add optional help-text
-overlays, and generate the binary. When the API changes, bump the pinned tag and
-regenerate.
+You declare pinned upstream specs or local working-tree specs, declare the CLI
+identity, add optional help-text overlays, and generate the binary. When the API
+changes, bump the pinned tag or rerun sync for the local source, then regenerate.
 
 The result is not just a wrapper. It is an agentic-friendly CLI surface with a
 runtime catalog that tells agents what commands exist, which flags are required,
@@ -74,7 +74,7 @@ built, and which output format to prefer.
 | Single runtime shape | Generated modules share one runtime for auth, request building, output formatting, pagination, streaming, and error handling. |
 | Agentic-friendly discovery | `search`, `commands --json`, `commands show`, and `commands schema` expose the CLI as structured data. |
 | Generated Skills | Codegen writes `skills/<cli-name>/` so agents can load the CLI's operating guide and module references. |
-| Reproducible inputs | Specs are pinned by tag, resolved to commit SHA, and regenerated from checked-in configuration. |
+| Reproducible inputs | Git specs are pinned by tag and resolved to commit SHA; local sources are staged from checked-in configuration. |
 | Real CLI UX | Hostname-keyed auth, --file, --set, --set-str, -o table\|json\|yaml\|raw, enum validation, pagination, streaming, and --debug. |
 | Overlay polish | Improve summaries, aliases, parameter help, grouping, and examples without editing generated code. |
 
@@ -98,7 +98,7 @@ then configure two files.
 Lathe release archives include one command-line tool, `lathe`, with generation
 subcommands:
 
-- `lathe specsync`: sync pinned upstream specs into the local cache.
+- `lathe specsync`: sync declared API specs into the local cache.
 - `lathe codegen`: generate runtime command specs and optional Skill files.
 - `lathe bootstrap`: run `specsync` and `codegen` in one pass.
 
@@ -129,7 +129,7 @@ auth:
 `<cli> <module> <group> <operation>`. Use `namespaced` to always keep the
 module segment.
 
-### 2. Pin API Sources
+### 2. Declare API Sources
 
 `specs/sources.yaml`:
 
@@ -181,6 +181,13 @@ sources:
       selection:
         max_depth: 2
         prune: ["App.secretToken"]
+
+  awire:
+    local_path: ../awire
+    backend: openapi3
+    openapi3:
+      files:
+        - openapi/awire.yaml
 ```
 
 ### 3. Generate and Build
@@ -190,7 +197,7 @@ lathe bootstrap
 go build -o bin/acmectl ./cmd/acmectl
 ```
 
-`lathe bootstrap` syncs pinned specs and runs codegen. Codegen emits generated Go
+`lathe bootstrap` syncs declared specs and runs codegen. Codegen emits generated Go
 modules and, by default, a Skill directory at `skills/acmectl/`.
 
 ### 4. Use the CLI
@@ -273,8 +280,9 @@ Declares which upstream specs become modules.
 
 | Field | Required | Notes |
 |---|---|---|
-| `repo_url` | Yes | Any URL `git clone` accepts. |
-| `pinned_tag` | Yes | Floating branches are rejected; reproducibility is mandatory. |
+| `repo_url` | Git sources | Any URL `git clone` accepts. |
+| `pinned_tag` | Git sources | Floating branches are rejected; reproducibility is mandatory. |
+| `local_path` | Local sources | Local filesystem path or `file://` URL, relative paths resolve from `specs/sources.yaml`. Mutually exclusive with `repo_url` and `pinned_tag`. |
 | `backend` | Yes | One of `swagger`, `openapi3`, `proto`, or `graphql`. |
 | `swagger.files` | Swagger only | One or more Swagger 2.0 JSON specs. |
 | `openapi3.files` | OpenAPI 3 only | JSON or YAML OpenAPI specs. |
@@ -384,8 +392,8 @@ body:
 
 Lathe has two phases:
 
-1. `lathe specsync` clones pinned upstream specs, verifies the resolved commit
-   SHA, and writes local spec state.
+1. `lathe specsync` checks out pinned Git sources or stages `local_path`
+   sources, then writes local spec state.
 2. `lathe codegen` normalizes specs into one intermediate representation, applies
    overlays, renders Go command modules, and renders the Skill directory.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,12 +153,12 @@ graph TD
 |---|---|---|
 | `cmd/lathe` | codegen | Single binary entrypoint for `specsync`, `codegen`, and `bootstrap`. |
 | `internal/lathecmd` | codegen | Resolves CLI flags and orchestrates: sync specs, load sources, verify sync state, parse, normalize, render. |
-| `internal/sourceconfig` | codegen | Parse `specs/sources.yaml`. Requires `pinned_tag`; treats the value as an immutable ref. |
-| `internal/specsync` | codegen | `git clone --filter=blob:none`, checkout pinned ref, stage relevant files into `.cache/specs-sync/<module>/`. Writes `sync-state.yaml` (including `resolved_sha`). |
+| `internal/sourceconfig` | codegen | Parse `specs/sources.yaml`. Supports immutable Git sources (`repo_url` + `pinned_tag`) and local working-tree sources (`local_path`). |
+| `internal/specsync` | codegen | For Git sources, `git clone --filter=blob:none` and checkout the pinned ref. For local sources, stage files directly from `local_path`. Writes `sync-state.yaml`. |
 | `internal/codegen/backends/swagger` | codegen | Parse `*.swagger.json` → `RawModule`. Merges multiple files; first-seen wins on duplicates. |
 | `internal/codegen/backends/openapi3` | codegen | Parse OpenAPI 3.x YAML/JSON → `RawModule`. Rewrites `$ref`; inherits path-level parameters. |
 | `internal/codegen/backends/proto` | codegen | Parse staged `.proto` tree → `RawModule`. Only RPCs with `google.api.http` become operations. |
-| `internal/codegen/backends/graphql` | codegen | Parse pinned SDL plus `graphql:` policy → `RawModule`. Emits `POST /graphql` operations with baked query templates and variable params. |
+| `internal/codegen/backends/graphql` | codegen | Parse staged SDL plus `graphql:` policy → `RawModule`. Emits `POST /graphql` operations with baked query templates and variable params. |
 | `internal/codegen/rawir` | codegen | Backend-agnostic raw types (`RawModule`, `RawOperation`, `RawSchema`). Includes `$ref` resolution. |
 | `internal/codegen/normalize` | codegen | Semantic projection: groups, `Short`, list path, default columns, method-ordering for determinism. |
 | `internal/codegen/render` | codegen | `text/template` → gofmt'd Go. Emits per-module `_gen.go` and top-level `modules_gen.go`. |
@@ -173,8 +173,8 @@ graph TD
 ```mermaid
 stateDiagram-v2
     [*] --> Declared: edit specs/sources.yaml
-    Declared --> Cloned: lathe specsync\n(git clone + checkout pinned_tag)
-    Cloned --> Staged: backend-specific staging\n(.cache/specs-sync/&lt;mod&gt;/)
+    Declared --> SourceReady: lathe specsync\n(git checkout or local_path)
+    SourceReady --> Staged: backend-specific staging\n(.cache/specs-sync/&lt;mod&gt;/)
     Staged --> Parsed: backend.Parse\n→ RawModule
     Parsed --> Normalized: normalize.Normalize\n→ []CommandSpec
     Normalized --> Polished: overlay merge\n(optional)
@@ -183,10 +183,10 @@ stateDiagram-v2
     Compiled --> Runnable: ./bin/&lt;name&gt; &lt;mod&gt; &lt;cmd&gt;
     Runnable --> [*]
 
-    Declared --> Declared: bump pinned_tag\n→ restart cycle
+    Declared --> Declared: bump pinned_tag/local_path\n→ restart cycle
 ```
 
-Each transition is idempotent and cache-checked. `specsync.VerifyState` rejects a stale cache where `sync-state.yaml` does not match `pinned_tag`.
+Each transition is idempotent and cache-checked. `specsync.VerifyState` rejects a stale cache where `sync-state.yaml` does not match the source mode, `pinned_tag`, or resolved `local_path`.
 
 ## Overlay merge matrix
 
@@ -293,11 +293,11 @@ Each extension is an injection point. The core works with a zero-config `Command
 These are structural, not stylistic. Violating any means the architecture breaks.
 
 1. **`pkg/runtime` does not import `internal/codegen/**`.** The runtime cannot know how a `CommandSpec` was produced. This is what makes "three backends, one IR" real rather than aspirational.
-2. **`pinned_tag` is required and validated.** `sourceconfig.Load` rejects empty values and floating refs (`HEAD`, `main`, `refs/heads/*`). Only immutable tags and 40-char SHAs are accepted. `specsync` records the resolved SHA and codegen verifies it.
+2. **Git sources require `pinned_tag`; local sources require `local_path`.** `sourceconfig.Load` rejects floating refs (`HEAD`, `main`, `refs/heads/*`) for Git sources and rejects configs that mix `local_path` with `repo_url` or `pinned_tag`. Relative `local_path` values resolve from `specs/sources.yaml`.
 3. **Codegen is never invoked at `go build` time.** Downstream consumers need no Go toolchain tags, build flags, or network access to install.
 4. **Overlays bake at codegen-time.** The runtime has no overlay concept. This keeps `pkg/runtime` small and overlay bugs from being runtime bugs.
 5. **No ambient "current host".** The host is a per-invocation input. This mirrors `gh` and avoids the "oops, wrong cluster" class of bug.
-6. **`sync-state.yaml` guards the cache.** `lathe codegen` refuses a cache that doesn't match `pinned_tag`. Stale generation fails loud, not silent.
+6. **`sync-state.yaml` guards the cache.** `lathe codegen` refuses a cache that doesn't match the source mode, pinned tag, or resolved local path. Stale generation fails loud, not silent.
 7. **Static codegen.** Downstream binaries carry no spec parser. The generated file is a pure data literal.
 8. **Single Go binary.** No `protoc`, `buf`, or other toolchain at install time. `go install` is the install path.
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -6,7 +6,7 @@ Use it in a target CLI repository that owns:
 
 - `go.mod`: the downstream module path for generated internal package imports.
 - `cli.yaml`: the generated CLI identity and optional auth validation config.
-- `specs/sources.yaml`: pinned upstream API specs.
+- `specs/sources.yaml`: declared upstream or local API specs.
 - `cmd/<cli-name>/main.go`: the thin runtime entrypoint for the generated CLI.
 
 The normal path is:
@@ -88,7 +88,7 @@ set it to `""` to disable Skill generation. The optional `skill.include` value
 points at repo-local Skill resources merged into generated Skill files. Keep the
 include directory outside `skill.root`.
 
-## Pin API Specs
+## Declare API Specs
 
 Create `specs/sources.yaml`:
 
@@ -140,10 +140,21 @@ sources:
       selection:
         max_depth: 2
         prune: ["App.secretToken"]
+
+  awire:
+    local_path: ../awire
+    backend: openapi3
+    openapi3:
+      files:
+        - openapi/awire.yaml
 ```
 
 Use immutable tags for reproducibility. `lathe specsync` resolves each tag to a
 commit SHA and writes sync state under `.cache/specs-sync/`.
+
+Use `local_path` instead of `repo_url`/`pinned_tag` for a working-tree source.
+Relative paths resolve from `specs/sources.yaml`; sync state records the
+resolved local path for cache checks.
 
 For `backend: graphql`, the pinned `graphql.schema` SDL file supplies API facts:
 root operations, arguments, return types, and selectable fields. The required
@@ -216,7 +227,7 @@ internal/generated/
 `internal/generated/` contains generated Go command specs. `<skill.root>/<cli-name>/`
 contains the generated agent Skill guide and module references when Skill
 generation is enabled. These outputs are reproducible from `cli.yaml`,
-`specs/sources.yaml`, pinned specs, and overlays. Skill output also includes any
+`specs/sources.yaml`, synced specs, and overlays. Skill output also includes any
 resources declared by `skill.include`.
 
 ## Wire the Generated CLI
@@ -320,7 +331,7 @@ bin/richapi commands show users list --json
 
 ### GraphQL
 
-`examples/graphql` is the minimal GraphQL path for a pinned SDL file plus
+`examples/graphql` is the minimal GraphQL path for a staged SDL file plus
 explicit `graphql:` policy:
 
 ```text

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -168,7 +168,7 @@ func runCodegen(sourcesPath string, manifestPath string, cacheRoot string, overl
 	var skillModules []render.SkillModule
 	for _, src := range ordered {
 		syncDir := filepath.Join(syncRoot, src.Name)
-		if err := specsync.VerifyState(syncDir, src.Name, src.Backend, src.PinnedTag); err != nil {
+		if err := specsync.VerifyState(syncDir, src); err != nil {
 			return err
 		}
 		state, err := specsync.LoadState(syncDir)

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -324,6 +324,77 @@ paths:
 	}
 }
 
+func TestRunBootstrapLocalPathSyncsAndGenerates(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeCodegenFile(t, "go.mod", "module example.com/fake\n\ngo 1.25\n")
+	writeCodegenFile(t, "cli.yaml", "cli:\n  name: acmectl\n  short: Acme CLI\n")
+	writeCodegenFile(t, "api/openapi.yaml", `openapi: "3.0.3"
+paths:
+  /users:
+    get:
+      operationId: Users_List
+      tags: [Users]
+      summary: List users
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+`)
+	writeCodegenFile(t, "specs/sources.yaml", `sources:
+  acme:
+    local_path: ../api
+    backend: openapi3
+    openapi3:
+      files: [openapi.yaml]
+`)
+
+	if err := RunBootstrap([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+
+	localPath, err := filepath.Abs("api")
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := os.ReadFile(".cache/specs-sync/acme/sync-state.yaml")
+	if err != nil {
+		t.Fatalf("read sync state: %v", err)
+	}
+	if !strings.Contains(string(state), "source_kind: local") || !strings.Contains(string(state), "synced_from: "+localPath) {
+		t.Fatalf("sync state = %s, want local source path %q", state, localPath)
+	}
+	for _, path := range []string{"internal/generated/acme/acme_gen.go", "skills/acmectl/SKILL.md"} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if strings.Contains(string(data), localPath) {
+			t.Fatalf("%s encoded local path %q", path, localPath)
+		}
+	}
+
+	writeCodegenFile(t, "other/openapi.yaml", `openapi: "3.0.3"
+paths: {}
+`)
+	writeCodegenFile(t, "specs/sources.yaml", `sources:
+  acme:
+    local_path: ../other
+    backend: openapi3
+    openapi3:
+      files: [openapi.yaml]
+`)
+	err = RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache"}, &bytes.Buffer{})
+	if err == nil {
+		t.Fatalf("codegen accepted stale local_path cache")
+	}
+	if !strings.Contains(err.Error(), "local_path") {
+		t.Fatalf("error = %v, want local_path mismatch", err)
+	}
+}
+
 func TestRunCodegen_SkillRootEmptyDisablesSkillGeneration(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -2,8 +2,10 @@ package sourceconfig
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -28,6 +30,7 @@ type Source struct {
 	DefaultHostname *string         `yaml:"default_hostname,omitempty"`
 	RepoURL         string          `yaml:"repo_url"`
 	PinnedTag       string          `yaml:"pinned_tag"`
+	LocalPath       string          `yaml:"local_path"`
 	Backend         string          `yaml:"backend"`
 	Swagger         *SwaggerConfig  `yaml:"swagger,omitempty"`
 	Proto           *ProtoConfig    `yaml:"proto,omitempty"`
@@ -95,9 +98,10 @@ func Load(path string) (*Config, error) {
 	if len(cfg.Sources) == 0 {
 		return nil, fmt.Errorf("%s declares no sources", path)
 	}
+	baseDir := filepath.Dir(path)
 	for name, src := range cfg.Sources {
 		src.Name = name
-		if err := validate(src); err != nil {
+		if err := validate(src, baseDir); err != nil {
 			return nil, fmt.Errorf("source %q: %w", name, err)
 		}
 	}
@@ -117,7 +121,7 @@ func (c *Config) Ordered() []*Source {
 	return out
 }
 
-func validate(s *Source) error {
+func validate(s *Source, baseDir string) error {
 	if s.DefaultHostname != nil {
 		hostname := latheconfig.NormalizeHostname(*s.DefaultHostname)
 		if hostname == "" {
@@ -125,14 +129,28 @@ func validate(s *Source) error {
 		}
 		*s.DefaultHostname = hostname
 	}
-	if s.RepoURL == "" {
-		return fmt.Errorf("missing repo_url")
-	}
-	if s.PinnedTag == "" {
-		return fmt.Errorf("missing pinned_tag")
-	}
-	if err := validateRef(s.PinnedTag); err != nil {
-		return err
+	if s.LocalPath != "" {
+		if s.RepoURL != "" {
+			return fmt.Errorf("local_path cannot be used with repo_url")
+		}
+		if s.PinnedTag != "" {
+			return fmt.Errorf("local_path cannot be used with pinned_tag")
+		}
+		localPath, err := resolveLocalPath(baseDir, s.LocalPath)
+		if err != nil {
+			return err
+		}
+		s.LocalPath = localPath
+	} else {
+		if s.RepoURL == "" {
+			return fmt.Errorf("missing repo_url")
+		}
+		if s.PinnedTag == "" {
+			return fmt.Errorf("missing pinned_tag")
+		}
+		if err := validateRef(s.PinnedTag); err != nil {
+			return err
+		}
 	}
 	switch s.Backend {
 	case BackendSwagger:
@@ -166,6 +184,37 @@ func validate(s *Source) error {
 		return fmt.Errorf("unknown backend %q", s.Backend)
 	}
 	return rejectForeignBlocks(s)
+}
+
+func resolveLocalPath(baseDir, raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("local_path must not be empty")
+	}
+	if u, err := url.Parse(raw); err == nil && u.Scheme != "" {
+		if u.Scheme != "file" {
+			return "", fmt.Errorf("local_path must be a filesystem path or file:// URL")
+		}
+		if u.Host != "" && u.Host != "localhost" {
+			return "", fmt.Errorf("local_path file:// URL must not include a remote host")
+		}
+		raw = filepath.FromSlash(u.Path)
+		if raw == "" {
+			return "", fmt.Errorf("local_path file:// URL must include a path")
+		}
+	} else if strings.Contains(raw, "://") {
+		return "", fmt.Errorf("local_path must be a filesystem path or file:// URL")
+	}
+	if colon := strings.IndexByte(raw, ':'); colon > 0 && strings.Contains(raw[:colon], "@") && !strings.ContainsAny(raw[:colon], `/\`) {
+		return "", fmt.Errorf("local_path must be a filesystem path or file:// URL")
+	}
+	if !filepath.IsAbs(raw) {
+		raw = filepath.Join(baseDir, raw)
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return "", fmt.Errorf("resolve local_path: %w", err)
+	}
+	return abs, nil
 }
 
 func rejectForeignBlocks(s *Source) error {

--- a/internal/sourceconfig/sources_test.go
+++ b/internal/sourceconfig/sources_test.go
@@ -103,6 +103,98 @@ func TestLoad_AcceptsImmutableTag(t *testing.T) {
 	}
 }
 
+func TestLoad_AcceptsLocalPathWithoutPinnedTag(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "specs", "sources.yaml")
+	body := `sources:
+  demo:
+    local_path: ..
+    backend: openapi3
+    openapi3:
+      files: [api.yaml]
+`
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed yaml: %v", err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sources["demo"].LocalPath != want {
+		t.Errorf("local_path = %q, want %q", cfg.Sources["demo"].LocalPath, want)
+	}
+}
+
+func TestLoad_RejectsLocalPathWithGitSourceFields(t *testing.T) {
+	cases := map[string]string{
+		"repo_url": `sources:
+  demo:
+    local_path: ..
+    repo_url: https://example.com/repo.git
+    backend: openapi3
+    openapi3:
+      files: [api.yaml]
+`,
+		"pinned_tag": `sources:
+  demo:
+    local_path: ..
+    pinned_tag: v1.0.0
+    backend: openapi3
+    openapi3:
+      files: [api.yaml]
+`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sources.yaml")
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatalf("seed yaml: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load accepted local_path with %s", name)
+			}
+			if !strings.Contains(err.Error(), "local_path") {
+				t.Errorf("error should mention local_path: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_RejectsRemoteLookingLocalPath(t *testing.T) {
+	for _, localPath := range []string{"https://example.com/repo.git", "git@example.com:repo.git"} {
+		t.Run(localPath, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sources.yaml")
+			body := `sources:
+  demo:
+    local_path: ` + localPath + `
+    backend: openapi3
+    openapi3:
+      files: [api.yaml]
+`
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatalf("seed yaml: %v", err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatalf("Load accepted remote local_path")
+			}
+			if !strings.Contains(err.Error(), "local_path") {
+				t.Errorf("error should mention local_path: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoad_AcceptsOpenAPI3(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sources.yaml")

--- a/internal/specsync/graphql_test.go
+++ b/internal/specsync/graphql_test.go
@@ -57,3 +57,44 @@ func TestSyncGraphQL_MissingSchema(t *testing.T) {
 		t.Errorf("error = %v, want to name the missing schema", err)
 	}
 }
+
+func TestSync_LocalOpenAPI3StagesWorkingTree(t *testing.T) {
+	root := t.TempDir()
+	local := filepath.Join(root, "api")
+	cache := filepath.Join(root, "cache")
+	rel := filepath.Join("openapi", "awire.yaml")
+	if err := os.MkdirAll(filepath.Join(local, "openapi"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(local, rel), []byte("openapi: \"3.0.3\"\ninfo:\n  title: Working Tree\n  version: v0\npaths: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &sourceconfig.Config{Sources: map[string]*sourceconfig.Source{
+		"awire": {
+			Name:      "awire",
+			LocalPath: local,
+			Backend:   sourceconfig.BackendOpenAPI3,
+			OpenAPI3:  &sourceconfig.OpenAPI3Config{Files: []string{rel}},
+		},
+	}}
+	if err := Sync(cfg, Options{CacheRoot: cache}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	syncDir := filepath.Join(cache, SyncSubdir, "awire")
+	got, err := os.ReadFile(filepath.Join(syncDir, rel))
+	if err != nil {
+		t.Fatalf("local spec not staged: %v", err)
+	}
+	if !strings.Contains(string(got), "Working Tree") {
+		t.Errorf("staged spec content = %q", got)
+	}
+	state, err := LoadState(syncDir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.SourceKind != SourceKindLocal || state.SyncedFrom != local || state.ResolvedSHA != "" {
+		t.Errorf("state = %+v, want local source from %q without sha", state, local)
+	}
+}

--- a/internal/specsync/state.go
+++ b/internal/specsync/state.go
@@ -5,12 +5,19 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/lathe-cli/lathe/internal/sourceconfig"
 	"gopkg.in/yaml.v3"
 )
 
 const StateFile = "sync-state.yaml"
 
+const (
+	SourceKindGit   = "git"
+	SourceKindLocal = "local"
+)
+
 type State struct {
+	SourceKind  string `yaml:"source_kind,omitempty"`
 	Source      string `yaml:"source"`
 	Backend     string `yaml:"backend"`
 	SyncedFrom  string `yaml:"synced_from"`
@@ -40,22 +47,38 @@ func SaveState(syncDir string, s *State) error {
 	return os.WriteFile(filepath.Join(syncDir, StateFile), data, 0o644)
 }
 
-func VerifyState(syncDir, source, backend, wantTag string) error {
+func VerifyState(syncDir string, src *sourceconfig.Source) error {
 	s, err := LoadState(syncDir)
 	if err != nil {
-		return fmt.Errorf("source %q: sync-state missing or unreadable (run `lathe specsync`): %w", source, err)
+		return fmt.Errorf("source %q: sync-state missing or unreadable (run `lathe specsync`): %w", src.Name, err)
 	}
-	if s.Source != source {
-		return fmt.Errorf("source %q: sync-state mismatch (got %q)", source, s.Source)
+	if s.Source != src.Name {
+		return fmt.Errorf("source %q: sync-state mismatch (got %q)", src.Name, s.Source)
 	}
-	if s.Backend != backend {
-		return fmt.Errorf("source %q: sync-state backend %q != config %q (re-run `lathe specsync`)", source, s.Backend, backend)
+	if s.Backend != src.Backend {
+		return fmt.Errorf("source %q: sync-state backend %q != config %q (re-run `lathe specsync`)", src.Name, s.Backend, src.Backend)
 	}
-	if s.SyncedFrom != wantTag {
-		return fmt.Errorf("source %q: synced_from=%q but pinned_tag=%q (re-run `lathe specsync`)", source, s.SyncedFrom, wantTag)
+	wantKind := SourceKindGit
+	wantFrom := src.PinnedTag
+	if src.LocalPath != "" {
+		wantKind = SourceKindLocal
+		wantFrom = src.LocalPath
 	}
-	if s.ResolvedSHA == "" {
-		return fmt.Errorf("source %q: sync-state missing resolved_sha (re-run `lathe specsync`)", source)
+	gotKind := s.SourceKind
+	if gotKind == "" {
+		gotKind = SourceKindGit
+	}
+	if gotKind != wantKind {
+		return fmt.Errorf("source %q: sync-state source_kind %q != config %q (re-run `lathe specsync`)", src.Name, gotKind, wantKind)
+	}
+	if s.SyncedFrom != wantFrom {
+		if wantKind == SourceKindLocal {
+			return fmt.Errorf("source %q: synced_from=%q but local_path=%q (re-run `lathe specsync`)", src.Name, s.SyncedFrom, wantFrom)
+		}
+		return fmt.Errorf("source %q: synced_from=%q but pinned_tag=%q (re-run `lathe specsync`)", src.Name, s.SyncedFrom, wantFrom)
+	}
+	if wantKind == SourceKindGit && s.ResolvedSHA == "" {
+		return fmt.Errorf("source %q: sync-state missing resolved_sha (re-run `lathe specsync`)", src.Name)
 	}
 	return nil
 }

--- a/internal/specsync/state_test.go
+++ b/internal/specsync/state_test.go
@@ -5,9 +5,19 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/lathe-cli/lathe/internal/sourceconfig"
 )
 
 const fakeSHA = "1234567890abcdef1234567890abcdef12345678"
+
+func gitSource() *sourceconfig.Source {
+	return &sourceconfig.Source{
+		Name:      "demo",
+		Backend:   sourceconfig.BackendSwagger,
+		PinnedTag: "v1.2.3",
+	}
+}
 
 func TestSaveLoadState_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
@@ -39,7 +49,28 @@ func TestVerifyState_AcceptsFullState(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveState: %v", err)
 	}
-	if err := VerifyState(dir, "demo", "swagger", "v1.2.3"); err != nil {
+	if err := VerifyState(dir, gitSource()); err != nil {
+		t.Errorf("VerifyState: %v", err)
+	}
+}
+
+func TestVerifyState_AcceptsLocalState(t *testing.T) {
+	dir := t.TempDir()
+	localPath := filepath.Join(t.TempDir(), "api")
+	if err := SaveState(dir, &State{
+		SourceKind: SourceKindLocal,
+		Source:     "demo",
+		Backend:    "openapi3",
+		SyncedFrom: localPath,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	src := &sourceconfig.Source{
+		Name:      "demo",
+		Backend:   sourceconfig.BackendOpenAPI3,
+		LocalPath: localPath,
+	}
+	if err := VerifyState(dir, src); err != nil {
 		t.Errorf("VerifyState: %v", err)
 	}
 }
@@ -52,7 +83,7 @@ func TestVerifyState_RejectsMissingResolvedSHA(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, StateFile), []byte(legacy), 0o644); err != nil {
 		t.Fatalf("seed legacy state: %v", err)
 	}
-	err := VerifyState(dir, "demo", "swagger", "v1.2.3")
+	err := VerifyState(dir, gitSource())
 	if err == nil {
 		t.Fatalf("VerifyState accepted state missing resolved_sha")
 	}
@@ -71,7 +102,7 @@ func TestVerifyState_RejectsStaleTag(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveState: %v", err)
 	}
-	err := VerifyState(dir, "demo", "swagger", "v1.2.3")
+	err := VerifyState(dir, gitSource())
 	if err == nil {
 		t.Fatalf("VerifyState accepted stale tag")
 	}
@@ -82,7 +113,7 @@ func TestVerifyState_RejectsStaleTag(t *testing.T) {
 
 func TestVerifyState_RejectsMissingFile(t *testing.T) {
 	dir := t.TempDir() // empty
-	err := VerifyState(dir, "demo", "swagger", "v1.2.3")
+	err := VerifyState(dir, gitSource())
 	if err == nil {
 		t.Fatalf("VerifyState accepted missing sync-state")
 	}

--- a/internal/specsync/sync.go
+++ b/internal/specsync/sync.go
@@ -36,36 +36,48 @@ func Sync(cfg *sourceconfig.Config, opts Options) error {
 		if err := os.RemoveAll(syncDir); err != nil {
 			return err
 		}
-		sha, err := ensureRepo(workDir, src.RepoURL, src.PinnedTag)
-		if err != nil {
-			return fmt.Errorf("source %q: %w", src.Name, err)
+		sourceDir := workDir
+		sha := ""
+		if src.LocalPath != "" {
+			sourceDir = src.LocalPath
+		} else {
+			var err error
+			sha, err = ensureRepo(workDir, src.RepoURL, src.PinnedTag)
+			if err != nil {
+				return fmt.Errorf("source %q: %w", src.Name, err)
+			}
 		}
 		switch src.Backend {
 		case sourceconfig.BackendSwagger:
-			if err := syncSwagger(src, workDir, syncDir); err != nil {
+			if err := syncSwagger(src, sourceDir, syncDir); err != nil {
 				return fmt.Errorf("source %q: %w", src.Name, err)
 			}
 		case sourceconfig.BackendProto:
-			if err := syncProto(src, workDir, syncDir); err != nil {
+			if err := syncProto(src, sourceDir, syncDir); err != nil {
 				return fmt.Errorf("source %q: %w", src.Name, err)
 			}
 		case sourceconfig.BackendOpenAPI3:
-			if err := syncOpenAPI3(src, workDir, syncDir); err != nil {
+			if err := syncOpenAPI3(src, sourceDir, syncDir); err != nil {
 				return fmt.Errorf("source %q: %w", src.Name, err)
 			}
 		case sourceconfig.BackendGraphQL:
-			if err := syncGraphQL(src, workDir, syncDir); err != nil {
+			if err := syncGraphQL(src, sourceDir, syncDir); err != nil {
 				return fmt.Errorf("source %q: %w", src.Name, err)
 			}
 		default:
 			return fmt.Errorf("source %q: unsupported backend %q", src.Name, src.Backend)
 		}
-		if err := SaveState(syncDir, &State{
+		state := &State{
 			Source:      src.Name,
 			Backend:     src.Backend,
 			SyncedFrom:  src.PinnedTag,
 			ResolvedSHA: sha,
-		}); err != nil {
+		}
+		if src.LocalPath != "" {
+			state.SourceKind = SourceKindLocal
+			state.SyncedFrom = src.LocalPath
+		}
+		if err := SaveState(syncDir, state); err != nil {
 			return fmt.Errorf("source %q: write sync-state: %w", src.Name, err)
 		}
 	}


### PR DESCRIPTION
## Summary

- Add `local_path` sources so specsync can stage working-tree API specs without cloning a Git repo.
- Record local source state and reject stale codegen caches when the source mode or resolved path changes.
- Document local source configuration and cover sourceconfig, specsync, and bootstrap behavior with focused tests.

## Verification

- `git diff --cached --check`
- `make check`
- `pre-ship --committed` (no MUST-FIX findings; sentinel written)

## Compatibility

Adds `local_path` as a mutually exclusive source mode alongside `repo_url` plus `pinned_tag`. Git source behavior remains unchanged. Local source sync state records `source_kind: local` and the resolved `synced_from` path. No catalog schema, auth, body, output, or generated command shape changes.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
