### PR TITLE
feat(lathe): move runtime controls under meta command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ built, and which output format to prefer.
 | Agentic-friendly discovery | `search`, `commands --json`, `commands show`, and `commands schema` expose the CLI as structured data. |
 | Generated Skills | Codegen writes `skills/<cli-name>/` so agents can load the CLI's operating guide and module references. |
 | Reproducible inputs | Git specs are pinned by tag and resolved to commit SHA; local sources are staged from checked-in configuration. |
-| Real CLI UX | Hostname-keyed auth, --file, --set, --set-str, -o table\|json\|yaml\|raw, enum validation, pagination, streaming, and --debug. |
+| Real CLI UX | Hostname-keyed auth, --file, --set, --set-str, -o table\|json\|yaml\|raw, enum validation, pagination, and streaming. |
 | Overlay polish | Improve summaries, aliases, parameter help, grouping, and examples without editing generated code. |
 
 ## Project Resources
@@ -364,8 +364,15 @@ go run ./cmd/lathe codegen -overlay internal/overlay
 |---|---|
 | `--hostname` | Select host for this invocation. |
 | `-o, --output` | Output format: `table`, `json`, `yaml`, or `raw`. |
-| `--insecure` | Skip TLS certificate verification. |
-| `--debug` | Print HTTP request/response details to stderr. |
+
+### Lathe Control Commands
+
+Lathe runtime commands that should not occupy generated API command names live under the hidden `__lathe` command:
+
+| Command | Effect |
+|---|---|
+| `<cli> __lathe version` | Print version information. |
+| `<cli> __lathe completion <shell>` | Generate shell completion scripts. |
 
 ### Environment
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -275,7 +275,7 @@ Three pieces of state cross the boundary:
 
 1. **Manifest** (immutable, from `cli.yaml` embedded at build time) — CLI identity and auth shape.
 2. **Hosts** (mutable, `~/.config/<name>/hosts.yml`) — per-hostname credentials. No "current host" stored.
-3. **Flags** (transient) — `--hostname`, `--output`, `--insecure`, plus operation-specific flags.
+3. **Flags** (transient) — `--hostname`, `--output`, plus operation-specific flags.
 
 ## Extension points
 

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -120,12 +120,11 @@ func rootCommandName(use string) string {
 }
 
 var reservedRootCommands = map[string]bool{
-	"auth":       true,
-	"commands":   true,
-	"completion": true,
-	"help":       true,
-	"search":     true,
-	"version":    true,
+	"__lathe":  true,
+	"auth":     true,
+	"commands": true,
+	"help":     true,
+	"search":   true,
 }
 
 func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -2,6 +2,7 @@ package lathe
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
-const authGroupID = "auth"
+const (
+	authGroupID     = "auth"
+	metaCommandName = "__lathe"
+)
 
 // NewApp builds the root cobra command for a lathe-style CLI identified by m.
 // It binds m for package-level helpers before returning the command.
@@ -26,10 +30,13 @@ func NewApp(m *config.Manifest) *cobra.Command {
 		Long:         agentHint(m.CLI.Name, m.CLI.Short),
 		SilenceUsage: true,
 	}
+	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.PersistentFlags().String("hostname", "", fmt.Sprintf("Server hostname (overrides $%s)", m.CLI.HostEnv))
 	cmd.PersistentFlags().StringP("output", "o", "table", "Output format: table|json|yaml|raw")
 	cmd.PersistentFlags().Bool("insecure", false, "Skip TLS certificate verification for this invocation")
 	cmd.PersistentFlags().Bool("debug", false, "Print HTTP request/response details to stderr")
+	_ = cmd.PersistentFlags().MarkHidden("insecure")
+	_ = cmd.PersistentFlags().MarkHidden("debug")
 
 	cmd.AddGroup(
 		&cobra.Group{ID: authGroupID, Title: "Authentication:"},
@@ -41,8 +48,30 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	cmd.AddCommand(authCmd)
 	cmd.AddCommand(commandsCmd(m))
 	cmd.AddCommand(searchCmd(m))
-	cmd.AddCommand(versionCmd())
+	cmd.AddCommand(metaCmd(m.CLI.Name))
 	return cmd
+}
+
+func metaCmd(cliName string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    metaCommandName,
+		Short:  "Lathe control commands",
+		Hidden: true,
+	}
+	cmd.AddCommand(versionCmd())
+	cmd.InitDefaultCompletionCmd()
+	rewriteCompletionHelp(cmd, cliName)
+	return cmd
+}
+
+func rewriteCompletionHelp(cmd *cobra.Command, cliName string) {
+	oldPath := metaCommandName + " completion"
+	newPath := cliName + " " + metaCommandName + " completion"
+	for _, child := range cmd.Commands() {
+		child.Long = strings.ReplaceAll(child.Long, oldPath, newPath)
+		child.Long = strings.ReplaceAll(child.Long, "for "+metaCommandName, "for "+cliName)
+		rewriteCompletionHelp(child, cliName)
+	}
 }
 
 // agentHint surfaces the catalog protocol in `<cli> --help` so agents

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -74,7 +74,7 @@ func TestRunMountsAndExecutesGeneratedCommands(t *testing.T) {
 		Version:  "1.2.3",
 		Commit:   "abc123",
 		Date:     "2026-05-26",
-	}, []string{"version"}, &stdout, &stderr)
+	}, []string{metaCommandName, "version"}, &stdout, &stderr)
 	if code != runtime.ExitOK {
 		t.Fatalf("version exit = %d, stderr = %q", code, stderr.String())
 	}


### PR DESCRIPTION
## Summary

- Move Lathe runtime-only `version` and shell `completion` commands under the hidden `__lathe` control command.
- Keep `auth`, `commands`, `search`, `--hostname`, and `-o/--output` at the generated CLI root.
- Release `version` and `completion` API group names for single-module flat mounting and document the new control command path.

## Verification

- `go test ./... -count=1`
- `git diff --check HEAD~1..HEAD`
- Pre-ship gate: round 1 fixed completion help path; round 2 passed with no remaining MUST-FIX findings.

## Compatibility

Generated CLI command shape changes: `version` and shell `completion` are no longer mounted at the root. Use `<cli> __lathe version` and `<cli> __lathe completion <shell>`. Catalog schema, auth command path, catalog commands, search, request body handling, and output behavior are unchanged. `--debug` and `--insecure` remain parsed for runtime compatibility but are hidden from root help.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.