### PR TITLE
fix(specsync): safely reuse shared checkouts

### DIFF
--- a/internal/specsync/git.go
+++ b/internal/specsync/git.go
@@ -28,7 +28,11 @@ func ensureRepo(workDir, repoURL, tag string) (string, error) {
 		if err := cmd.Run(); err != nil {
 			return "", fmt.Errorf("git clone: %w", err)
 		}
-		checkout := exec.Command("git", "-C", cloneDir, "-c", "advice.detachedHead=false", "checkout", "--quiet", tag)
+		checkoutRef := tag
+		if len(tag) != 40 || !isHex(tag) {
+			checkoutRef = qualifiedTagRef(tag)
+		}
+		checkout := exec.Command("git", "-C", cloneDir, "-c", "advice.detachedHead=false", "checkout", "--quiet", checkoutRef)
 		checkout.Stderr = os.Stderr
 		if err := checkout.Run(); err != nil {
 			return "", fmt.Errorf("git checkout %s: %w", tag, err)
@@ -69,10 +73,7 @@ func remoteRefSHA(repoURL, ref string) (string, error) {
 	if len(ref) == 40 && isHex(ref) {
 		return ref, nil
 	}
-	tagRef := ref
-	if !strings.HasPrefix(tagRef, "refs/tags/") {
-		tagRef = "refs/tags/" + tagRef
-	}
+	tagRef := qualifiedTagRef(ref)
 	peeledRef := tagRef + "^{}"
 	var out bytes.Buffer
 	cmd := exec.Command("git", "ls-remote", repoURL, tagRef, peeledRef)
@@ -102,6 +103,13 @@ func remoteRefSHA(repoURL, ref string) (string, error) {
 		return "", fmt.Errorf("git ref %q not found in remote", ref)
 	}
 	return sha, nil
+}
+
+func qualifiedTagRef(ref string) string {
+	if strings.HasPrefix(ref, "refs/tags/") {
+		return ref
+	}
+	return "refs/tags/" + ref
 }
 
 func repoSHA(workDir string) (string, error) {

--- a/internal/specsync/git.go
+++ b/internal/specsync/git.go
@@ -6,39 +6,105 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
-// ensureRepo clones or updates workDir to the given tag and returns the
-// resolved commit SHA. A tag moved upstream would produce a different SHA on
-// the next sync; VerifyState compares the stored sha to enforce that.
+// ensureRepo publishes a complete checkout atomically so concurrent syncs
+// never mutate the same worktree.
 func ensureRepo(workDir, repoURL, tag string) (string, error) {
 	gitDir := filepath.Join(workDir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(workDir), 0o755); err != nil {
 			return "", err
 		}
+		cloneDir, err := os.MkdirTemp(filepath.Dir(workDir), ".checkout-*")
+		if err != nil {
+			return "", err
+		}
+		defer func() { _ = os.RemoveAll(cloneDir) }()
 		fmt.Fprintf(os.Stderr, "=> clone %s\n", repoURL)
-		cmd := exec.Command("git", "clone", "--filter=blob:none", "--quiet", repoURL, workDir)
+		cmd := exec.Command("git", "clone", "--filter=blob:none", "--quiet", repoURL, cloneDir)
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			return "", fmt.Errorf("git clone: %w", err)
 		}
+		checkout := exec.Command("git", "-C", cloneDir, "-c", "advice.detachedHead=false", "checkout", "--quiet", tag)
+		checkout.Stderr = os.Stderr
+		if err := checkout.Run(); err != nil {
+			return "", fmt.Errorf("git checkout %s: %w", tag, err)
+		}
+		sha, err := repoSHA(cloneDir)
+		if err != nil {
+			return "", err
+		}
+		if err := os.Rename(cloneDir, workDir); err != nil {
+			if _, statErr := os.Stat(gitDir); statErr != nil {
+				return "", fmt.Errorf("publish git clone: %w", err)
+			}
+			return verifiedRepoSHA(workDir, repoURL, tag)
+		}
+		return sha, nil
 	} else if err != nil {
 		return "", err
-	} else {
-		fmt.Fprintf(os.Stderr, "=> fetch %s\n", workDir)
-		cmd := exec.Command("git", "-C", workDir, "fetch", "--tags", "--quiet")
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return "", fmt.Errorf("git fetch: %w", err)
+	}
+	return verifiedRepoSHA(workDir, repoURL, tag)
+}
+
+func verifiedRepoSHA(workDir, repoURL, ref string) (string, error) {
+	sha, err := repoSHA(workDir)
+	if err != nil {
+		return "", err
+	}
+	want, err := remoteRefSHA(repoURL, ref)
+	if err != nil {
+		return "", err
+	}
+	if sha != want {
+		return "", fmt.Errorf("configured ref %q changed upstream: cached checkout is %s, remote resolves to %s", ref, sha, want)
+	}
+	return sha, nil
+}
+
+func remoteRefSHA(repoURL, ref string) (string, error) {
+	if len(ref) == 40 && isHex(ref) {
+		return ref, nil
+	}
+	tagRef := ref
+	if !strings.HasPrefix(tagRef, "refs/tags/") {
+		tagRef = "refs/tags/" + tagRef
+	}
+	peeledRef := tagRef + "^{}"
+	var out bytes.Buffer
+	cmd := exec.Command("git", "ls-remote", repoURL, tagRef, peeledRef)
+	cmd.Stdout = &out
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git ls-remote %s: %w", ref, err)
+	}
+	var direct, peeled string
+	for _, line := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		switch fields[1] {
+		case tagRef:
+			direct = fields[0]
+		case peeledRef:
+			peeled = fields[0]
 		}
 	}
