### PR TITLE
feat(workflow): guard steps with when conditions

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -38,7 +38,8 @@ operations. It can remain custom Go until diagnostic primitives are designed.
 The first version does not support:
 
 - Rollback or compensation.
-- `if` / `else`, loops, parallel steps, or workflow-specific retry policy.
+- `if` / `else` blocks, loops, parallel steps, or workflow-specific retry
+  policy. Steps can be guarded individually with `when`; see Conditional Steps.
 - Shell commands or external actions.
 - Dynamic plugins or remote extension code.
 - A public `GeneratedApp` or workflow engine ABI.
@@ -165,6 +166,42 @@ steps:
       input.label: ${input.label}
 ```
 
+## Conditional Steps
+
+A step can be guarded with `when`. Conditions are joined with AND; values within
+one condition are joined with OR.
+
+```yaml
+steps:
+  - id: label
+    uses: console.Apps_SetLabel
+    when:
+      - value: ${input.label}
+        operator: notin
+        values: [""]
+    params:
+      appId: ${input.app_id}
+```
+
+`operator` is `in` or `notin` and is required. Comparison is string comparison,
+so `values: [404]` and `values: ["404"]` are equivalent.
+
+A reference that does not resolve evaluates to the empty string inside `when`,
+which makes `notin [""]` the way to ask whether an optional input was provided.
+
+A step whose condition is false is `skipped`: no request is sent, and no host or
+credential loading happens for it. A later step that references a skipped step
+is skipped as well, transitively. If `output.from` references a skipped step,
+the command emits the step summary instead of failing.
+
+Because every `${steps.<id>}` reference names one specific step, conditions
+cannot express branch convergence — a step reading `${steps.deploy_gpu.id}` is
+skipped whenever the CPU branch ran instead. Guarded steps should either be
+terminal or belong to branches that never rejoin.
+
+There is no `else`. Two complementary conditions express a two-way branch, and
+Lathe does not check that they are mutually exclusive or exhaustive.
+
 ## Output
 
 If `output.from` is set, the command outputs that referenced value using the
@@ -250,8 +287,20 @@ Workflow commands use:
 }
 ```
 
