### PR TITLE
fix: harden generation for real-world API specs

### DIFF
--- a/internal/codegen/backends/swagger/backend.go
+++ b/internal/codegen/backends/swagger/backend.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
+	"gopkg.in/yaml.v3"
 )
 
 func anyToString(v any) string {
@@ -82,6 +83,16 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 		data, err := os.ReadFile(p)
 		if err != nil {
 			return nil, fmt.Errorf("read %s: %w", p, err)
+		}
+		if ext := strings.ToLower(filepath.Ext(p)); ext == ".yaml" || ext == ".yml" {
+			var document any
+			if err := yaml.Unmarshal(data, &document); err != nil {
+				return nil, fmt.Errorf("parse %s: %w", p, err)
+			}
+			data, err = json.Marshal(document)
+			if err != nil {
+				return nil, fmt.Errorf("parse %s: %w", p, err)
+			}
 		}
 		var sw swaggerDoc
 		if err := json.Unmarshal(data, &sw); err != nil {
@@ -167,7 +178,16 @@ func convertOp(op operation, method, path string, docProduces []string, globalSe
 		produces = docProduces
 	}
 	out.Produces = produces
+	seenParameters := map[string]parameter{}
 	for _, p := range op.Parameters {
+		key := p.In + "\x00" + p.Name
+		if existing, ok := seenParameters[key]; ok {
+			if !sameJSON(existing, p) {
+				fmt.Fprintf(os.Stderr, "warn: diverging duplicate parameter %q in %s %s (kept first)\n", p.Name, out.Method, path)
+			}
+			continue
+		}
+		seenParameters[key] = p
 		if p.In == "body" {
 			out.RequestBody = &rawir.RawRequestBody{Required: p.Required, Schema: convertSchema(p.Schema)}
 			continue

--- a/internal/codegen/backends/swagger/backend_test.go
+++ b/internal/codegen/backends/swagger/backend_test.go
@@ -3,8 +3,11 @@ package swagger
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
 
+	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
 	"github.com/lathe-cli/lathe/internal/testutil"
 )
@@ -45,6 +48,60 @@ func TestParse_Golden(t *testing.T) {
 	}
 }
 
+func TestParse_YAMLMatchesJSON(t *testing.T) {
+	syncDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(syncDir, "petstore.json"), []byte(petstoreMinInput), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(syncDir, "petstore.yaml"), []byte(petstoreMinYAMLInput), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	parse := func(file string) *rawir.RawModule {
+		t.Helper()
+		src := &sourceconfig.Source{
+			Name:    "demo",
+			Swagger: &sourceconfig.SwaggerConfig{Files: []string{file}},
+		}
+		mod, err := Parse(src, syncDir)
+		if err != nil {
+			t.Fatalf("Parse(%s): %v", file, err)
+		}
+		return mod
+	}
+
+	jsonModule := parse("petstore.json")
+	yamlModule := parse("petstore.yaml")
+	for _, module := range []*rawir.RawModule{jsonModule, yamlModule} {
+		sort.Slice(module.Operations, func(i, j int) bool {
+			return module.Operations[i].Method+" "+module.Operations[i].Path <
+				module.Operations[j].Method+" "+module.Operations[j].Path
+		})
+	}
+	if !reflect.DeepEqual(jsonModule, yamlModule) {
+		t.Fatalf("YAML module differs from JSON\nJSON: %#v\nYAML: %#v", jsonModule, yamlModule)
+	}
+}
+
+func TestParse_DeduplicatesSwaggerParameters(t *testing.T) {
+	syncDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(syncDir, "duplicate.yaml"), []byte(duplicateParameterYAMLInput), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := &sourceconfig.Source{
+		Name:    "demo",
+		Swagger: &sourceconfig.SwaggerConfig{Files: []string{"duplicate.yaml"}},
+	}
+
+	mod, err := Parse(src, syncDir)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := len(mod.Operations[0].Parameters); got != 1 {
+		t.Fatalf("parameters = %d, want one unique parameter", got)
+	}
+}
+
 const petstoreMinInput = `{
   "swagger": "2.0",
   "definitions": {
@@ -78,6 +135,54 @@ const petstoreMinInput = `{
     }
   }
 }
