### PR TITLE
chore(gitignore): ignore wrangler local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 examples/*/bin/
 examples/*/skills/
 examples/*/internal/generated/
+.wrangler/


### PR DESCRIPTION
## Summary

Ignore Cloudflare Wrangler local state directory (`.wrangler/`) so local tooling artifacts are not committed.

## Verification

- Inspected staged/committed diff: single-line addition to `.gitignore`
- CJK scan on added lines: clean
- Pre-ship (7-lens) on `HEAD~1..HEAD`: 0 findings, 0 MUST-FIX

## Compatibility

None

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.