### PR TITLE
fix(codegen): drop module prefix from operation command names

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -24,7 +24,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 			opID = synthOperationID(op.Method, op.Path)
 			useName = synthUseName(op.Method, op.Path, trim)
 		} else {
-			useName = kebabFromID(opNameFromID(opID, group(op)))
+			useName = kebabFromID(opNameFromID(opID, group(op), mod.Name))
 		}
 		if opID == "" || useName == "" {
 			continue
@@ -261,12 +261,10 @@ func group(op rawir.RawOperation) string {
 	return "Default"
 }
 
-// opNameFromID drops a leading segment only when it repeats the group
-// ("Dashboards_getList" in group "Dashboards"). Dropping it unconditionally
-// collapsed create_chunk/update_chunk/delete_chunk onto one name.
-func opNameFromID(id, group string) string {
+// Blind prefix stripping collapses create_chunk/update_chunk/delete_chunk onto one name.
+func opNameFromID(id, group, module string) string {
 	idx := strings.Index(id, "_")
-	if idx <= 0 || !sameToken(id[:idx], group) {
+	if idx <= 0 || !sameToken(id[:idx], group) && !sameToken(id[:idx], module) {
 		return id
 	}
 	return id[idx+1:]

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -419,6 +419,19 @@ func TestOpNameKeepsVerbWhenPrefixIsNotTheGroup(t *testing.T) {
 	}
 }
 
+func TestOpNameDropsModulePrefix(t *testing.T) {
+	mod := &rawir.RawModule{
+		Name: "console",
+		Operations: []rawir.RawOperation{{
+			Group: "Apps", OperationID: "console_listApps", Method: "POST", Path: "/graphql",
+		}},
+	}
+	specs := Normalize(mod)
+	if got := specs[0].Use; got != "list-apps" {
+		t.Fatalf("Use = %q, want list-apps", got)
+	}
+}
+
 func TestSynthUseNameDropsSharedNoisePrefix(t *testing.T) {
 	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
 		{Group: "Dashboards", Method: "GET", Path: "/api/v1/dashboard/"},


### PR DESCRIPTION
## Summary

- Strip a leading `operationId` segment when it matches the **module name** (in addition to the group name), so names like `console_listApps` become `list-apps` instead of `console-list-apps`.
- Keep the existing guard against blind prefix stripping, which would collapse CRUD verbs (`create_chunk` / `update_chunk` / `delete_chunk`) onto one command name.
- Add a focused unit test for the module-prefix path.

## Verification

```sh
go test ./internal/codegen/normalize/ -count=1
```

## Compatibility

Generated command `Use` names may shorten when an `operationId` is prefixed with the module name. Group-prefix behavior is unchanged. Catalog schema, auth, body, and output format are unaffected.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.

## Considered and deferred

- internal/codegen/normalize/normalize.go:267 [BOT-NIT]: Missing parentheses around the && clause is less readable but Go precedence is correct; not changing.