+`
+
+const petstoreMinYAMLInput = `swagger: "2.0"
+definitions:
+  Pet:
+    type: object
+    properties:
+      id:
+        type: integer
+      name:
+        type: string
+paths:
+  /pets:
+    get:
+      operationId: Pet_List
+      tags: [Pets]
+      summary: List pets.
+      responses:
+        "200":
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/Pet"
+  /pets/{id}:
+    get:
+      operationId: Pet_Get
+      tags: [Pets]
+      summary: Get one pet.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+      responses:
+        "200":
+          schema:
+            $ref: "#/definitions/Pet"
+`
+
+const duplicateParameterYAMLInput = `swagger: "2.0"
+paths:
+  /jit:
+    get:
+      parameters:
+        - {name: network, in: query, required: true, type: string}
+        - {name: network, in: query, required: true, type: string}
+      responses:
+        "200": {description: ok}
 `
 
 const refResolutionInput = `{

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -88,6 +88,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	var bodyFile string
 	var bodySets []string
 	var bodyStringSets []string
+	var bodyFileFlag string
 	var paginateAll bool
 	var maxPages int
 	var waitPoll bool
@@ -120,7 +121,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return err
 			}
 
-			hasFile := s.RequestBody != nil && cmd.Flags().Changed("file")
+			hasFile := s.RequestBody != nil && cmd.Flags().Changed(bodyFileFlag)
 			var fileBody []byte
 			if hasFile {
 				fileBody, err = ReadBody(bodyFile)
@@ -164,27 +165,32 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		bindParamFlag(cmd, vals, s.Params[i], s.RequestBody != nil)
 	}
 	if s.RequestBody != nil {
+		bodyFileFlag = controlFlagName(cmd, "file")
+		bodySetFlag := controlFlagName(cmd, "set")
+		bodyStringSetFlag := controlFlagName(cmd, "set-str")
 		fileHelp := "path to JSON body file, or '-' for stdin"
-		setHelp := "set body field with type inference, e.g. --set spec.replicas=3 (repeatable; nested via dots)"
-		setStrHelp := "set body field as string, e.g. --set-str spec.replicas=3 (repeatable; nested via dots)"
+		setHelp := fmt.Sprintf("set body field with type inference, e.g. --%s spec.replicas=3 (repeatable; nested via dots)", bodySetFlag)
+		setStrHelp := fmt.Sprintf("set body field as string, e.g. --%s spec.replicas=3 (repeatable; nested via dots)", bodyStringSetFlag)
 		if s.RequestBody.Required {
-			suffix := " (use --file, --set, or --set-str)"
+			suffix := fmt.Sprintf(" (use --%s, --%s, or --%s)", bodyFileFlag, bodySetFlag, bodyStringSetFlag)
 			fileHelp += suffix
 			setHelp += suffix
 			setStrHelp += suffix
 		}
-		cmd.Flags().StringVarP(&bodyFile, "file", "f", "", fileHelp)
-		cmd.Flags().StringArrayVar(&bodySets, "set", nil, setHelp)
-		cmd.Flags().StringArrayVar(&bodyStringSets, "set-str", nil, setStrHelp)
+		cmd.Flags().StringVarP(&bodyFile, bodyFileFlag, "f", "", fileHelp)
+		cmd.Flags().StringArrayVar(&bodySets, bodySetFlag, nil, setHelp)
+		cmd.Flags().StringArrayVar(&bodyStringSets, bodyStringSetFlag, nil, setStrHelp)
 	}
 	if s.Output.Pagination != nil {
-		cmd.Flags().BoolVar(&paginateAll, "all", false, "fetch all pages")
-		cmd.Flags().IntVar(&maxPages, "max-pages", DefaultMaxPages, "maximum pages to fetch with --all")
+		allFlag := controlFlagName(cmd, "all")
+		maxPagesFlag := controlFlagName(cmd, "max-pages")
+		cmd.Flags().BoolVar(&paginateAll, allFlag, false, "fetch all pages")
+		cmd.Flags().IntVar(&maxPages, maxPagesFlag, DefaultMaxPages, "maximum pages to fetch with --"+allFlag)
 	}
 	if s.Method == "POST" || s.Method == "PUT" || s.Method == "DELETE" || s.Method == "PATCH" {
-		cmd.Flags().BoolVar(&waitPoll, "wait", false, "poll until long-running operation completes")
+		cmd.Flags().BoolVar(&waitPoll, controlFlagName(cmd, "wait"), false, "poll until long-running operation completes")
 	}
