### PR TITLE
feat(auth): let cli.yaml own login defaults and validate credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Defines CLI identity and optional auth validation behavior.
 | `cli.name` | Binary and command name, for example `acmectl`. |
 | `cli.short` | Root command summary. |
 | `auth.login` | Optional OAuth device login endpoints used by `auth login --device-auth`. |
-| `auth.validate` | Optional endpoint used by `auth status` to display the logged-in user. |
+| `auth.validate` | Optional endpoint used to validate credentials during login. Supports `assert.field` and `assert.non_empty`. |
 
 ### `specs/sources.yaml`
 

--- a/README.md
+++ b/README.md
@@ -296,12 +296,14 @@ go run ./cmd/lathe codegen -skill-root ""
 
 ### `cli.yaml`
 
-Defines CLI identity and optional auth validation behavior.
+Defines CLI identity and auth behavior.
 
 | Field | Notes |
 |---|---|
 | `cli.name` | Binary and command name, for example `acmectl`. |
 | `cli.short` | Root command summary. |
+| `auth.default_type` | Default `auth login` type: `bearer`, `apikey`, `basic`, or `oauth`. |
+| `auth.api_key_header` | API key header used by `apikey` login; defaults to `X-API-Key`. |
 | `auth.login` | Optional OAuth device login endpoints used by `auth login --device-auth`. |
 | `auth.validate` | Optional endpoint used to validate credentials during login. Supports `assert.field` and `assert.non_empty`. |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -252,7 +252,8 @@ go run ./cmd/lathe codegen -skill-root ""
 |---|---|
 | `cli.name` | 二进制和命令名称，例如 `acmectl`。 |
 | `cli.short` | 根命令摘要。 |
-| `auth.validate` | 可选端点，供 `auth status` 展示已登录用户。 |
+| `auth.login` | 可选 OAuth device login 端点，供 `auth login --device-auth` 使用。 |
+| `auth.validate` | 登录时校验凭据的可选端点，支持 `assert.field` 和 `assert.non_empty`。 |
 
 ### `specs/sources.yaml`
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -246,12 +246,14 @@ go run ./cmd/lathe codegen -skill-root ""
 
 ### `cli.yaml`
 
-定义 CLI 身份和可选的认证校验行为。
+定义 CLI 身份和认证行为。
 
 | 字段 | 说明 |
 |---|---|
 | `cli.name` | 二进制和命令名称，例如 `acmectl`。 |
 | `cli.short` | 根命令摘要。 |
+| `auth.default_type` | `auth login` 默认类型：`bearer`、`apikey`、`basic` 或 `oauth`。 |
+| `auth.api_key_header` | `apikey` 登录使用的请求头，默认 `X-API-Key`。 |
 | `auth.login` | 可选 OAuth device login 端点，供 `auth login --device-auth` 使用。 |
 | `auth.validate` | 登录时校验凭据的可选端点，支持 `assert.field` 和 `assert.non_empty`。 |
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -68,6 +68,9 @@ auth:
   validate:
     method: GET
     path: /api/v1/whoami
+    assert:
+      field: data.id
+      non_empty: true
     display:
       username_field: data.username
       fallback_field: data.email
@@ -86,6 +89,15 @@ module flat path and fail codegen on root command conflicts.
 `verification_uri`, optional `user_code`, `interval`, `expires_in`, and later
 `access_token`). `refresh_path` is optional; when present, generated commands
 refresh expired bearer tokens before execution.
+
+`auth.validate.assert.field` requires a dot-separated JSON response path;
+numeric path segments index arrays. Add `non_empty: true` to reject empty
+values. With no field, `non_empty: true` checks the raw response body, including
+plain-text endpoints. Display paths accept JSON scalar leaves.
+
+With neither `assert` nor a `display` path, `auth.validate` only proves the
+request succeeded and no longer requires a JSON response body. Endpoints that
+return 200 for anonymous callers need `assert` to reject invalid credentials.
 
 To customize generated Skill output, add an optional top-level `skill` block:
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -5,7 +5,7 @@ Lathe ships one generator binary: `lathe`.
 Use it in a target CLI repository that owns:
 
 - `go.mod`: the downstream module path for generated internal package imports.
