### PR TITLE
test: cover lower-case api key header

### DIFF
--- a/pkg/runtime/auth_test.go
+++ b/pkg/runtime/auth_test.go
@@ -47,6 +47,16 @@ func TestAPIKeyAuth_CustomHeader(t *testing.T) {
 	}
 }
 
+func TestAPIKeyAuth_CustomLowercaseHeader(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://x", nil)
+	if err := (APIKeyAuth{Key: "k3", Header: "x-api-key"}).Apply(req); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("x-api-key"); got != "k3" {
+		t.Errorf("want k3, got %q", got)
+	}
+}
+
 func TestAPIKeyAuth_Empty(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://x", nil)
 	if err := (APIKeyAuth{}).Apply(req); err != nil {
@@ -126,6 +136,19 @@ func TestNewAuthFromHost(t *testing.T) {
 				}
 				if ak.Header != "X-Custom" {
 					t.Errorf("want X-Custom, got %q", ak.Header)
+				}
+			},
+		},
+		{
+			name:  "apikey lower-case header",
+			entry: config.HostEntry{AuthType: "apikey", APIKey: "k2", APIKeyHeader: "x-api-key"},
+			check: func(t *testing.T, a Authenticator) {
+				ak, ok := a.(APIKeyAuth)
+				if !ok {
+					t.Fatalf("want APIKeyAuth, got %T", a)
+				}
+				if ak.Header != "x-api-key" {
+					t.Errorf("want x-api-key, got %q", ak.Header)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

Covers custom lower-case `x-api-key` API key headers in runtime auth application and host config mapping. Some OpenAPI specs declare header names in lower case, so this keeps the runtime behavior covered directly.

## Verification

`go test ./pkg/runtime ./pkg/config`

## Compatibility

No generated command shape, catalog schema, auth behavior, body behavior, output behavior, or docs changes. Test coverage only.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented or not applicable.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.