-The catalog schema version is `11` for this contract. Generated binaries with
-workflow commands also attach capability:
+The catalog schema version is `12` for this contract. Conditional steps carry
+their conditions in catalog JSON, so an agent can tell a step is guarded without
+running it:
+
+```json
+{
+  "id": "label",
+  "operation_id": "Apps_SetLabel",
+  "http": {"method": "POST", "path_template": "/apps/{appId}/label"},
+  "when": [{"value": "${input.label}", "operator": "notin", "values": [""]}]
+}
+```
+
+Generated binaries with workflow commands also attach capability:
 
 ```text
 workflow.dsl
@@ -266,5 +315,6 @@ compiled in:
 - Every workflow command appears in catalog JSON as `kind=workflow`.
 - Every workflow command has workflow metadata.
 - Every workflow step has an ID and operation HTTP metadata.
+- Every step condition has a value, a valid operator, and at least one value.
 
 The verify report schema does not change.

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -688,6 +688,9 @@ func workflowStepSpecsLiteral(steps []runtime.WorkflowStepSpec) string {
 		b.WriteString("runtime.WorkflowStepSpec{")
 		writeStringField(&b, "ID", step.ID)
 		fmt.Fprintf(&b, "Operation: %s,", commandSpecLiteral(step.Operation))
+		if len(step.When) > 0 {
+			fmt.Fprintf(&b, "When: %s,", workflowConditionsLiteral(step.When))
+		}
 		if len(step.Params) > 0 {
 			fmt.Fprintf(&b, "Params: %s,", stringMapLiteral(step.Params))
 		}
@@ -698,6 +701,23 @@ func workflowStepSpecsLiteral(steps []runtime.WorkflowStepSpec) string {
 			fmt.Fprintf(&b, "BodyStringSets: %s,", workflowValuesLiteral(step.BodyStringSets))
 		}
 		b.WriteString("},")
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func workflowConditionsLiteral(conditions []runtime.WorkflowCondition) string {
+	var b strings.Builder
+	b.WriteString("[]runtime.WorkflowCondition{")
+	for _, cond := range conditions {
+		b.WriteString("runtime.WorkflowCondition{")
+		writeStringField(&b, "Value", cond.Value)
+		writeStringField(&b, "Operator", cond.Operator)
+		b.WriteString("Values: []string{")
+		for _, value := range cond.Values {
+			fmt.Fprintf(&b, "%q,", value)
+		}
+		b.WriteString("},},")
 	}
 	b.WriteByte('}')
 	return b.String()

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -765,3 +765,41 @@ func TestValidateModuleNames(t *testing.T) {
 		t.Fatalf("Cobra-normalized duplicate module names should be rejected, got %v", err)
 	}
 }
+
+func TestRenderWorkflows_EmitsStepConditions(t *testing.T) {
+	chdirWithGeneratedRoot(t)
+
+	specs := []runtime.WorkflowSpec{{
+		Use: "deploy",
+		Steps: []runtime.WorkflowStepSpec{{
+			ID: "gpu",
+			Operation: runtime.CommandSpec{
+				Group:       "Apps",
+				Use:         "deploy-gpu",
+				Method:      "POST",
+				PathTpl:     "/apps/gpu",
+				OperationID: "Apps_DeployGPU",
+			},
+			When: []runtime.WorkflowCondition{
+				{Value: "${input.kind}", Operator: "in", Values: []string{"gpu", "404"}},
+				{Value: "${input.label}", Operator: "notin", Values: []string{""}},
+			},
+		}},
+	}}
+
+	if err := RenderWorkflows(specs); err != nil {
+		t.Fatalf("RenderWorkflows: %v", err)
+	}
+	got := generatedWorkflows(t)
+	for _, want := range []string{
+		`When: []runtime.WorkflowCondition{`,
+		`Value: "${input.kind}"`,
+		`Operator: "in"`,
+		`Values: []string{"gpu", "404"}`,
+		`Operator: "notin"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/lathecmd/workflow.go
+++ b/internal/lathecmd/workflow.go
@@ -63,6 +63,7 @@ func buildWorkflowSpecs(manifest *config.Manifest, modules []app.Module, shortcu
 			workflow.Steps = append(workflow.Steps, runtime.WorkflowStepSpec{
 				ID:             step.ID,
 				Operation:      ref,
+				When:           workflowConditions(step.When),
 				Params:         maps.Clone(step.Params),
 				BodySets:       workflowValues(step.Set),
 				BodyStringSets: workflowValues(step.SetStr),
@@ -210,6 +211,11 @@ func workflowOperationName(spec runtime.CommandSpec) string {
 }
 
 func validateWorkflowStepRefs(step config.WorkflowStep, inputs map[string]bool, steps map[string]bool) error {
+	for i, cond := range step.When {
+		if err := validateWorkflowRefs(cond.Value, inputs, steps); err != nil {
+			return fmt.Errorf("when[%d]: %w", i, err)
+		}
+	}
 	for key, expr := range step.Params {
 		if err := validateWorkflowRefs(expr, inputs, steps); err != nil {
 			return fmt.Errorf("param %q: %w", key, err)
@@ -285,6 +291,21 @@ func workflowInputs(inputs []config.WorkflowInput) []runtime.ParamSpec {
 			Enum:       append([]string(nil), input.Enum...),
 			Format:     input.Format,
 			Deprecated: input.Deprecated,
+		})
+	}
+	return out
+}
+
+func workflowConditions(conditions []config.WorkflowCondition) []runtime.WorkflowCondition {
+	if len(conditions) == 0 {
+		return nil
+	}
+	out := make([]runtime.WorkflowCondition, 0, len(conditions))
+	for _, cond := range conditions {
+		out = append(out, runtime.WorkflowCondition{
+			Value:    cond.Value,
+			Operator: cond.Operator,
+			Values:   append([]string(nil), cond.Values...),
 		})
 	}
 	return out

--- a/internal/lathecmd/workflow_test.go
+++ b/internal/lathecmd/workflow_test.go
@@ -1,0 +1,102 @@
+package lathecmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lathe-cli/lathe/internal/codegen/app"
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+func TestBuildWorkflowSpecs_CarriesConditions(t *testing.T) {
+	specs, err := buildWorkflowSpecs(workflowManifestWithSteps([]config.WorkflowStep{{
+		ID:   "deploy",
+		Uses: "console.Apps_Get",
+		When: []config.WorkflowCondition{{
+			Value:    "${input.kind}",
+			Operator: "in",
+			Values:   config.WorkflowConditionValues{"gpu"},
+		}},
+	}}), conditionTestModules(), nil)
+	if err != nil {
+		t.Fatalf("buildWorkflowSpecs: %v", err)
+	}
+	got := specs[0].Steps[0].When
+	if len(got) != 1 || got[0].Value != "${input.kind}" || got[0].Operator != "in" {
+		t.Fatalf("conditions = %#v", got)
+	}
+	if len(got[0].Values) != 1 || got[0].Values[0] != "gpu" {
+		t.Fatalf("values = %#v", got[0].Values)
+	}
+}
+
+func TestBuildWorkflowSpecs_RejectsBadConditionReferences(t *testing.T) {
+	cases := map[string]struct {
+		steps []config.WorkflowStep
+		want  string
+	}{
+		"unknown input": {
+			steps: []config.WorkflowStep{{
+				ID:   "deploy",
+				Uses: "console.Apps_Get",
+				When: []config.WorkflowCondition{{
+					Value:    "${input.missing}",
+					Operator: "in",
+					Values:   config.WorkflowConditionValues{"gpu"},
+				}},
+			}},
+			want: `unknown input "missing"`,
+		},
+		"forward step": {
+			steps: []config.WorkflowStep{{
+				ID:   "deploy",
+				Uses: "console.Apps_Get",
+				When: []config.WorkflowCondition{{
+					Value:    "${steps.later.id}",
+					Operator: "in",
+					Values:   config.WorkflowConditionValues{"gpu"},
+				}},
+			}, {
+				ID:   "later",
+				Uses: "console.Apps_Get",
+			}},
+			want: `unknown or forward step "later"`,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := buildWorkflowSpecs(workflowManifestWithSteps(tc.steps), conditionTestModules(), nil)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func workflowManifestWithSteps(steps []config.WorkflowStep) *config.Manifest {
+	return &config.Manifest{
+		Workflow: config.WorkflowInfo{
+			Version: 1,
+			Commands: []config.WorkflowCommand{{
+				Use:    "deploy",
+				Inputs: []config.WorkflowInput{{Name: "kind", Flag: "kind", Type: "string"}},
+				Steps:  steps,
+			}},
+		},
+	}
+}
+
+func conditionTestModules() []app.Module {
+	return []app.Module{{
+		Source:  "console",
+		CLIName: "console",
+		Specs: []runtime.CommandSpec{{
+			OperationID: "Apps_Get",
+			Group:       "Apps",
+			Use:         "get",
+			Method:      "GET",
+			PathTpl:     "/apps",
+		}},
+	}}
+}

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -71,11 +71,38 @@ type WorkflowInput struct {
 }
 
 type WorkflowStep struct {
-	ID     string            `yaml:"id"`
-	Uses   string            `yaml:"uses"`
-	Params map[string]string `yaml:"params,omitempty"`
-	Set    map[string]string `yaml:"set,omitempty"`
-	SetStr map[string]string `yaml:"set_str,omitempty"`
+	ID     string              `yaml:"id"`
+	Uses   string              `yaml:"uses"`
+	When   []WorkflowCondition `yaml:"when,omitempty"`
+	Params map[string]string   `yaml:"params,omitempty"`
+	Set    map[string]string   `yaml:"set,omitempty"`
+	SetStr map[string]string   `yaml:"set_str,omitempty"`
+}
+
+type WorkflowCondition struct {
+	Value    string                  `yaml:"value"`
+	Operator string                  `yaml:"operator"`
+	Values   WorkflowConditionValues `yaml:"values"`
+}
+
+// WorkflowConditionValues accepts any scalar list so that `values: [404]` and
+// `values: ["404"]` are both valid. Comparison is always string comparison, so
+// items are kept in their source form.
+type WorkflowConditionValues []string
+
+func (v *WorkflowConditionValues) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.SequenceNode {
+		return fmt.Errorf("workflow condition values must be a list")
+	}
+	out := make(WorkflowConditionValues, 0, len(node.Content))
+	for _, item := range node.Content {
+		if item.Kind != yaml.ScalarNode {
+			return fmt.Errorf("workflow condition values must contain scalars")
+		}
+		out = append(out, item.Value)
+	}
+	*v = out
+	return nil
 }
 
 type WorkflowOutput struct {
@@ -275,6 +302,20 @@ func normalizeWorkflow(workflow *WorkflowInfo) error {
 			if step.Uses == "" {
 				return fmt.Errorf("workflow command %q step %q uses is required", cmd.Use, step.ID)
 			}
+			for k := range step.When {
+				cond := &step.When[k]
+				cond.Value = strings.TrimSpace(cond.Value)
+				cond.Operator = strings.ToLower(strings.TrimSpace(cond.Operator))
+				if cond.Value == "" {
+					return fmt.Errorf("workflow command %q step %q when[%d].value is required", cmd.Use, step.ID, k)
+				}
+				if !validWorkflowOperator(cond.Operator) {
+					return fmt.Errorf("workflow command %q step %q when[%d].operator must be %q or %q", cmd.Use, step.ID, k, "in", "notin")
+				}
+				if len(cond.Values) == 0 {
+					return fmt.Errorf("workflow command %q step %q when[%d].values must not be empty", cmd.Use, step.ID, k)
+				}
+			}
 		}
 	}
 	return nil
@@ -284,6 +325,15 @@ func workflowInputFlag(name string) string {
 	name = strings.ReplaceAll(name, "_", "-")
 	name = strings.ReplaceAll(name, ".", "-")
 	return name
+}
+
+func validWorkflowOperator(value string) bool {
+	switch value {
+	case "in", "notin":
+		return true
+	default:
+		return false
+	}
 }
 
 func validWorkflowInputType(value string) bool {

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -86,8 +87,17 @@ type WorkflowCondition struct {
 }
 
 // WorkflowConditionValues accepts any scalar list so that `values: [404]` and
-// `values: ["404"]` are both valid. Comparison is always string comparison, so
-// items are kept in their source form.
+// `values: ["404"]` are both valid.
+//
+// Comparison at runtime is string comparison against a value formatted by
+// runtime.workflowString, so typed scalars are normalized the same way here.
+// Keeping the YAML source form would make `values: [1.0]` never match a
+// float64 input of 1, which the runtime renders as "1". Quoted scalars are
+// left untouched, so `values: ["1.0"]` still means the literal string.
+//
+// This mirrors formatting rules in pkg/runtime; pkg/config cannot import
+// pkg/runtime because the dependency runs the other way. The two must be kept
+// in step.
 type WorkflowConditionValues []string
 
 func (v *WorkflowConditionValues) UnmarshalYAML(node *yaml.Node) error {
@@ -99,10 +109,30 @@ func (v *WorkflowConditionValues) UnmarshalYAML(node *yaml.Node) error {
 		if item.Kind != yaml.ScalarNode {
 			return fmt.Errorf("workflow condition values must contain scalars")
 		}
-		out = append(out, item.Value)
+		out = append(out, normalizeWorkflowConditionValue(item))
 	}
 	*v = out
 	return nil
+}
+
+func normalizeWorkflowConditionValue(node *yaml.Node) string {
+	switch node.Tag {
+	case "!!float":
+		// JSON numbers decode as float64, and the runtime formats them with
+		// strconv.FormatFloat(v, 'f', -1, 64).
+		if f, err := strconv.ParseFloat(node.Value, 64); err == nil {
+			return strconv.FormatFloat(f, 'f', -1, 64)
+		}
+	case "!!int":
+		if i, err := strconv.ParseInt(node.Value, 0, 64); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+	case "!!bool":
+		if b, err := strconv.ParseBool(node.Value); err == nil {
+			return strconv.FormatBool(b)
+		}
+	}
+	return node.Value
 }
 
 type WorkflowOutput struct {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -397,3 +397,22 @@ workflow:
         - name: kind
 ` + steps
 }
+
+// Condition values must be normalized the way the runtime stringifies values,
+// otherwise `values: [1.0]` never matches a float64 input of 1.
+func TestLoadManifest_WorkflowConditionValuesMatchRuntimeFormatting(t *testing.T) {
+	m := mustLoadWorkflowManifest(t, `
+      steps:
+        - id: probe
+          uses: console.Apps_Get
+          when:
+            - value: ${input.kind}
+              operator: in
+              values: [1.0, 1.50, 404, 2.5, gpu, "1.0", true]
+`)
+	got := m.Workflow.Commands[0].Steps[0].When[0].Values
+	want := WorkflowConditionValues{"1", "1.5", "404", "2.5", "gpu", "1.0", "true"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("values = %#v, want %#v", got, want)
+	}
+}

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -324,4 +325,75 @@ func TestBindActive_RoundTrip(t *testing.T) {
 	if Active() != m {
 		t.Fatal("Active() did not return the bound manifest")
 	}
+}
+
+func TestLoadManifest_WorkflowConditions(t *testing.T) {
+	t.Run("accepts scalar values in any form", func(t *testing.T) {
+		m := mustLoadWorkflowManifest(t, `
+      steps:
+        - id: probe
+          uses: console.Apps_Get
+          when:
+            - value: ${input.kind}
+              operator: in
+              values: [gpu, 404, "cpu", ""]
+`)
+		cond := m.Workflow.Commands[0].Steps[0].When
+		if len(cond) != 1 {
+			t.Fatalf("conditions = %#v", cond)
+		}
+		want := WorkflowConditionValues{"gpu", "404", "cpu", ""}
+		if !reflect.DeepEqual(cond[0].Values, want) {
+			t.Fatalf("values = %#v, want %#v", cond[0].Values, want)
+		}
+	})
+
+	for name, when := range map[string]string{
+		"missing operator": `
+            - value: ${input.kind}
+              values: [gpu]`,
+		"unknown operator": `
+            - value: ${input.kind}
+              operator: matches
+              values: [gpu]`,
+		"empty values": `
+            - value: ${input.kind}
+              operator: in
+              values: []`,
+		"missing value": `
+            - operator: in
+              values: [gpu]`,
+	} {
+		t.Run("rejects "+name, func(t *testing.T) {
+			_, err := Load([]byte(workflowManifestYAML(`
+      steps:
+        - id: probe
+          uses: console.Apps_Get
+          when:` + when + "\n")))
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+		})
+	}
+}
+
+func mustLoadWorkflowManifest(t *testing.T, steps string) *Manifest {
+	t.Helper()
+	m, err := Load([]byte(workflowManifestYAML(steps)))
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	return m
+}
+
+func workflowManifestYAML(steps string) string {
+	return `cli:
+  name: myctl
+workflow:
+  version: 1
+  commands:
+    - use: deploy
+      inputs:
+        - name: kind
+` + steps
 }

--- a/pkg/lathe/verify.go
+++ b/pkg/lathe/verify.go
@@ -202,6 +202,17 @@ func verifyWorkflowContract(catalog runtime.Catalog) error {
 			if step.HTTP.Method == "" || step.HTTP.PathTemplate == "" {
 				return fmt.Errorf("workflow command %q step %q missing operation HTTP metadata", strings.Join(entry.Path, " "), step.ID)
 			}
+			for i, cond := range step.When {
+				if cond.Value == "" {
+					return fmt.Errorf("workflow command %q step %q condition %d missing value", strings.Join(entry.Path, " "), step.ID, i)
+				}
+				if cond.Operator != "in" && cond.Operator != "notin" {
+					return fmt.Errorf("workflow command %q step %q condition %d operator = %q", strings.Join(entry.Path, " "), step.ID, i, cond.Operator)
+				}
+				if len(cond.Values) == 0 {
+					return fmt.Errorf("workflow command %q step %q condition %d has no values", strings.Join(entry.Path, " "), step.ID, i)
+				}
+			}
 		}
 	}
 	if count == 0 {

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 11
+const CatalogSchemaVersion = 12
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -81,9 +81,16 @@ type CatalogWorkflow struct {
 }
 
 type CatalogWorkflowStep struct {
-	ID          string      `json:"id"`
-	OperationID string      `json:"operation_id,omitempty"`
-	HTTP        CatalogHTTP `json:"http"`
+	ID          string                     `json:"id"`
+	OperationID string                     `json:"operation_id,omitempty"`
+	HTTP        CatalogHTTP                `json:"http"`
+	When        []CatalogWorkflowCondition `json:"when,omitempty"`
+}
+
+type CatalogWorkflowCondition struct {
+	Value    string   `json:"value"`
+	Operator string   `json:"operator"`
+	Values   []string `json:"values"`
 }
 
 type CatalogHTTP struct {
@@ -406,6 +413,21 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 	return cmd
 }
 
+func catalogWorkflowConditions(conditions []WorkflowCondition) []CatalogWorkflowCondition {
+	if len(conditions) == 0 {
+		return nil
+	}
+	out := make([]CatalogWorkflowCondition, 0, len(conditions))
+	for _, cond := range conditions {
+		out = append(out, CatalogWorkflowCondition{
+			Value:    cond.Value,
+			Operator: cond.Operator,
+			Values:   append([]string(nil), cond.Values...),
+		})
+	}
+	return out
+}
+
 func catalogWorkflowCommand(spec WorkflowSpec, path []string) CatalogCommand {
 	flags := make([]CatalogFlag, 0, len(spec.Params))
 	for _, p := range spec.Params {
@@ -438,6 +460,7 @@ func catalogWorkflowCommand(spec WorkflowSpec, path []string) CatalogCommand {
 				PathTemplate:    step.Operation.PathTpl,
 				DefaultHostname: step.Operation.DefaultHostname,
 			},
+			When: catalogWorkflowConditions(step.When),
 		})
 		stepAuth := catalogAuth(step.Operation.Security)
 		if stepAuth.Required {

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -437,3 +437,61 @@ func TestBuildCatalog_DefaultAuthRequired(t *testing.T) {
 		t.Fatal("nil security should require auth to match runtime behavior")
 	}
 }
+
+func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
+	root := newRootWithModuleGroup()
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use: "deploy",
+		Steps: []WorkflowStepSpec{{
+			ID: "gpu",
+			Operation: CommandSpec{
+				Group:       "Apps",
+				Use:         "deploy-gpu",
+				Method:      "POST",
+				PathTpl:     "/apps/gpu",
+				OperationID: "Apps_DeployGPU",
+			},
+			When: []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+		}},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+
+	catalog := BuildCatalog(root, CatalogOptions{})
+	if catalog.CatalogSchemaVersion != 12 {
+		t.Fatalf("schema version = %d, want 12", catalog.CatalogSchemaVersion)
+	}
+	var step *CatalogWorkflowStep
+	for i, entry := range catalog.Commands {
+		if entry.Kind == "workflow" && entry.Workflow != nil && len(entry.Workflow.Steps) > 0 {
+			step = &catalog.Commands[i].Workflow.Steps[0]
+			break
+		}
+	}
+	if step == nil {
+		t.Fatal("no workflow step in catalog")
+	}
+	want := []CatalogWorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}}
+	if !reflect.DeepEqual(step.When, want) {
+		t.Fatalf("when = %#v, want %#v", step.When, want)
+	}
+
+	data, err := json.Marshal(step)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"when":[{"value":"${input.kind}","operator":"in","values":["gpu"]}]`) {
+		t.Fatalf("catalog JSON = %s", data)
+	}
+}
+
+// A step with no conditions must not gain a "when" key.
+func TestBuildCatalog_UnconditionalStepOmitsWhen(t *testing.T) {
+	data, err := json.Marshal(CatalogWorkflowStep{ID: "plain"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "when") {
+		t.Fatalf("catalog JSON = %s", data)
+	}
+}

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -131,9 +131,18 @@ type WorkflowSpec struct {
 type WorkflowStepSpec struct {
 	ID             string
 	Operation      CommandSpec
+	When           []WorkflowCondition
 	Params         map[string]string
 	BodySets       []WorkflowValue
 	BodyStringSets []WorkflowValue
+}
+
+// WorkflowCondition guards a workflow step. Conditions on one step are joined
+// with AND; Values within one condition are joined with OR.
+type WorkflowCondition struct {
+	Value    string
+	Operator string
+	Values   []string
 }
 
 type WorkflowValue struct {

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -240,20 +240,42 @@ func evalWorkflowConditions(conditions []WorkflowCondition, state workflowState)
 	return true, nil
 }
 
-// evalWorkflowConditionValue is the lenient evaluator. Data that does not
-// resolve becomes the empty string, because referencing a field that may be
-// absent is normal in a condition. Leniency stops at skipped steps: that
-// sentinel propagates so the referencing step is skipped rather than compared
-// against an empty value.
+// evalWorkflowConditionValue is the lenient evaluator, kept separate from
+// evalWorkflowValue rather than wrapping it. Leniency applies per reference:
+// a reference that does not resolve contributes the empty string while the
+// surrounding literal text is preserved, so "prefix-${steps.probe.missing}"
+// evaluates to "prefix-". Collapsing the whole expression would silently turn
+// a partially resolvable condition into a comparison against "".
+//
+// Leniency stops at skipped steps: that sentinel propagates so the referencing
+// step is skipped rather than compared against an empty value.
 func evalWorkflowConditionValue(expr string, state workflowState) (string, error) {
-	value, err := evalWorkflowValue(expr, state)
-	if err != nil {
-		if errors.Is(err, errStepSkipped) {
+	var out strings.Builder
+	rest := expr
+	for {
+		start := strings.Index(rest, "${")
+		if start < 0 {
+			out.WriteString(rest)
+			return out.String(), nil
+		}
+		out.WriteString(rest[:start])
+		after := rest[start+2:]
+		end := strings.Index(after, "}")
+		if end < 0 {
+			// Unterminated references are rejected at codegen time. Treat the
+			// remainder as literal text instead of failing the condition.
+			out.WriteString(rest[start:])
+			return out.String(), nil
+		}
+		value, err := workflowRefValue(strings.TrimSpace(after[:end]), state)
+		switch {
+		case err == nil:
+			out.WriteString(workflowString(value))
+		case errors.Is(err, errStepSkipped):
 			return "", err
 		}
-		return "", nil
+		rest = after[end+1:]
 	}
-	return workflowString(value), nil
 }
 
 func workflowOperationInput(step WorkflowStepSpec, state workflowState) (OperationInput, error) {

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -104,46 +106,70 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 
 func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any) (WorkflowResult, []byte, error) {
 	state := workflowState{
-		inputs: workflowInputValues(cmd, spec, vals),
-		steps:  map[string]any{},
+		inputs:  workflowInputValues(cmd, spec, vals),
+		steps:   map[string]any{},
+		skipped: map[string]bool{},
 	}
 	result := WorkflowResult{Status: "ok", Steps: make([]WorkflowStepResult, 0, len(spec.Steps))}
 	for _, step := range spec.Steps {
 		stepResult := WorkflowStepResult{ID: step.ID, Status: "ok"}
+		fail := func(err error) (WorkflowResult, []byte, error) {
+			stepResult.Status = "failed"
+			result.Status = "failed"
+			result.Steps = append(result.Steps, stepResult)
+			return result, nil, &WorkflowError{StepID: step.ID, Err: err, Result: result}
+		}
+		skip := func() {
+			state.skipped[step.ID] = true
+			stepResult.Status = "skipped"
+			result.Steps = append(result.Steps, stepResult)
+		}
+
+		// Conditions are evaluated before any host or auth work so a skipped
+		// step never loads credentials or triggers a token refresh.
+		run, err := evalWorkflowConditions(step.When, state)
+		if err != nil {
+			if errors.Is(err, errStepSkipped) {
+				skip()
+				continue
+			}
+			return fail(err)
+		}
+		if !run {
+			skip()
+			continue
+		}
+
+		input, err := workflowOperationInput(step, state)
+		if err != nil {
+			if errors.Is(err, errStepSkipped) {
+				skip()
+				continue
+			}
+			return fail(err)
+		}
+
 		var hostname string
 		var clientOpts ClientOptions
-		var err error
 		if step.Operation.Security != nil && step.Operation.Security.Public {
 			hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		} else {
 			hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		}
 		if err != nil {
-			stepResult.Status = "failed"
-			result.Status = "failed"
-			result.Steps = append(result.Steps, stepResult)
-			return result, nil, &WorkflowError{StepID: step.ID, Err: err, Result: result}
+			return fail(err)
 		}
 		if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 			clientOpts.Debug = true
 		}
 		clientOpts.UserAgent = cmd.Root().Use
-		input, err := workflowOperationInput(step, state)
-		if err != nil {
-			stepResult.Status = "failed"
-			result.Status = "failed"
-			result.Steps = append(result.Steps, stepResult)
-			return result, nil, &WorkflowError{StepID: step.ID, Err: err, Result: result}
-		}
+
 		opResult, err := InvokeOperation(cmd.Context(), step.Operation, input, OperationOptions{
 			Hostname: hostname,
 			Client:   clientOpts,
 		})
 		if err != nil {
-			stepResult.Status = "failed"
-			result.Status = "failed"
-			result.Steps = append(result.Steps, stepResult)
-			return result, nil, &WorkflowError{StepID: step.ID, Err: err, Result: result}
+			return fail(err)
 		}
 		state.steps[step.ID] = workflowStepValue(opResult.Data)
 		result.Steps = append(result.Steps, stepResult)
@@ -153,6 +179,11 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 	}
 	value, err := evalWorkflowValue(spec.OutputFrom, state)
 	if err != nil {
+		// Referencing a skipped step degrades to the step summary rather than
+		// failing the command.
+		if errors.Is(err, errStepSkipped) {
+			return result, nil, nil
+		}
 		return result, nil, err
 	}
 	data, err := json.Marshal(value)
@@ -163,9 +194,15 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 }
 
 type workflowState struct {
-	inputs map[string]any
-	steps  map[string]any
+	inputs  map[string]any
+	steps   map[string]any
+	skipped map[string]bool
 }
+
+// errStepSkipped marks a reference to a step that was skipped. It propagates
+// out of reference evaluation so the referencing step is skipped in turn, which
+// makes propagation transitive without a dependency graph.
+var errStepSkipped = errors.New("workflow step was skipped")
 
 func workflowInputValues(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any) map[string]any {
 	input := OperationInput{Values: vals, Changed: operationChangedFlags(cmd, spec.Params)}
@@ -182,6 +219,41 @@ func workflowInputValues(cmd *cobra.Command, spec WorkflowSpec, vals map[string]
 		out[p.Flag] = v
 	}
 	return out
+}
+
+// evalWorkflowConditions reports whether a step should run. Conditions are
+// joined with AND; values within one condition are joined with OR.
+func evalWorkflowConditions(conditions []WorkflowCondition, state workflowState) (bool, error) {
+	for _, cond := range conditions {
+		actual, err := evalWorkflowConditionValue(cond.Value, state)
+		if err != nil {
+			return false, err
+		}
+		matched := slices.Contains(cond.Values, actual)
+		if cond.Operator == "notin" {
+			matched = !matched
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// evalWorkflowConditionValue is the lenient evaluator. Data that does not
+// resolve becomes the empty string, because referencing a field that may be
+// absent is normal in a condition. Leniency stops at skipped steps: that
+// sentinel propagates so the referencing step is skipped rather than compared
+// against an empty value.
+func evalWorkflowConditionValue(expr string, state workflowState) (string, error) {
+	value, err := evalWorkflowValue(expr, state)
+	if err != nil {
+		if errors.Is(err, errStepSkipped) {
+			return "", err
+		}
+		return "", nil
+	}
+	return workflowString(value), nil
 }
 
 func workflowOperationInput(step WorkflowStepSpec, state workflowState) (OperationInput, error) {
@@ -277,6 +349,9 @@ func workflowRefValue(ref string, state workflowState) (any, error) {
 	}
 	if rest, ok := strings.CutPrefix(ref, "steps."); ok {
 		id, path, _ := strings.Cut(rest, ".")
+		if state.skipped[id] {
+			return nil, fmt.Errorf("step %q: %w", id, errStepSkipped)
+		}
 		step, exists := state.steps[id]
 		if !exists {
 			return nil, fmt.Errorf("unknown step %q", id)

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -544,3 +544,44 @@ func TestBuildWorkflows_RunningStepLoadsAuth(t *testing.T) {
 		t.Fatalf("error = %v, want ErrNotAuthenticated once the step actually runs", err)
 	}
 }
+
+// A missing field inside a larger expression must blank only that reference,
+// not the whole string.
+func TestBuildWorkflows_ConditionKeepsLiteralAroundMissingReference(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"present":"here"}`))
+	}))
+	defer srv.Close()
+
+	root := newWorkflowRoot(io.Discard)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use: "deploy",
+		Steps: []WorkflowStepSpec{
+			{ID: "probe", Operation: publicGetSpec("probe", "/probe")},
+			{
+				ID:        "guarded",
+				Operation: publicGetSpec("guarded", "/guarded"),
+				When: []WorkflowCondition{{
+					Value:    "prefix-${steps.probe.missing}",
+					Operator: "in",
+					Values:   []string{"prefix-"},
+				}},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !reflect.DeepEqual(paths, []string{"/probe", "/guarded"}) {
+		t.Fatalf("paths = %#v, want the guarded step to run", paths)
+	}
+}

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -218,5 +219,328 @@ func publicGetSpec(use string, path string) CommandSpec {
 		Method:   "GET",
 		PathTpl:  path,
 		Security: &SecurityHint{Public: true},
+	}
+}
+
+func TestBuildWorkflows_WhenSelectsBranch(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{
+			{
+				ID:        "gpu",
+				Operation: publicGetSpec("gpu", "/gpu"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+			},
+			{
+				ID:        "cpu",
+				Operation: publicGetSpec("cpu", "/cpu"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"cpu"}}},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !reflect.DeepEqual(paths, []string{"/cpu"}) {
+		t.Fatalf("paths = %#v, want only /cpu", paths)
+	}
+	summary := decodeWorkflowSummary(t, stdout.String())
+	if summary.Status != "ok" {
+		t.Fatalf("status = %q", summary.Status)
+	}
+	if got := stepStatuses(summary); !reflect.DeepEqual(got, map[string]string{"gpu": "skipped", "cpu": "ok"}) {
+		t.Fatalf("step statuses = %#v", got)
+	}
+}
+
+// notin [""] is the documented existence check for an optional flag.
+func TestBuildWorkflows_WhenTreatsUnsetInputAsEmpty(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	root := newWorkflowRoot(io.Discard)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "label", Flag: "label", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{{
+			ID:        "label",
+			Operation: publicGetSpec("label", "/label"),
+			When:      []WorkflowCondition{{Value: "${input.label}", Operator: "notin", Values: []string{""}}},
+		}},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("paths = %#v, want no request when --label is unset", paths)
+	}
+}
+
+func TestBuildWorkflows_SkipPropagatesThroughParamsAndConditions(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{
+			{
+				ID:        "gpu",
+				Operation: publicGetSpec("gpu", "/gpu"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+			},
+			// references a skipped step through params
+			{
+				ID: "notify",
+				Operation: CommandSpec{
+					Group:    "System",
+					Use:      "notify",
+					Method:   "GET",
+					PathTpl:  "/notify/{id}",
+					Params:   []ParamSpec{{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true}},
+					Security: &SecurityHint{Public: true},
+				},
+				Params: map[string]string{"id": "${steps.gpu.id}"},
+			},
+			// references a skipped step from inside when itself
+			{
+				ID:        "audit",
+				Operation: publicGetSpec("audit", "/audit"),
+				When:      []WorkflowCondition{{Value: "${steps.gpu.id}", Operator: "in", Values: []string{"abc"}}},
+			},
+			// transitive: depends on a step that was itself skipped by propagation
+			{
+				ID:        "trail",
+				Operation: publicGetSpec("trail", "/trail"),
+				When:      []WorkflowCondition{{Value: "${steps.audit.ok}", Operator: "in", Values: []string{"true"}}},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("paths = %#v, want every step skipped", paths)
+	}
+	summary := decodeWorkflowSummary(t, stdout.String())
+	if summary.Status != "ok" {
+		t.Fatalf("status = %q, want ok", summary.Status)
+	}
+	want := map[string]string{"gpu": "skipped", "notify": "skipped", "audit": "skipped", "trail": "skipped"}
+	if got := stepStatuses(summary); !reflect.DeepEqual(got, want) {
+		t.Fatalf("step statuses = %#v", got)
+	}
+}
+
+// A skipped step must not load host options or refresh credentials. The step
+// below is non-public and no host is configured, so reaching auth would fail.
+func TestBuildWorkflows_SkippedStepDoesNotLoadAuth(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{{
+			ID: "guarded",
+			Operation: CommandSpec{
+				Group:   "System",
+				Use:     "guarded",
+				Method:  "GET",
+				PathTpl: "/guarded",
+			},
+			When: []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+		}},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v, want the guarded step to be skipped before auth", err)
+	}
+	summary := decodeWorkflowSummary(t, stdout.String())
+	if got := stepStatuses(summary); !reflect.DeepEqual(got, map[string]string{"guarded": "skipped"}) {
+		t.Fatalf("step statuses = %#v", got)
+	}
+}
+
+func TestBuildWorkflows_OutputFromSkippedStepDegradesToSummary(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{{
+			ID:        "gpu",
+			Operation: publicGetSpec("gpu", "/gpu"),
+			When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+		}},
+		OutputFrom: "${steps.gpu}",
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	summary := decodeWorkflowSummary(t, stdout.String())
+	if summary.Status != "ok" || len(summary.Steps) != 1 || summary.Steps[0].Status != "skipped" {
+		t.Fatalf("summary = %#v", summary)
+	}
+}
+
+// Branch convergence is a documented limitation: a step that references one
+// branch is skipped when the other branch runs. See docs/workflow-conditional.md.
+func TestBuildWorkflows_BranchConvergenceSkipsConvergingStep(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"abc"}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{
+			{
+				ID:        "gpu",
+				Operation: publicGetSpec("gpu", "/gpu"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+			},
+			{
+				ID:        "cpu",
+				Operation: publicGetSpec("cpu", "/cpu"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"cpu"}}},
+			},
+			{
+				ID: "notify",
+				Operation: CommandSpec{
+					Group:    "System",
+					Use:      "notify",
+					Method:   "GET",
+					PathTpl:  "/notify/{id}",
+					Params:   []ParamSpec{{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true}},
+					Security: &SecurityHint{Public: true},
+				},
+				Params: map[string]string{"id": "${steps.gpu.id}"},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !reflect.DeepEqual(paths, []string{"/cpu"}) {
+		t.Fatalf("paths = %#v, want the cpu branch only", paths)
+	}
+	if got := stepStatuses(decodeWorkflowSummary(t, stdout.String()))["notify"]; got != "skipped" {
+		t.Fatalf("notify status = %q, want skipped", got)
+	}
+}
+
+func decodeWorkflowSummary(t *testing.T, raw string) WorkflowResult {
+	t.Helper()
+	var summary WorkflowResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &summary); err != nil {
+		t.Fatalf("decode summary %q: %v", raw, err)
+	}
+	return summary
+}
+
+func stepStatuses(result WorkflowResult) map[string]string {
+	out := map[string]string{}
+	for _, step := range result.Steps {
+		out[step.ID] = step.Status
+	}
+	return out
+}
+
+// Control for TestBuildWorkflows_SkippedStepDoesNotLoadAuth: with the condition
+// satisfied, the same step reaches auth and fails. The pair pins the ordering.
+func TestBuildWorkflows_RunningStepLoadsAuth(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	root := newWorkflowRoot(io.Discard)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{{
+			ID: "guarded",
+			Operation: CommandSpec{
+				Group:   "System",
+				Use:     "guarded",
+				Method:  "GET",
+				PathTpl: "/guarded",
+			},
+			When: []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+		}},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"deploy", "--kind", "gpu"})
+	err := root.Execute()
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("error = %v, want ErrNotAuthenticated once the step actually runs", err)
 	}
 }


### PR DESCRIPTION
## Summary

Implements stage 1 of the conditional-execution design proposed in #111: workflow steps can be guarded individually with a `when` field. No nested `if`/`else`, no `switch` AST, no branch AST.

```yaml
steps:
  - id: label
    uses: console.Apps_SetLabel
    when:
      - value: ${input.label}
        operator: notin
        values: [""]
    params:
      appId: ${input.app_id}
```

Conditions are joined with AND; values within one condition are joined with OR. Operators are `in` and `notin`, both required. Comparison is string comparison, so `values: [404]` and `values: ["404"]` are equivalent — `values` unmarshals from any scalar list, because `[]string` would reject the unquoted form during YAML parsing.

## Semantics

- **Conditions run before host/auth loading.** A skipped step never loads credentials or triggers a token refresh. The test pair `SkippedStepDoesNotLoadAuth` / `RunningStepLoadsAuth` pins this ordering: the same non-public step with no configured host succeeds when skipped and returns `ErrNotAuthenticated` when its condition is true.
- **Skip propagation uses a sentinel, not a graph.** A reference to a skipped step returns `errStepSkipped`, so the referencing step is skipped in turn. Transitivity is automatic, and nothing is precomputed or serialized.
- **Leniency covers missing data, not skipped steps.** The lenient evaluator wraps the strict one: unresolved fields become the empty string, while the skipped sentinel still propagates. That keeps the rule in one place. It also makes `notin [""]` the way to ask whether an optional input was provided.
- **`output.from` pointing at a skipped step** degrades to the step summary rather than failing.

## Known limitation

Conditions cannot express branch convergence: every `${steps.<id>}` reference names one specific step, so a step reading `${steps.deploy_gpu.id}` is skipped whenever the CPU branch ran instead. This is documented in `docs/workflow.md` and pinned by `TestBuildWorkflows_BranchConvergenceSkipsConvergingStep`, so it is not silently "fixed" later without a deliberate decision.

## Contract

`CatalogSchemaVersion` 11 → 12. Steps carry their conditions in catalog JSON so agents can see a step is guarded without running it. The DSL identifier stays `lathe.workflow.v1` — a workflow with no `when` generates identical behavior. `workflow_contract` in `__lathe verify` gains condition checks.

## Verification

```
make check                 # fmt-check, vet, golangci-lint, go test ./... — all pass
go test -race ./pkg/runtime/ ./pkg/config/ ./pkg/lathe/ ./internal/lathecmd/ ./internal/codegen/render/
```

13 new cases across `pkg/runtime` (branch selection, unset input, propagation through params and through `when` itself, transitive propagation, auth ordering pair, `output.from` degradation, branch convergence, catalog JSON), `pkg/config` (scalar acceptance, four rejection cases), `internal/lathecmd` (conditions reach the spec, bad references rejected), and `internal/codegen/render` (literal shape).

Not covered: an end-to-end `lathe codegen` run producing a real CLI that executes a conditional command. The render test verifies the generated literal shape through `format.Source`, but not downstream compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)