-- `cli.yaml`: the generated CLI identity and optional auth validation config.
+- `cli.yaml`: the generated CLI identity and auth behavior.
 - `specs/sources.yaml`: declared upstream or local API specs.
 - `cmd/<cli-name>/main.go`: the thin runtime entrypoint for the generated CLI.
 
@@ -60,6 +60,8 @@ cli:
   short: "Command-line tool for Acme services"
 
 auth:
+  default_type: apikey
+  api_key_header: X-Auth-Token
   login:
     type: oauth_device
     start_path: /auth/device/start
@@ -89,6 +91,13 @@ module flat path and fail codegen on root command conflicts.
 `verification_uri`, optional `user_code`, `interval`, `expires_in`, and later
 `access_token`). `refresh_path` is optional; when present, generated commands
 refresh expired bearer tokens before execution.
+
+`auth.default_type` controls `auth login` when `--auth-type` is omitted and
+defaults to `bearer`; `oauth` requires an `auth.login` block. For API key login,
+`auth.api_key_header` replaces the `X-API-Key` default, including
+non-interactive `--with-token` login. The header is resolved at login time and
+stored in `hosts.yml`, so hosts logged in before the value changed keep their
+previous header until the next `auth login`.
 
 `auth.validate.assert.field` requires a dot-separated JSON response path;
 numeric path segments index arrays. Add `non_empty: true` to reject empty

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -215,7 +215,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 			hostname = config.NormalizeHostname(hostname)
 			authType = strings.ToLower(strings.TrimSpace(authType))
 			if deviceAuth {
-				if authType != "" && authType != "oauth" {
+				if cmd.Flags().Changed("auth-type") && authType != "oauth" {
 					return fmt.Errorf("--device-auth cannot be used with --auth-type %s", authType)
 				}
 				authType = "oauth"
@@ -241,8 +241,13 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					return errors.New("empty API key")
 				}
 				entry.APIKey = key
+				entry.APIKeyHeader = m.Auth.APIKeyHeader
 				if !withToken {
-					fmt.Fprint(os.Stderr, "? Header name [X-API-Key]: ")
+					header := entry.APIKeyHeader
+					if header == "" {
+						header = "X-API-Key"
+					}
+					fmt.Fprintf(os.Stderr, "? Header name [%s]: ", header)
 					line, err := readLine(os.Stdin)
 					if err != nil {
 						return err
@@ -311,7 +316,11 @@ func newLogin(m *config.Manifest) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&authType, "auth-type", "", "Authentication type: bearer (default), apikey, basic, oauth")
+	authTypeUsage := "Authentication type: bearer, apikey, basic, oauth"
+	if m.Auth.DefaultType == "" {
+		authTypeUsage = "Authentication type: bearer (default), apikey, basic, oauth"
+	}
+	cmd.Flags().StringVar(&authType, "auth-type", m.Auth.DefaultType, authTypeUsage)
 	cmd.Flags().StringVar(&provider, "provider", "", "OAuth provider hint passed to the service")
 	cmd.Flags().BoolVar(&withToken, "with-token", false, "Read token/key from stdin")
 	cmd.Flags().BoolVar(&deviceAuth, "device-auth", false, "Use OAuth device login")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -91,6 +92,64 @@ func TestOAuthDeviceLoginSavesBearerHost(t *testing.T) {
 		t.Fatal("host not saved")
 	}
 	if entry.AuthType != "bearer" || entry.LoginType != config.AuthLoginOAuthDevice || entry.LoginProvider != "github" || entry.OAuthToken != "access-1" || entry.OAuthRefreshToken != "refresh-1" || entry.User != "octo@example.com" || entry.OAuthExpiresAt == 0 {
+		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestAPIKeyLoginUsesManifestDefaults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-Auth-Token"); got != "secret" {
+			t.Errorf("X-Auth-Token = %q, want secret", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+		Auth: config.AuthInfo{
+			DefaultType:  "apikey",
+			APIKeyHeader: "X-Auth-Token",
+			Validate:     &config.AuthValidate{Path: "/", Assert: &config.AuthValidateAssert{Field: "ok", NonEmpty: true}},
+		},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+
+	stdin, input, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := input.WriteString("secret\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.Close(); err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	defer func() {
+		stdin.Close()
+		os.Stdin = oldStdin
+	}()
+
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", srv.URL, "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--with-token"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	entry, ok := hosts.Get(srv.URL)
+	if !ok {
+		t.Fatal("host not saved")
+	}
+	if entry.AuthType != "apikey" || entry.APIKey != "secret" || entry.APIKeyHeader != "X-Auth-Token" {
 		t.Fatalf("entry = %+v", entry)
 	}
 }

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -1,9 +1,12 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,10 +18,8 @@ type validateResult struct {
 	Username string
 }
 
-// validateToken hits the auth validation endpoint declared by cli.yaml and
-// plucks a display username from the JSON response. A nil v means the
-// manifest has no auth.validate block, which is equivalent to passing
-// --skip-validate: returns a zero result with nil error.
+// validateWithAuth checks the endpoint and optional success assertion declared
+// by cli.yaml. A nil v is equivalent to passing --skip-validate.
 func validateWithAuth(ctx context.Context, hostname string, auth runtime.Authenticator, v *config.AuthValidate, opts runtime.ClientOptions) (validateResult, error) {
 	if v == nil {
 		return validateResult{}, nil
@@ -35,42 +36,92 @@ func validateWithAuth(ctx context.Context, hostname string, auth runtime.Authent
 	if err != nil {
 		return validateResult{}, err
 	}
-	if len(data) == 0 {
+	assertField := v.Assert != nil && v.Assert.Field != ""
+	needsJSON := assertField || v.Display.UsernameField != "" || v.Display.FallbackField != ""
+	if len(bytes.TrimSpace(data)) == 0 {
+		if v.Assert != nil && (v.Assert.NonEmpty || assertField) {
+			return validateResult{}, fmt.Errorf("validation assertion failed: response body is empty")
+		}
 		return validateResult{}, nil
 	}
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
+	if !needsJSON {
+		return validateResult{}, nil
+	}
+	var raw any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&raw); err != nil {
 		return validateResult{}, fmt.Errorf("decode response: %w", err)
 	}
-	user := pluck(raw, v.Display.UsernameField)
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return validateResult{}, fmt.Errorf("decode response: unexpected trailing data")
+	}
+	if assertField {
+		value, ok := pluck(raw, v.Assert.Field)
+		if !ok {
+			return validateResult{}, fmt.Errorf("validation assertion failed: field %q is missing", v.Assert.Field)
+		}
+		if v.Assert.NonEmpty && !nonEmpty(value) {
+			return validateResult{}, fmt.Errorf("validation assertion failed: field %q is empty", v.Assert.Field)
+		}
+	}
+	user := pluckString(raw, v.Display.UsernameField)
 	if user == "" {
-		user = pluck(raw, v.Display.FallbackField)
+		user = pluckString(raw, v.Display.FallbackField)
 	}
 	return validateResult{Username: user}, nil
 }
 
-// pluck walks a dot-separated path (e.g. "data.user.name") through a decoded
-// JSON object and returns the final value as a string. A plain key
-// (e.g. "username") walks a single step. Returns "" if any segment is
-// missing or if the leaf is not a string.
-func pluck(raw map[string]any, path string) string {
+func pluck(raw any, path string) (any, bool) {
 	if path == "" {
-		return ""
+		return nil, false
 	}
-	var cur any = raw
-	for _, p := range strings.Split(path, ".") {
-		m, ok := cur.(map[string]any)
-		if !ok {
-			return ""
+	cur := raw
+	for _, part := range strings.Split(path, ".") {
+		var ok bool
+		switch value := cur.(type) {
+		case map[string]any:
+			cur, ok = value[part]
+		case []any:
+			index, err := strconv.Atoi(part)
+			if err != nil || index < 0 || index >= len(value) {
+				return nil, false
+			}
+			cur, ok = value[index], true
+		default:
+			return nil, false
 		}
-		cur, ok = m[p]
 		if !ok {
-			return ""
+			return nil, false
 		}
 	}
-	s, ok := cur.(string)
+	return cur, true
+}
+
+func pluckString(raw any, path string) string {
+	value, ok := pluck(raw, path)
 	if !ok {
 		return ""
 	}
-	return s
+	switch value.(type) {
+	case nil, map[string]any, []any:
+		return ""
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+func nonEmpty(value any) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case string:
+		return strings.TrimSpace(value) != ""
+	case map[string]any:
+		return len(value) > 0
+	case []any:
+		return len(value) > 0
+	default:
+		return true
+	}
 }

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,23 +14,59 @@ import (
 func TestPluck(t *testing.T) {
 	cases := []struct {
 		name string
-		raw  map[string]any
+		raw  any
 		path string
-		want string
+		want any
+		ok   bool
 	}{
-		{"flat hit", map[string]any{"username": "alice"}, "username", "alice"},
-		{"flat miss", map[string]any{"username": "alice"}, "missing", ""},
-		{"nested hit", map[string]any{"data": map[string]any{"user": map[string]any{"name": "bob"}}}, "data.user.name", "bob"},
-		{"nested leaf miss", map[string]any{"data": map[string]any{"user": map[string]any{}}}, "data.user.name", ""},
-		{"nested mid miss", map[string]any{"data": map[string]any{}}, "data.user.name", ""},
-		{"non-string value", map[string]any{"n": 42}, "n", ""},
-		{"empty path", map[string]any{"username": "alice"}, "", ""},
+		{"flat hit", map[string]any{"username": "alice"}, "username", "alice", true},
+		{"flat miss", map[string]any{"username": "alice"}, "missing", nil, false},
+		{"nested hit", map[string]any{"data": map[string]any{"user": map[string]any{"name": "bob"}}}, "data.user.name", "bob", true},
+		{"nested leaf miss", map[string]any{"data": map[string]any{"user": map[string]any{}}}, "data.user.name", nil, false},
+		{"nested mid miss", map[string]any{"data": map[string]any{}}, "data.user.name", nil, false},
+		{"array hit", []any{map[string]any{"id": "u1"}}, "0.id", "u1", true},
+		{"array miss", []any{}, "0.id", nil, false},
+		{"array bad index", []any{map[string]any{"id": "u1"}}, "id", nil, false},
+		{"empty path", map[string]any{"username": "alice"}, "", nil, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := pluck(tc.raw, tc.path)
-			if got != tc.want {
-				t.Errorf("pluck(%v, %q) = %q, want %q", tc.raw, tc.path, got, tc.want)
+			got, ok := pluck(tc.raw, tc.path)
+			if got != tc.want || ok != tc.ok {
+				t.Errorf("pluck(%v, %q) = (%v, %v), want (%v, %v)", tc.raw, tc.path, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestPluckString pins the display contract: scalar leaves render as strings
+// (JSON numbers keep their literal form), while containers and misses render
+// as empty so the caller falls through to fallback_field.
+func TestPluckString(t *testing.T) {
+	raw := map[string]any{
+		"name":   "alice",
+		"id":     json.Number("9007199254740993"),
+		"active": true,
+		"obj":    map[string]any{"k": "v"},
+		"arr":    []any{"a"},
+		"null":   nil,
+	}
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"name", "alice"},
+		{"id", "9007199254740993"},
+		{"active", "true"},
+		{"obj", ""},
+		{"arr", ""},
+		{"null", ""},
+		{"missing", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			if got := pluckString(raw, tc.path); got != tc.want {
+				t.Errorf("pluckString(%q) = %q, want %q", tc.path, got, tc.want)
 			}
 		})
 	}
@@ -120,5 +157,68 @@ func TestValidateToken_NestedPluck(t *testing.T) {
 	}
 	if r.Username != "carol" {
 		t.Errorf("want carol, got %q", r.Username)
+	}
+}
+
+// TestValidateToken_NoAssertNoDisplaySkipsDecode pins the loosening introduced
+// alongside auth.validate.assert: with neither an assertion nor a display path,
+// validation only proves the request succeeded and no longer rejects a
+// non-JSON body.
+func TestValidateToken_NoAssertNoDisplaySkipsDecode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("v4.0.0"))
+	}))
+	defer srv.Close()
+
+	v := &config.AuthValidate{Path: "/"}
+	r, err := validateWithAuth(context.Background(), srv.URL, runtime.BearerAuth{Token: "tok"}, v, runtime.ClientOptions{})
+	if err != nil {
+		t.Fatalf("validateWithAuth: %v", err)
+	}
+	if r.Username != "" {
+		t.Errorf("Username = %q, want empty", r.Username)
+	}
+}
+
+func TestValidateToken_Assertions(t *testing.T) {
+	responses := map[string]string{
+		"/array":     `[{"id":42}]`,
+		"/anonymous": `{"message":"ok"}`,
+		"/text":      "v4.0.0",
+		"/empty":     " \n",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(responses[r.URL.Path]))
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		path     string
+		assert   config.AuthValidateAssert
+		display  string
+		wantUser string
+		wantErr  bool
+	}{
+		{"array scalar", "/array", config.AuthValidateAssert{Field: "0.id", NonEmpty: true}, "0.id", "42", false},
+		{"missing field", "/anonymous", config.AuthValidateAssert{Field: "user.id", NonEmpty: true}, "", "", true},
+		{"plain text", "/text", config.AuthValidateAssert{NonEmpty: true}, "", "", false},
+		{"empty body", "/empty", config.AuthValidateAssert{NonEmpty: true}, "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := &config.AuthValidate{
+				Path:    tc.path,
+				Assert:  &tc.assert,
+				Display: config.AuthValidateDisplay{UsernameField: tc.display},
+			}
+			result, err := validateWithAuth(context.Background(), srv.URL, runtime.BearerAuth{Token: "tok"}, v, runtime.ClientOptions{})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateWithAuth error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if result.Username != tc.wantUser {
+				t.Fatalf("Username = %q, want %q", result.Username, tc.wantUser)
+			}
+		})
 	}
 }

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -26,8 +26,10 @@ type CLIInfo struct {
 }
 
 type AuthInfo struct {
-	Validate *AuthValidate `yaml:"validate,omitempty"`
-	Login    *AuthLogin    `yaml:"login,omitempty"`
+	DefaultType  string        `yaml:"default_type,omitempty"`
+	APIKeyHeader string        `yaml:"api_key_header,omitempty"`
+	Validate     *AuthValidate `yaml:"validate,omitempty"`
+	Login        *AuthLogin    `yaml:"login,omitempty"`
 }
 
 type UpdateInfo struct {
@@ -147,6 +149,13 @@ func Load(bytes []byte) (*Manifest, error) {
 			return nil, fmt.Errorf("update.github.owner, update.github.repo, and update.github.asset are required")
 		}
 	}
+	m.Auth.DefaultType = strings.ToLower(strings.TrimSpace(m.Auth.DefaultType))
+	m.Auth.APIKeyHeader = strings.TrimSpace(m.Auth.APIKeyHeader)
+	switch m.Auth.DefaultType {
+	case "", "bearer", "apikey", "basic", "oauth":
+	default:
+		return nil, fmt.Errorf("auth.default_type must be one of bearer, apikey, basic, or oauth")
+	}
 	if m.Auth.Validate != nil && m.Auth.Validate.Assert != nil {
 		m.Auth.Validate.Assert.Field = strings.TrimSpace(m.Auth.Validate.Assert.Field)
 		if m.Auth.Validate.Assert.Field == "" && !m.Auth.Validate.Assert.NonEmpty {
@@ -170,6 +179,8 @@ func Load(bytes []byte) (*Manifest, error) {
 		if m.Auth.Login.RefreshPath != "" && !strings.HasPrefix(m.Auth.Login.RefreshPath, "/") {
 			return nil, fmt.Errorf("auth.login.refresh_path must start with /")
 		}
+	} else if m.Auth.DefaultType == "oauth" {
+		return nil, fmt.Errorf("auth.default_type oauth requires an auth.login block")
 	}
 	m.CLI.CommandPath = strings.ToLower(strings.TrimSpace(m.CLI.CommandPath))
 	if m.CLI.CommandPath == "" {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -100,11 +100,17 @@ type AuthValidate struct {
 	Method  string              `yaml:"method"`
 	Path    string              `yaml:"path"`
 	Display AuthValidateDisplay `yaml:"display"`
+	Assert  *AuthValidateAssert `yaml:"assert,omitempty"`
 }
 
 type AuthValidateDisplay struct {
 	UsernameField string `yaml:"username_field"`
 	FallbackField string `yaml:"fallback_field"`
+}
+
+type AuthValidateAssert struct {
+	Field    string `yaml:"field,omitempty"`
+	NonEmpty bool   `yaml:"non_empty,omitempty"`
 }
 
 const (
@@ -139,6 +145,12 @@ func Load(bytes []byte) (*Manifest, error) {
 		m.Update.GitHub.Asset = strings.TrimSpace(m.Update.GitHub.Asset)
 		if m.Update.GitHub.Owner == "" || m.Update.GitHub.Repo == "" || m.Update.GitHub.Asset == "" {
 			return nil, fmt.Errorf("update.github.owner, update.github.repo, and update.github.asset are required")
+		}
+	}
+	if m.Auth.Validate != nil && m.Auth.Validate.Assert != nil {
+		m.Auth.Validate.Assert.Field = strings.TrimSpace(m.Auth.Validate.Assert.Field)
+		if m.Auth.Validate.Assert.Field == "" && !m.Auth.Validate.Assert.NonEmpty {
+			return nil, fmt.Errorf("auth.validate.assert requires field or non_empty")
 		}
 	}
 	if m.Auth.Login != nil {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -19,6 +19,9 @@ auth:
   validate:
     method: POST
     path: /whoami
+    assert:
+      field: user.id
+      non_empty: true
     display:
       username_field: user.name
       fallback_field: uid
@@ -41,6 +44,9 @@ auth:
 	}
 	if m.Auth.Validate.Method != "POST" || m.Auth.Validate.Path != "/whoami" {
 		t.Errorf("unexpected AuthValidate: %+v", m.Auth.Validate)
+	}
+	if m.Auth.Validate.Assert == nil || m.Auth.Validate.Assert.Field != "user.id" || !m.Auth.Validate.Assert.NonEmpty {
+		t.Errorf("unexpected AuthValidate.Assert: %+v", m.Auth.Validate.Assert)
 	}
 	if m.Auth.Validate.Display.UsernameField != "user.name" {
 		t.Errorf("unexpected UsernameField: %q", m.Auth.Validate.Display.UsernameField)
@@ -249,6 +255,17 @@ auth:
     type: oauth_device
     start_path: start
     token_path: /token
+`,
+		},
+		{
+			name: "empty assertion",
+			yaml: `
+cli:
+  name: demo
+auth:
+  validate:
+    path: /whoami
+    assert: {}
 `,
 		},
 	}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -11,6 +11,8 @@ cli:
   name: demo
   short: "demo CLI"
 auth:
+  default_type: apikey
+  api_key_header: X-Auth-Token
   login:
     type: oauth_device
     start_path: /auth/cli/start
@@ -38,6 +40,9 @@ auth:
 	}
 	if m.Auth.Login == nil {
 		t.Fatal("expected Auth.Login non-nil")
+	}
+	if m.Auth.DefaultType != "apikey" || m.Auth.APIKeyHeader != "X-Auth-Token" {
+		t.Errorf("unexpected auth defaults: %+v", m.Auth)
 	}
 	if m.Auth.Login.Type != AuthLoginOAuthDevice || m.Auth.Login.StartPath != "/auth/cli/start" || m.Auth.Login.TokenPath != "/auth/cli/token" || m.Auth.Login.RefreshPath != "/auth/cli/refresh" {
 		t.Errorf("unexpected AuthLogin: %+v", m.Auth.Login)
@@ -255,6 +260,24 @@ auth:
     type: oauth_device
     start_path: start
     token_path: /token
+`,
+		},
+		{
+			name: "unsupported default auth type",
+			yaml: `
+cli:
+  name: demo
+auth:
+  default_type: digest
+`,
+		},
+		{
+			name: "oauth default without login block",
+			yaml: `
+cli:
+  name: demo
+auth:
+  default_type: oauth
 `,
 		},
 		{


### PR DESCRIPTION
Two commits, each independently green under `make check`.

## `feat(auth): assert credentials during login validation`

`auth.validate` only plucked a display username from the response, so any endpoint answering 200 for anonymous callers reported a successful login with an invalid credential. Adds an optional `auth.validate.assert` block requiring a response field to be present, and optionally non-empty, before login succeeds.

`pluck` now returns `(value, ok)` so a missing field is distinguishable from an empty one, walks numeric segments into JSON arrays, and decodes with `UseNumber` so large integer ids keep their literal form. Display paths render any scalar leaf instead of strings only.

Behavior change worth flagging for existing downstreams: with neither `assert` nor a `display` path, validation no longer requires a JSON response body (previously any non-JSON 200 failed login with `decode response`). Documented in `docs/cli-usage.md` and pinned by `TestValidateToken_NoAssertNoDisplaySkipsDecode`.

## `feat(auth): take login defaults from cli.yaml`

`entry.APIKeyHeader` was only assigned inside the interactive prompt branch, so `--with-token` always fell back to the runtime `X-API-Key` default — any API keyed on a different header was unusable from CI. Adds `auth.default_type` and `auth.api_key_header`; the header is now resolved on both the interactive and `--with-token` paths.

`--device-auth` keys its conflict check on whether `--auth-type` was explicitly passed, so a non-oauth `default_type` no longer blocks device login. `Load` rejects an unknown `default_type`, and rejects `oauth` without an `auth.login` block instead of deferring that failure to login time.

The header is resolved at login time and stored in `hosts.yml`, so hosts logged in before the value changed keep their previous header until the next `auth login` — documented.

## Compatibility

`pkg/config` gains fields and one type, no removals or renames. `default_type` and `assert` are new keys, so the added validation cannot reject an existing `cli.yaml`. `pkg/runtime` is untouched; `internal/codegen/render/skill.go` only renders `auth login --device-auth`, so generated Skill output is unaffected.

## Verification

- `make check` — gofmt, `go vet`, `golangci-lint` (0 issues), `go test ./...`
- `go test -race -count=1 ./internal/auth/... ./pkg/config/... ./pkg/runtime/...`
- Both run on each commit individually, not just the tip.