### PR TITLE
fix(codegen): derive readable command names and report a real version

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -12,20 +12,21 @@ import (
 )
 
 func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
+	trim := commonNoisePrefix(mod.Operations)
 	var specs []runtime.CommandSpec
 	for _, op := range mod.Operations {
 		// Fall back to a method+path-derived id when the spec omits operationId
 		// (common with swaggo/springfox and framework-extracted drafts); without
 		// this the operation is silently dropped and the CLI is empty.
 		opID := op.OperationID
+		useName := ""
 		if opID == "" {
 			opID = synthOperationID(op.Method, op.Path)
+			useName = synthUseName(op.Method, op.Path, trim)
+		} else {
+			useName = kebabFromID(opNameFromID(opID, group(op)))
 		}
-		if opID == "" {
-			continue
-		}
-		useName := camelToKebab(opNameFromID(opID))
-		if useName == "" {
+		if opID == "" || useName == "" {
 			continue
 		}
 		spec := runtime.CommandSpec{
@@ -85,8 +86,8 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 }
 
 // synthOperationID builds a camelCase id like "getUsersId" from a method and
-// path, for specs that omit operationId. It contains no underscore, so
-// opNameFromID returns it whole and camelToKebab yields the command name.
+// path, for specs that omit operationId. It stands in for the missing id in the
+// catalog and Skill; the command name comes from synthUseName instead.
 func synthOperationID(method, path string) string {
 	var b strings.Builder
 	b.WriteString(strings.ToLower(method))
@@ -108,11 +109,107 @@ func synthOperationID(method, path string) string {
 	return b.String()
 }
 
+// synthUseName names an operation the spec never named, from the path rather
+// than the id: "delete-dashboard-pk-favorites", not
+// "delete-api-v1dashboard-pk-favorites".
+func synthUseName(method, path string, trim int) string {
+	segs := pathSegments(path)
+	if trim < len(segs) {
+		segs = segs[trim:]
+	}
+	parts := []string{strings.ToLower(method)}
+	for _, seg := range segs {
+		if s := sanitizeSegment(seg); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, "-")
+}
+
+// commonNoisePrefix counts leading segments ("api", "v1") shared by every
+// unnamed operation. Module-wide rather than per-operation, so a spec serving
+// two API versions keeps them distinct instead of collapsing onto one name.
+func commonNoisePrefix(ops []rawir.RawOperation) int {
+	var paths [][]string
+	for _, op := range ops {
+		if op.OperationID != "" {
+			continue
+		}
+		paths = append(paths, pathSegments(op.Path))
+	}
+	if len(paths) == 0 {
+		return 0
+	}
+	n := 0
+	for {
+		// Always leave one segment: a command needs a noun.
+		if n >= len(paths[0])-1 || !noiseSegment(paths[0][n]) {
+			return n
+		}
+		for _, p := range paths[1:] {
+			if n >= len(p)-1 || p[n] != paths[0][n] {
+				return n
+			}
+		}
+		n++
+	}
+}
+
+func noiseSegment(seg string) bool {
+	switch folded := foldToken(seg); folded {
+	case "api", "apis", "rest":
+		return true
+	default:
+		if len(folded) < 2 || folded[0] != 'v' || folded[1] < '0' || folded[1] > '9' {
+			return false
+		}
+		return true
+	}
+}
+
+func pathSegments(path string) []string {
+	var out []string
+	for _, seg := range strings.Split(path, "/") {
+		if seg != "" {
+			out = append(out, seg)
+		}
+	}
+	return out
+}
+
+func sanitizeSegment(seg string) string {
+	seg = strings.Trim(seg, "{}")
+	seg = strings.NewReplacer("_", "-", ".", "-", " ", "-").Replace(seg)
+	var b strings.Builder
+	for _, r := range camelToKebab(seg) {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return strings.Trim(collapseDashes(b.String()), "-")
+}
+
+func collapseDashes(s string) string {
+	var b strings.Builder
+	prev := false
+	for _, r := range s {
+		if r == '-' {
+			if prev {
+				continue
+			}
+			prev = true
+		} else {
+			prev = false
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
 // disambiguateUse makes each command's Group+Use unique. Distinct operations can
-// normalize to the same command name (e.g. GET /groups and GET /Groups, or
-// create_x and get_x whose ids both reduce to "x"); without this, codegen aborts
-// on the collision instead of exposing both endpoints. Runs after the sort so
-// the suffix assignment is deterministic.
+// still normalize to the same command name (e.g. GET /groups and GET /Groups);
+// without this, codegen aborts on the collision instead of exposing both
+// endpoints. Runs after the sort so the suffix assignment is deterministic.
 func disambiguateUse(specs []runtime.CommandSpec) {
 	used := map[string]bool{}
 	for i := range specs {
@@ -164,11 +261,39 @@ func group(op rawir.RawOperation) string {
 	return "Default"
 }
 
-func opNameFromID(id string) string {
-	if idx := strings.Index(id, "_"); idx >= 0 {
-		return id[idx+1:]
+// opNameFromID drops a leading segment only when it repeats the group
+// ("Dashboards_getList" in group "Dashboards"). Dropping it unconditionally
+// collapsed create_chunk/update_chunk/delete_chunk onto one name.
+func opNameFromID(id, group string) string {
+	idx := strings.Index(id, "_")
+	if idx <= 0 || !sameToken(id[:idx], group) {
+		return id
 	}
-	return id
+	return id[idx+1:]
+}
+
+// kebabFromID renders an operationId as a command name. Edge separators are
+// trimmed: "_foo" would otherwise yield "-foo", which cobra reads as a flag.
+func kebabFromID(id string) string {
+	return strings.Trim(collapseDashes(camelToKebab(strings.ReplaceAll(id, "_", "-"))), "-")
+}
+
+func sameToken(a, b string) bool {
+	fa, fb := foldToken(a), foldToken(b)
+	if fa == "" || fb == "" {
+		return false
+	}
+	return fa == fb || strings.TrimSuffix(fa, "s") == strings.TrimSuffix(fb, "s")
+}
+
+func foldToken(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return b.String()
 }
 
 func pickShort(op rawir.RawOperation) string {

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -378,18 +378,91 @@ func securityScopes() *rawir.RawModule {
 }
 
 func TestDisambiguateUseCollisions(t *testing.T) {
+	// Same group, same derived name: distinct operations must both survive with
+	// distinct command names rather than aborting codegen.
 	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
-		{OperationID: "getGroups", Method: "GET", Path: "/groups"},
-		{OperationID: "getGroupsUpper", Method: "GET", Path: "/Groups"},
+		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/groups"},
+		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/Groups"},
 	}}
-	// Force both to the same base Use via identical opNameFromID output.
-	mod.Operations[0].OperationID = "x_groups"
-	mod.Operations[1].OperationID = "y_groups"
 	specs := Normalize(mod)
 	if len(specs) != 2 {
 		t.Fatalf("want 2 specs, got %d", len(specs))
 	}
 	if specs[0].Use == specs[1].Use {
 		t.Errorf("colliding command names not disambiguated: both %q", specs[0].Use)
+	}
+}
+
+// A leading id segment is redundant only when it repeats the group. Stripping
+// it unconditionally collapsed every CRUD verb onto the same command name.
+func TestOpNameKeepsVerbWhenPrefixIsNotTheGroup(t *testing.T) {
+	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Chunk", OperationID: "create_chunk", Method: "POST", Path: "/api/chunk"},
+		{Group: "Chunk", OperationID: "update_chunk", Method: "PUT", Path: "/api/chunk"},
+		{Group: "Chunk", OperationID: "delete_chunk", Method: "DELETE", Path: "/api/chunk"},
+		{Group: "Chunks", OperationID: "Chunks_search", Method: "POST", Path: "/api/chunk/search"},
+	}}
+	got := map[string]string{}
+	for _, spec := range Normalize(mod) {
+		got[spec.OperationID] = spec.Use
+	}
+	want := map[string]string{
+		"create_chunk":  "create-chunk",
+		"update_chunk":  "update-chunk",
+		"delete_chunk":  "delete-chunk",
+		"Chunks_search": "search",
+	}
+	for id, expected := range want {
+		if got[id] != expected {
+			t.Errorf("%s: want Use %q, got %q", id, expected, got[id])
+		}
+	}
+}
+
+func TestSynthUseNameDropsSharedNoisePrefix(t *testing.T) {
+	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Dashboards", Method: "GET", Path: "/api/v1/dashboard/"},
+		{Group: "Dashboards", Method: "DELETE", Path: "/api/v1/dashboard/{pk}/favorites/"},
+		{Group: "Charts", Method: "POST", Path: "/api/v1/advanced_data_type/convert"},
+	}}
+	want := map[string]string{
+		"GET":    "get-dashboard",
+		"DELETE": "delete-dashboard-pk-favorites",
+		"POST":   "post-advanced-data-type-convert",
+	}
+	for _, spec := range Normalize(mod) {
+		if want[spec.Method] != spec.Use {
+			t.Errorf("%s %s: want Use %q, got %q", spec.Method, spec.PathTpl, want[spec.Method], spec.Use)
+		}
+	}
+}
+
+// Two API versions in one spec must stay distinguishable: the version segment
+// is only noise when every unnamed operation shares it.
+func TestSynthUseNameKeepsDivergingVersions(t *testing.T) {
+	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Users", Method: "GET", Path: "/api/v1/users"},
+		{Group: "Users", Method: "GET", Path: "/api/v2/users"},
+	}}
+	specs := Normalize(mod)
+	uses := []string{specs[0].Use, specs[1].Use}
+	for _, use := range uses {
+		if use != "get-v1-users" && use != "get-v2-users" {
+			t.Errorf("want versioned command names, got %v", uses)
+		}
+	}
+	if uses[0] == uses[1] {
+		t.Errorf("versions collapsed onto one name: %v", uses)
+	}
+}
+
+// An operationId can start or end with an underscore; the command name must not
+// start with a dash, which cobra would read as a flag.
+func TestKebabFromIDTrimsEdgeSeparators(t *testing.T) {
+	cases := map[string]string{"_foo": "foo", "foo_": "foo", "a__b": "a-b", "_": ""}
+	for id, want := range cases {
+		if got := kebabFromID(id); got != want {
+			t.Errorf("kebabFromID(%q) = %q, want %q", id, got, want)
+		}
 	}
 }

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -66,7 +66,8 @@ func runWithOutputs(args []string, stdout io.Writer, stderr io.Writer) error {
 	case "skill":
 		return RunSkill(args[1:], stdout, stderr)
 	case "version":
-		fmt.Fprintf(stdout, "lathe %s (%s, %s)\n", lathe.Version, lathe.Commit, lathe.Date)
+		version, commit, date := lathe.VersionInfo()
+		fmt.Fprintf(stdout, "lathe %s (%s, %s)\n", version, commit, date)
 		return nil
 	default:
 		return fmt.Errorf("unknown command %q", args[0])

--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -123,7 +123,7 @@ func searchCmd(m *config.Manifest) *cobra.Command {
 func catalogOptions(m *config.Manifest, includeHidden bool) runtime.CatalogOptions {
 	return runtime.CatalogOptions{
 		CLIName:       m.CLI.Name,
-		CLIVersion:    Version,
+		CLIVersion:    catalogCLIVersion(),
 		IncludeHidden: includeHidden,
 	}
 }

--- a/pkg/lathe/version.go
+++ b/pkg/lathe/version.go
@@ -1,6 +1,11 @@
 package lathe
 
-import "github.com/spf13/cobra"
+import (
+	"runtime/debug"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 var (
 	Version = "dev"
@@ -8,8 +13,60 @@ var (
 	Date    = "unknown"
 )
 
+// VersionInfo reports the values linked at build time, falling back to what Go
+// records in the binary. `go install <module>@<ref>` links no ldflags, so
+// without the fallback every such build calls itself "dev (none, unknown)".
+func VersionInfo() (version, commit, date string) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return Version, Commit, Date
+	}
+	var revision, vcsTime string
+	var modified bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.time":
+			vcsTime = setting.Value
+		case "vcs.modified":
+			modified = setting.Value == "true"
+		}
+	}
+	return resolveVersion(Version, Commit, Date, info.Main.Version, revision, vcsTime, modified)
+}
+
+func resolveVersion(linkedVersion, linkedCommit, linkedDate, moduleVersion, revision, vcsTime string, modified bool) (string, string, string) {
+	version, commit, date := linkedVersion, linkedCommit, linkedDate
+
+	if version == "dev" {
+		if v := strings.TrimSuffix(moduleVersion, "+dirty"); v != "" && v != "(devel)" {
+			version = v
+		}
+	}
+	if commit == "none" && revision != "" {
+		commit = revision
+		if modified {
+			// A dirty tree must not pass for the commit it names.
+			commit += "+dirty"
+		}
+	}
+	if date == "unknown" && vcsTime != "" {
+		date = vcsTime
+	}
+	return version, commit, date
+}
+
+// catalogCLIVersion resolves the same way the `version` command does, so one
+// binary does not answer the question two ways.
+func catalogCLIVersion() string {
+	version, _, _ := VersionInfo()
+	return version
+}
+
 func versionInfo() string {
-	return Version + " (" + Commit + ", " + Date + ")"
+	version, commit, date := VersionInfo()
+	return version + " (" + commit + ", " + date + ")"
 }
 
 func versionCmd() *cobra.Command {

--- a/pkg/lathe/version_test.go
+++ b/pkg/lathe/version_test.go
@@ -1,0 +1,39 @@
+package lathe
+
+import "testing"
+
+func TestResolveVersionPrefersLinkedValues(t *testing.T) {
+	version, commit, date := resolveVersion("v1.2.3", "abc123", "2026-01-01", "v9.9.9", "def456", "2026-02-02", true)
+	if version != "v1.2.3" || commit != "abc123" || date != "2026-01-01" {
+		t.Fatalf("linked ldflags must win, got %s (%s, %s)", version, commit, date)
+	}
+}
+
+// `go install <module>@<ref>` links no ldflags; the module version Go records is
+// the only thing identifying the build.
+func TestResolveVersionFallsBackToModuleVersion(t *testing.T) {
+	version, commit, date := resolveVersion("dev", "none", "unknown", "v0.4.6", "", "", false)
+	if version != "v0.4.6" {
+		t.Errorf("want module version v0.4.6, got %q", version)
+	}
+	if commit != "none" || date != "unknown" {
+		t.Errorf("without vcs settings commit/date stay unknown, got %q / %q", commit, date)
+	}
+}
+
+func TestResolveVersionUsesVCSSettingsAndMarksDirty(t *testing.T) {
+	_, commit, date := resolveVersion("dev", "none", "unknown", "(devel)", "deadbeef", "2026-07-24T00:00:00Z", true)
+	if commit != "deadbeef+dirty" {
+		t.Errorf("a modified tree must not look like a clean commit, got %q", commit)
+	}
+	if date != "2026-07-24T00:00:00Z" {
+		t.Errorf("want vcs.time as date, got %q", date)
+	}
+}
+
+func TestResolveVersionIgnoresDevelPlaceholder(t *testing.T) {
+	version, _, _ := resolveVersion("dev", "none", "unknown", "(devel)", "", "", false)
+	if version != "dev" {
+		t.Errorf("(devel) is not a version, got %q", version)
+	}
+}


### PR DESCRIPTION
## Summary

Command names collapsed two ways, and neither was visible until real specs ran through codegen.

`opNameFromID` dropped everything before the first underscore, so `create_chunk`, `update_chunk` and `delete_chunk` all became `chunk` and the disambiguator shipped `chunk`, `chunk-2`, `chunk-3` — names nothing can tell apart without `commands show`. That stripping exists for ids that repeat their tag (`Dashboards_getList` in group `Dashboards`), so it now applies only in that case.

Operations a spec never named took their command name from the synthesized id, carrying the whole path into it: `get-api-v1dashboard-pk-favorites`. The name is now built from the path directly, minus the noise prefix (`api`, `v1`) that every unnamed operation in the module shares, yielding `delete-dashboard-pk-favorites`. The prefix is computed per module, not per operation, so a spec serving two API versions keeps `get-v1-users` and `get-v2-users` distinct instead of collapsing both onto one name.

Separately, `lathe version` reported `dev (none, unknown)` for anything not built with release ldflags — including `go install <module>@<ref>` — so a build record could not say which Lathe produced an artifact. It now falls back to `debug.ReadBuildInfo`, marking a modified tree `+dirty` so a dirty build cannot pass for the commit it names. The catalog's `cli.version` resolves the same way, so one binary does not answer the question two different ways.

## Verification

- `make check` (fmt-check, vet, golangci-lint, tests) — passing
- Measured against real recipes by generating each CLI and reading its catalog:
  - Apache Superset (276 operations, 224 without an `operationId`): `get-api-v1dashboard` -> `get-dashboard`
  - Trieve: collision-suffixed names 32/133 -> 0; searching its smoke intent now resolves to `search-chunks` at score 280 instead of `chunks-2` at 90
- All 16 normalize goldens unchanged — their ids are `Group_Verb` shaped, which is exactly the case the narrowed stripping still covers
- New tests: verb retention when the prefix is not the group, noise-prefix removal, diverging API versions, edge-separator trimming, and version resolution (linked ldflags, module fallback, VCS settings with dirty marker, `(devel)` placeholder)

## Compatibility

**Generated command names change** for two classes of spec, both toward readability:

- snake_case `operationId`s whose first segment is not the tag now keep the verb (`chunk-2` -> `update-chunk`), and underscores render as kebab like every other command name
- specs without `operationId` lose the path prefix from the name (`get-api-v1dashboard` -> `get-dashboard`)

Downstream CLIs regenerated with this change will rename those commands; specs whose ids already repeat their tag are unaffected. Catalog schema is unchanged; `cli.version` may now report a resolved version where it previously said `dev`.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
