### PR TITLE
fix(init): prefix release stamps with v for go.mod

### DIFF
--- a/internal/lathecmd/init.go
+++ b/internal/lathecmd/init.go
@@ -194,14 +194,23 @@ func selectLanguage(reader *bufio.Reader, output io.Writer) (string, error) {
 
 func resolveInitVersion(linkedVersion, moduleVersion, override string) (string, error) {
 	if linkedVersion != "dev" {
-		return linkedVersion, nil
+		return withVPrefix(linkedVersion), nil
 	}
 	if override != "" {
-		return override, nil
+		return withVPrefix(override), nil
 	}
 	moduleVersion = strings.TrimSuffix(moduleVersion, "+dirty")
 	if moduleVersion != "" && moduleVersion != "(devel)" {
-		return moduleVersion, nil
+		return withVPrefix(moduleVersion), nil
 	}
 	return "", errors.New("cannot determine generator/runtime version; set LATHE_INIT_VERSION")
+}
+
+// Release builds stamp the tag without its leading "v" ("0.5.0"), which is not
+// a valid go.mod requirement and made `lathe init` reject its own version.
+func withVPrefix(version string) string {
+	if version != "" && version[0] >= '0' && version[0] <= '9' {
+		return "v" + version
+	}
+	return version
 }

--- a/internal/lathecmd/init_test.go
+++ b/internal/lathecmd/init_test.go
@@ -63,3 +63,13 @@ func TestInitSelectsLanguageInTerminal(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveInitVersionAddsVPrefixToReleaseStamp(t *testing.T) {
+	got, err := resolveInitVersion("0.5.0", "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v0.5.0" {
+		t.Fatalf("version = %q, want v0.5.0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Release builds stamp `lathe.Version` via GoReleaser as `0.5.0` (no leading `v`). `lathe init` passed that value through to `projectinit`, which requires a go-mod-style version (`^v[0-9]+...`) and rejected the binary's own release stamp.

Normalize versions that start with a digit by adding a leading `v` in `resolveInitVersion`, so release stamps, overrides, and bare numeric module versions become valid `lathe_version` values without double-prefixing already-tagged forms (`v0.5.0`).

## Verification

- `go test ./internal/lathecmd/ -count=1`
- Pre-ship gate (committed mode, round 1/2): 0 MUST-FIX

## Compatibility

- User-facing: release-stamped `lathe init` no longer fails with `invalid Lathe version "x.y.z"` when writing starter `lathe_version` / go.mod requirements.
- Catalog schema, auth/body/output, and generated command shape: none.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.