-	checkout := exec.Command("git", "-C", workDir, "-c", "advice.detachedHead=false", "checkout", "--quiet", tag)
-	checkout.Stderr = os.Stderr
-	if err := checkout.Run(); err != nil {
-		return "", fmt.Errorf("git checkout %s: %w", tag, err)
+	sha := peeled
+	if sha == "" {
+		sha = direct
 	}
+	if len(sha) != 40 || !isHex(sha) {
+		return "", fmt.Errorf("git ref %q not found in remote", ref)
+	}
+	return sha, nil
+}
 
+func repoSHA(workDir string) (string, error) {
 	var out bytes.Buffer
 	rev := exec.Command("git", "-C", workDir, "rev-parse", "HEAD")
 	rev.Stdout = &out

--- a/internal/specsync/sync.go
+++ b/internal/specsync/sync.go
@@ -1,6 +1,7 @@
 package specsync
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ type Options struct {
 func Sync(cfg *sourceconfig.Config, opts Options) error {
 	workRoot := filepath.Join(opts.CacheRoot, WorkSubdir)
 	syncRoot := filepath.Join(opts.CacheRoot, SyncSubdir)
+	checkouts := make(map[string]string)
 	if err := os.MkdirAll(workRoot, 0o755); err != nil {
 		return err
 	}
@@ -31,20 +33,24 @@ func Sync(cfg *sourceconfig.Config, opts Options) error {
 		if opts.Filter != "" && src.Name != opts.Filter {
 			continue
 		}
-		workDir := filepath.Join(workRoot, src.Name)
 		syncDir := filepath.Join(syncRoot, src.Name)
 		if err := os.RemoveAll(syncDir); err != nil {
 			return err
 		}
-		sourceDir := workDir
+		sourceDir := src.LocalPath
 		sha := ""
-		if src.LocalPath != "" {
-			sourceDir = src.LocalPath
-		} else {
-			var err error
-			sha, err = ensureRepo(workDir, src.RepoURL, src.PinnedTag)
-			if err != nil {
-				return fmt.Errorf("source %q: %w", src.Name, err)
+		if src.LocalPath == "" {
+			key := src.RepoURL + "\x00" + src.PinnedTag
+			sourceDir = filepath.Join(workRoot, fmt.Sprintf("%x", sha256.Sum256([]byte(key))))
+			if cached, ok := checkouts[key]; ok {
+				sha = cached
+			} else {
+				var err error
+				sha, err = ensureRepo(sourceDir, src.RepoURL, src.PinnedTag)
+				if err != nil {
+					return fmt.Errorf("source %q: %w", src.Name, err)
+				}
+				checkouts[key] = sha
 			}
 		}
 		switch src.Backend {

--- a/internal/specsync/sync_test.go
+++ b/internal/specsync/sync_test.go
@@ -1,0 +1,166 @@
+package specsync
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/lathe-cli/lathe/internal/sourceconfig"
+)
+
+func TestSyncRejectsMovedTagWithExistingCheckout(t *testing.T) {
+	upstream := filepath.Join(t.TempDir(), "upstream")
+	if err := os.MkdirAll(upstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = upstream
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "--quiet")
+	writeSpec := func(version int) {
+		t.Helper()
+		body := []byte(fmt.Sprintf("{\"version\":%d}\n", version))
+		if err := os.WriteFile(filepath.Join(upstream, "swagger.json"), body, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit("add", "swagger.json")
+		runGit("-c", "user.name=Lathe Test", "-c", "user.email=lathe@example.com", "commit", "--quiet", "-m", "fixture")
+	}
+	writeSpec(1)
+	runGit("tag", "v1.0.0")
+
+	cfg := &sourceconfig.Config{Sources: map[string]*sourceconfig.Source{
+		"demo": {
+			Name:      "demo",
+			RepoURL:   upstream,
+			PinnedTag: "v1.0.0",
+			Backend:   sourceconfig.BackendSwagger,
+			Swagger:   &sourceconfig.SwaggerConfig{Files: []string{"swagger.json"}},
+		},
+	}}
+	cache := t.TempDir()
+	if err := Sync(cfg, Options{CacheRoot: cache}); err != nil {
+		t.Fatal(err)
+	}
+	writeSpec(2)
+	runGit("tag", "-f", "v1.0.0")
+
+	err := Sync(cfg, Options{CacheRoot: cache})
+	if err == nil {
+		t.Fatal("Sync accepted a cached checkout after its configured tag moved upstream")
+	}
+	if !strings.Contains(err.Error(), "changed upstream") {
+		t.Fatalf("Sync error = %v, want moved-ref diagnostic", err)
+	}
+}
+
+func TestSyncConcurrentProcessesShareCheckout(t *testing.T) {
+	if name := os.Getenv("LATHE_SPECSYNC_CHILD"); name != "" {
+		cfg := &sourceconfig.Config{Sources: map[string]*sourceconfig.Source{
+			name: {
+				Name:      name,
+				RepoURL:   os.Getenv("LATHE_SPECSYNC_REPO"),
+				PinnedTag: "v1.0.0",
+				Backend:   sourceconfig.BackendSwagger,
+				Swagger:   &sourceconfig.SwaggerConfig{Files: []string{"swagger.json"}},
+			},
+		}}
+		if err := Sync(cfg, Options{CacheRoot: os.Getenv("LATHE_SPECSYNC_CACHE")}); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+
+	upstream := filepath.Join(t.TempDir(), "upstream")
+	if err := os.MkdirAll(upstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = upstream
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "--quiet")
+	if err := os.WriteFile(filepath.Join(upstream, "swagger.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "swagger.json")
+	runGit("-c", "user.name=Lathe Test", "-c", "user.email=lathe@example.com", "commit", "--quiet", "-m", "fixture")
+	runGit("tag", "v1.0.0")
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapperDir := t.TempDir()
+	barrierDir := t.TempDir()
+	wrapper := filepath.Join(wrapperDir, "git")
+	script := `#!/bin/sh
+if [ "$1" = "clone" ]; then
+  : > "$LATHE_SPECSYNC_BARRIER/ready-$$"
+  attempts=0
+  while :; do
+    ready=$(find "$LATHE_SPECSYNC_BARRIER" -name 'ready-*' -type f | wc -l | tr -d ' ')
+    [ "$ready" -ge 2 ] && break
+    attempts=$((attempts + 1))
+    [ "$attempts" -ge 500 ] && exit 99
+    sleep 0.01
+  done
+fi
+exec "$LATHE_SPECSYNC_REAL_GIT" "$@"
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := t.TempDir()
+	command := func(name string, output *bytes.Buffer) *exec.Cmd {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestSyncConcurrentProcessesShareCheckout$", "-test.count=1")
+		cmd.Env = append(os.Environ(),
+			"LATHE_SPECSYNC_CHILD="+name,
+			"LATHE_SPECSYNC_REPO="+upstream,
+			"LATHE_SPECSYNC_CACHE="+cache,
+			"LATHE_SPECSYNC_BARRIER="+barrierDir,
+			"LATHE_SPECSYNC_REAL_GIT="+realGit,
+			"PATH="+wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		)
+		cmd.Stdout = output
+		cmd.Stderr = output
+		return cmd
+	}
+	var outputA, outputB bytes.Buffer
+	cmdA := command("qdrant-a", &outputA)
+	cmdB := command("qdrant-b", &outputB)
+	if err := cmdA.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmdB.Start(); err != nil {
+		_ = cmdA.Process.Kill()
+		_ = cmdA.Wait()
+		t.Fatal(err)
+	}
+	errA := cmdA.Wait()
+	errB := cmdB.Wait()
+	if errA != nil || errB != nil {
+		t.Fatalf("concurrent sync failed: a=%v\n%s\nb=%v\n%s", errA, outputA.Bytes(), errB, outputB.Bytes())
+	}
+	checkouts, err := os.ReadDir(filepath.Join(cache, WorkSubdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checkouts) != 1 {
+		t.Fatalf("checkout count = %d, want 1", len(checkouts))
+	}
+}

--- a/internal/specsync/sync_test.go
+++ b/internal/specsync/sync_test.go
@@ -26,6 +26,7 @@ func TestSyncRejectsMovedTagWithExistingCheckout(t *testing.T) {
 		}
 	}
 	runGit("init", "--quiet")
+	runGit("branch", "-m", "v1.0.0")
 	writeSpec := func(version int) {
 		t.Helper()
 		body := []byte(fmt.Sprintf("{\"version\":%d}\n", version))
@@ -37,6 +38,7 @@ func TestSyncRejectsMovedTagWithExistingCheckout(t *testing.T) {
 	}
 	writeSpec(1)
 	runGit("tag", "v1.0.0")
+	writeSpec(2)
 
 	cfg := &sourceconfig.Config{Sources: map[string]*sourceconfig.Source{
 		"demo": {
@@ -51,10 +53,16 @@ func TestSyncRejectsMovedTagWithExistingCheckout(t *testing.T) {
 	if err := Sync(cfg, Options{CacheRoot: cache}); err != nil {
 		t.Fatal(err)
 	}
-	writeSpec(2)
+	synced, err := os.ReadFile(filepath.Join(cache, SyncSubdir, "demo", "swagger.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(synced) != "{\"version\":1}\n" {
+		t.Fatalf("synced spec = %q, want configured tag contents", synced)
+	}
 	runGit("tag", "-f", "v1.0.0")
 
-	err := Sync(cfg, Options{CacheRoot: cache})
+	err = Sync(cfg, Options{CacheRoot: cache})
 	if err == nil {
 		t.Fatal("Sync accepted a cached checkout after its configured tag moved upstream")
 	}


### PR DESCRIPTION
## Summary

- Key Git worktrees by repository and pinned ref so sources can share one checkout.
- Publish cloned worktrees atomically to prevent concurrent sync processes from mutating the same checkout.
- Revalidate cached tags against the remote commit and fail loudly when a tag moves.
- Cover concurrent checkout publication and moved-tag cache reuse with regression tests.

## Verification

- `make check`
- `go test -race ./internal/specsync`
- `go test ./internal/specsync -run '^TestSyncConcurrentProcessesShareCheckout$' -count=10`

## Compatibility

Generated command shape, catalog schema, auth, body, and output behavior are unchanged. Existing Git checkout caches remain reusable; a pinned tag that moves upstream now fails loudly instead of silently staging stale specs.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented by the existing stale-cache invariant.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
