### PR TITLE
fix(runtime): improve catalog search recall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GO          ?= go
 OUT_DIR     := ./bin
+BINDIR      ?= $(if $(GOBIN),$(GOBIN),$(or $(GOPATH),$(HOME)/go)/bin)
 
 BOLD  := \033[1m
 CYAN  := \033[36m
@@ -10,12 +11,17 @@ RESET := \033[0m
 
 # ── Build ────────────────────────────────────────────────────────────────────
 
-.PHONY: build
+.PHONY: build install
 
 build: ## Build local lathe binary into ./bin/lathe
 	@mkdir -p $(OUT_DIR)
 	$(GO) build -trimpath -o $(OUT_DIR)/lathe ./cmd/lathe
 	@printf '\n$(GREEN)  ✓ built $(CYAN)$(OUT_DIR)/lathe$(RESET)\n\n'
+
+install: build ## Install local lathe binary into BINDIR
+	@mkdir -p $(BINDIR)
+	@cp $(OUT_DIR)/lathe $(BINDIR)/lathe
+	@printf '\n$(GREEN)  ✓ installed $(CYAN)$(BINDIR)/lathe$(RESET)\n\n'
 
 # ── Quality ──────────────────────────────────────────────────────────────────
 

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 )
@@ -172,14 +173,16 @@ func SearchCatalog(root *cobra.Command, query string, opts SearchOptions) []Sear
 	if limit <= 0 {
 		limit = DefaultSearchLimit
 	}
-	tokens := strings.Fields(strings.ToLower(query))
+	tokens := searchTokens(query)
 	if len(tokens) == 0 {
 		return []SearchResult{}
 	}
+	fullQuery := strings.ToLower(query)
+	normalizedQuery := normalizeSearchText(query)
 	results := make([]SearchResult, 0)
 	for _, cmd := range BuildCatalog(root, opts.CatalogOptions).Commands {
 		view := newSearchView(cmd)
-		score, ok := scoreCatalogCommand(view, tokens, strings.ToLower(query))
+		score, ok := scoreCatalogCommand(view, tokens, fullQuery, normalizedQuery)
 		if !ok {
 			continue
 		}
@@ -371,16 +374,28 @@ func newSearchView(cmd CatalogCommand) searchView {
 	}
 }
 
-func scoreCatalogCommand(cmd searchView, tokens []string, fullQuery string) (int, bool) {
+func scoreCatalogCommand(cmd searchView, tokens []string, fullQuery string, normalizedQuery string) (int, bool) {
 	score := 0
+	matches := 0
+	strong := false
 	for _, token := range tokens {
 		tokenScore := scoreToken(cmd, token)
 		if tokenScore == 0 {
-			return 0, false
+			continue
+		}
+		matches++
+		if tokenScore >= 45 {
+			strong = true
 		}
 		score += tokenScore
 	}
-	if fullQuery == cmd.fullPath || fullQuery == cmd.operationID || fullQuery == cmd.use {
+	if matches == 0 || (!strong && matches < 2) {
+		return 0, false
+	}
+	if fullQuery == cmd.fullPath || fullQuery == cmd.operationID || fullQuery == cmd.use ||
+		normalizedQuery == normalizeSearchText(cmd.fullPath) ||
+		normalizedQuery == normalizeSearchText(cmd.operationID) ||
+		normalizedQuery == normalizeSearchText(cmd.use) {
 		score += 100
 	}
 	return score, true
@@ -413,8 +428,33 @@ func scoreToken(cmd searchView, token string) int {
 }
 
 func scoreField(field string, token string, value int) int {
-	if strings.Contains(field, token) {
+	if strings.Contains(field, token) || strings.Contains(normalizeSearchText(field), token) {
 		return value
 	}
 	return 0
+}
+
+func searchTokens(query string) []string {
+	return strings.Fields(normalizeSearchText(query))
+}
+
+func normalizeSearchText(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	var prev rune
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if b.Len() > 0 && unicode.IsUpper(r) && (unicode.IsLower(prev) || unicode.IsDigit(prev)) {
+				b.WriteByte(' ')
+			}
+			b.WriteRune(unicode.ToLower(r))
+			prev = r
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		prev = 0
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
 }

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -218,6 +218,44 @@ func TestFindAndSearchCatalog(t *testing.T) {
 	}
 }
 
+func TestSearchCatalog_SoftMatchesNoisyIntent(t *testing.T) {
+	root := newRootWithModuleGroup()
+	Build(root, "demo", []CommandSpec{
+		{
+			Group:       "Users",
+			Use:         "get-user",
+			Aliases:     []string{"show-user"},
+			Short:       "Get a user",
+			OperationID: "getUser",
+			Method:      "GET",
+			PathTpl:     "/users/{id}",
+		},
+		{
+			Group:       "Users",
+			Use:         "list-users",
+			Short:       "List users",
+			OperationID: "listUsers",
+			Method:      "GET",
+			PathTpl:     "/users",
+		},
+	})
+
+	results := SearchCatalog(root, "get user stray", SearchOptions{Limit: 10})
+	if len(results) == 0 || results[0].Command.Use != "get-user" {
+		t.Fatalf("noisy get user results = %+v", results)
+	}
+
+	results = SearchCatalog(root, "show_user stray", SearchOptions{Limit: 10})
+	if len(results) == 0 || results[0].Command.Use != "get-user" {
+		t.Fatalf("normalized alias results = %+v", results)
+	}
+
+	results = SearchCatalog(root, "doesnotexist", SearchOptions{Limit: 10})
+	if len(results) != 0 {
+		t.Fatalf("unknown query results = %+v", results)
+	}
+}
+
 func TestBuildCatalog_DefaultAuthRequired(t *testing.T) {
 	root := newRootWithModuleGroup()
 	Build(root, "demo", []CommandSpec{{


### PR DESCRIPTION
## Summary

- Makes catalog search tolerate noisy multi-token agent queries by scoring matching tokens instead of requiring every token to match.
- Normalizes search text across separators and camel case so intents like `get user` can match `get-user` / `getUser`.
- Adds regression coverage for noisy intents, normalized aliases, and unknown queries.

## Verification

- `git diff --check HEAD~1..HEAD`
- `go test ./pkg/runtime ./pkg/lathe -count=1`
- `go test ./... -count=1`
- `make check`

## Compatibility

Search ranking/recall changes only. No catalog schema, generated command shape, auth, body, output, or generated artifact changes.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] Documentation not updated because the documented search workflow and output shape are unchanged.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.

## Considered and deferred

- pkg/runtime/catalog.go:430 [BOT-NIT]: normalizeSearchText runs during scoring; catalog search is small enough to keep the search view simple.