### PR TITLE
fix(codegen): handle command-name collisions and missing operationId

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -3,6 +3,7 @@ package normalize
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -72,7 +73,34 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 		}
 		return specs[i].OperationID < specs[j].OperationID
 	})
+	disambiguateUse(specs)
 	return specs
+}
+
+// disambiguateUse makes each command's Group+Use unique. Distinct operations can
+// normalize to the same command name (e.g. GET /groups and GET /Groups, or
+// create_x and get_x whose ids both reduce to "x"); without this, codegen aborts
+// on the collision instead of exposing both endpoints. Runs after the sort so
+// the suffix assignment is deterministic.
+func disambiguateUse(specs []runtime.CommandSpec) {
+	used := map[string]bool{}
+	for i := range specs {
+		key := specs[i].Group + "\x00" + specs[i].Use
+		if !used[key] {
+			used[key] = true
+			continue
+		}
+		base := specs[i].Use
+		for n := 2; ; n++ {
+			cand := base + "-" + strconv.Itoa(n)
+			ck := specs[i].Group + "\x00" + cand
+			if !used[ck] {
+				specs[i].Use = cand
+				used[ck] = true
+				break
+			}
+		}
+	}
 }
 
 func applyRawOutputHints(spec *runtime.CommandSpec, hints *rawir.RawOutputHints) {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -14,10 +14,17 @@ import (
 func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 	var specs []runtime.CommandSpec
 	for _, op := range mod.Operations {
-		if op.OperationID == "" {
+		// Fall back to a method+path-derived id when the spec omits operationId
+		// (common with swaggo/springfox and framework-extracted drafts); without
+		// this the operation is silently dropped and the CLI is empty.
+		opID := op.OperationID
+		if opID == "" {
+			opID = synthOperationID(op.Method, op.Path)
+		}
+		if opID == "" {
 			continue
 		}
-		useName := camelToKebab(opNameFromID(op.OperationID))
+		useName := camelToKebab(opNameFromID(opID))
 		if useName == "" {
 			continue
 		}
@@ -25,7 +32,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 			Group:       group(op),
 			Use:         useName,
 			Short:       pickShort(op),
-			OperationID: op.OperationID,
+			OperationID: opID,
 			Method:      op.Method,
 			PathTpl:     op.Path,
 		}
@@ -75,6 +82,30 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 	})
 	disambiguateUse(specs)
 	return specs
+}
+
+// synthOperationID builds a camelCase id like "getUsersId" from a method and
+// path, for specs that omit operationId. It contains no underscore, so
+// opNameFromID returns it whole and camelToKebab yields the command name.
+func synthOperationID(method, path string) string {
+	var b strings.Builder
+	b.WriteString(strings.ToLower(method))
+	for _, seg := range strings.Split(path, "/") {
+		seg = strings.Trim(seg, "{}")
+		var s strings.Builder
+		for _, r := range seg {
+			if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+				s.WriteRune(r)
+			}
+		}
+		if s.Len() == 0 {
+			continue
+		}
+		w := s.String()
+		b.WriteString(strings.ToUpper(w[:1]))
+		b.WriteString(w[1:])
+	}
+	return b.String()
 }
 
 // disambiguateUse makes each command's Group+Use unique. Distinct operations can

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -376,3 +376,20 @@ func securityScopes() *rawir.RawModule {
 		}},
 	}
 }
+
+func TestDisambiguateUseCollisions(t *testing.T) {
+	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
+		{OperationID: "getGroups", Method: "GET", Path: "/groups"},
+		{OperationID: "getGroupsUpper", Method: "GET", Path: "/Groups"},
+	}}
+	// Force both to the same base Use via identical opNameFromID output.
+	mod.Operations[0].OperationID = "x_groups"
+	mod.Operations[1].OperationID = "y_groups"
+	specs := Normalize(mod)
+	if len(specs) != 2 {
+		t.Fatalf("want 2 specs, got %d", len(specs))
+	}
+	if specs[0].Use == specs[1].Use {
+		t.Errorf("colliding command names not disambiguated: both %q", specs[0].Use)
+	}
+}

--- a/internal/codegen/normalize/testdata/no-op-id.golden.json
+++ b/internal/codegen/normalize/testdata/no-op-id.golden.json
@@ -1,1 +1,25 @@
-null
+[
+  {
+    "Group": "Users",
+    "Use": "get-users",
+    "Aliases": null,
+    "Short": "",
+    "Long": "",
+    "Example": "",
+    "OperationID": "getUsers",
+    "Hidden": false,
+    "Deprecated": false,
+    "Method": "GET",
+    "PathTpl": "/users",
+    "Params": null,
+    "RequestBody": null,
+    "Output": {
+      "ListPath": "",
+      "DefaultColumns": null,
+      "ResponseMediaType": "",
+      "Pagination": null,
+      "Streaming": null
+    },
+    "Security": null
+  }
+]


### PR DESCRIPTION
## Summary

Two codegen robustness fixes in `internal/codegen/normalize`, surfaced by
generating CLIs from 100 real API repos where valid specs produced no CLI:

- **Disambiguate colliding command names instead of aborting.** Distinct
  operations can normalize to the same `Group`+`Use` (e.g. `GET /groups` and
  `GET /Groups`, or operationIds `create_x`/`get_x` that both reduce to `x` via
  `opNameFromID`). `validateCommandPaths` turned any collision into a hard error,
  so codegen produced no CLI at all. Deduplicate in `Normalize` after the
  deterministic sort by appending `-2`/`-3` to the colliding `Use`.
- **Synthesize a command name when `operationId` is absent.** Operations without
  an operationId were silently dropped, so specs from generators that omit it
  (swaggo, springfox) produced an empty CLI. Fall back to a method+path-derived
  id (`getUsers`), reusing the existing name derivation.

Verified on real specs: superset 52, trieve 133, gin 107, chi 86 went from a
codegen abort to a working CLI; go8 0→12, go-gin-example 0→23,
gin-vue-admin 0→245 recovered from empty.

## Verification

- `make check` — fmt-check, vet, golangci-lint, tests — passes.
- Added a regression test for the collision case; updated the `no-op-id` golden
  (now yields a `get-users` command). Only that golden changed.

## Compatibility

Generated command shape changes in two intended ways: operations without an
operationId now produce a command (previously dropped), and two commands that
would share a name now get a `-N` suffix instead of failing codegen. Catalog
schema, auth/body/output behavior unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.