-	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print resolved request JSON without sending it")
+	cmd.Flags().BoolVar(&dryRun, controlFlagName(cmd, "dry-run"), false, "print resolved request JSON without sending it")
 	cmd.Hidden = s.Hidden
 	if s.Deprecated {
 		cmd.Deprecated = "this command is deprecated"
@@ -193,6 +199,22 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		cmd.Long = fmt.Sprintf("%s\n\nRequired scopes: %s", cmd.Short, strings.Join(s.Security.Scopes, ", "))
 	}
 	return cmd
+}
+
+func controlFlagName(cmd *cobra.Command, name string) string {
+	if cmd.Flags().Lookup(name) == nil {
+		return name
+	}
+	base := "lathe-" + name
+	if cmd.Flags().Lookup(base) == nil {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", base, i)
+		if cmd.Flags().Lookup(candidate) == nil {
+			return candidate
+		}
+	}
 }
 
 func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequestBody bool) {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -808,6 +808,42 @@ func TestBuild_WaitFlagOnMutating(t *testing.T) {
 	}
 }
 
+func TestBuild_ControlFlagsAvoidOperationParameterCollisions(t *testing.T) {
+	names := []string{"all", "max-pages", "wait", "dry-run", "file", "set", "set-str"}
+	params := make([]ParamSpec, 0, len(names))
+	for _, name := range names {
+		params = append(params, ParamSpec{Name: name, Flag: name, In: InQuery, GoType: "string"})
+	}
+	params = append(params, ParamSpec{Name: "lathe-dry-run", Flag: "lathe-dry-run", In: InQuery, GoType: "string"})
+	specs := []CommandSpec{{
+		Group:       "Resources",
+		Use:         "create-resource",
+		Method:      "POST",
+		PathTpl:     "/resources",
+		Params:      params,
+		RequestBody: &RequestBody{MediaType: "application/json"},
+		Output: OutputHints{
+			Pagination: &PaginationHint{Strategy: "cursor", TokenParam: "page_token", TokenField: "next_page_token"},
+		},
+	}}
+
+	root := newRootWithModuleGroup()
+	mustBuild(t, root, "demo", specs)
+
+	create := mustFindChild(t, mustFindChild(t, mustFindChild(t, root, "demo"), "resources"), "create-resource")
+	for _, name := range names {
+		if create.Flag(name) == nil {
+			t.Errorf("create-resource missing operation parameter --%s", name)
+		}
+		if create.Flag("lathe-"+name) == nil {
+			t.Errorf("create-resource missing collision-safe control flag --lathe-%s", name)
+		}
+	}
+	if create.Flag("lathe-dry-run-2") == nil {
+		t.Error("create-resource missing deterministic fallback --lathe-dry-run-2")
+	}
+}
+
 func mustFindChild(t *testing.T, parent *cobra.Command, use string) *cobra.Command {
 	t.Helper()
 	for _, c := range parent.Commands() {


### PR DESCRIPTION
## What changed

- Parse Swagger 2.0 YAML inputs through the existing JSON model.
- Deduplicate repeated Swagger parameters by location and name, warning when duplicate definitions diverge.
- Preserve operation parameter flags and deterministically rename colliding Lathe control flags.

## Why

Real-world Swagger specs can be YAML, repeat parameters, or define names such as `all`, `file`, and `dry-run`. Those cases previously blocked generation or caused the generated CLI to panic while registering flags.

## Impact

Generated CLIs now accept these specs without losing API parameters or crashing. Existing control flag names remain unchanged when there is no collision.

## Verification

- `make check`
- `make build`
- `LATHE_BIN=/Users/x/git/samzong/lathe/bin/lathe node scripts/gate.mjs` in `lathe-registry` (all 14 recipes passed)
