### PR TITLE
fix(workflow): preserve conditional value semantics

### DIFF
--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -120,7 +120,8 @@ func normalizeWorkflowConditionValue(node *yaml.Node) string {
 	case "!!float":
 		// JSON numbers decode as float64, and the runtime formats them with
 		// strconv.FormatFloat(v, 'f', -1, 64).
-		if f, err := strconv.ParseFloat(node.Value, 64); err == nil {
+		var f float64
+		if err := node.Decode(&f); err == nil {
 			return strconv.FormatFloat(f, 'f', -1, 64)
 		}
 	case "!!int":
@@ -131,6 +132,8 @@ func normalizeWorkflowConditionValue(node *yaml.Node) string {
 		if b, err := strconv.ParseBool(node.Value); err == nil {
 			return strconv.FormatBool(b)
 		}
+	case "!!null":
+		return ""
 	}
 	return node.Value
 }
@@ -334,9 +337,8 @@ func normalizeWorkflow(workflow *WorkflowInfo) error {
 			}
 			for k := range step.When {
 				cond := &step.When[k]
-				cond.Value = strings.TrimSpace(cond.Value)
 				cond.Operator = strings.ToLower(strings.TrimSpace(cond.Operator))
-				if cond.Value == "" {
+				if strings.TrimSpace(cond.Value) == "" {
 					return fmt.Errorf("workflow command %q step %q when[%d].value is required", cmd.Use, step.ID, k)
 				}
 				if !validWorkflowOperator(cond.Operator) {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -408,11 +408,26 @@ func TestLoadManifest_WorkflowConditionValuesMatchRuntimeFormatting(t *testing.T
           when:
             - value: ${input.kind}
               operator: in
-              values: [1.0, 1.50, 404, 2.5, gpu, "1.0", true]
+              values: [1.0, 1.50, 404, 2.5, gpu, "1.0", true, .nan, .inf, -.inf, null]
 `)
 	got := m.Workflow.Commands[0].Steps[0].When[0].Values
-	want := WorkflowConditionValues{"1", "1.5", "404", "2.5", "gpu", "1.0", "true"}
+	want := WorkflowConditionValues{"1", "1.5", "404", "2.5", "gpu", "1.0", "true", "NaN", "+Inf", "-Inf", ""}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("values = %#v, want %#v", got, want)
+	}
+}
+
+func TestLoadManifest_WorkflowConditionPreservesValueWhitespace(t *testing.T) {
+	m := mustLoadWorkflowManifest(t, `
+      steps:
+        - id: probe
+          uses: console.Apps_Get
+          when:
+            - value: " ${input.kind} "
+              operator: in
+              values: [" gpu "]
+`)
+	if got := m.Workflow.Commands[0].Steps[0].When[0].Value; got != " ${input.kind} " {
+		t.Fatalf("value = %q, want surrounding spaces preserved", got)
 	}
 }

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -329,6 +329,8 @@ func coerceOperationValue(v any, p ParamSpec) (any, error) {
 		return append([]string(nil), (*tv)...), nil
 	case string:
 		return parseStringOperationValue(tv, p)
+	case json.Number:
+		return parseStringOperationValue(tv.String(), p)
 	case int:
 		return int64(tv), nil
 	case int64:

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"slices"
 	"strconv"
 	"strings"
@@ -319,8 +320,13 @@ func workflowStepValue(data []byte) any {
 		return nil
 	}
 	var value any
-	if err := json.Unmarshal(data, &value); err == nil {
-		return value
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err == nil {
+		var trailing any
+		if err := decoder.Decode(&trailing); errors.Is(err, io.EOF) {
+			return value
+		}
 	}
 	return string(data)
 }

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -405,7 +405,15 @@ func workflowString(value any) string {
 	case []byte:
 		return string(tv)
 	case json.Number:
-		return tv.String()
+		raw := tv.String()
+		if strings.ContainsAny(raw, ".eE") {
+			if f, err := strconv.ParseFloat(raw, 64); err == nil {
+				return strconv.FormatFloat(f, 'f', -1, 64)
+			}
+		} else if i, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+		return raw
 	case bool:
 		return fmt.Sprint(tv)
 	case float64:

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -585,3 +585,50 @@ func TestBuildWorkflows_ConditionKeepsLiteralAroundMissingReference(t *testing.T
 		t.Fatalf("paths = %#v, want the guarded step to run", paths)
 	}
 }
+
+func TestBuildWorkflows_PreservesLargeIntegerReferences(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/probe" {
+			_, _ = w.Write([]byte(`{"id":9007199254740993}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	root := newWorkflowRoot(io.Discard)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use: "deploy",
+		Steps: []WorkflowStepSpec{
+			{ID: "probe", Operation: publicGetSpec("probe", "/probe")},
+			{
+				ID: "fetch",
+				Operation: CommandSpec{
+					Use:      "fetch",
+					Method:   "GET",
+					PathTpl:  "/items/{id}",
+					Params:   []ParamSpec{{Name: "id", Flag: "id", In: InPath, GoType: "int64", Required: true}},
+					Security: &SecurityHint{Public: true},
+				},
+				When:   []WorkflowCondition{{Value: "${steps.probe.id}", Operator: "in", Values: []string{"9007199254740993"}}},
+				Params: map[string]string{"id": "${steps.probe.id}"},
+			},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	want := []string{"/probe", "/items/9007199254740993"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("paths = %#v, want %#v", paths, want)
+	}
+}

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -586,7 +586,7 @@ func TestBuildWorkflows_ConditionKeepsLiteralAroundMissingReference(t *testing.T
 	}
 }
 
-func TestBuildWorkflows_PreservesLargeIntegerReferences(t *testing.T) {
+func TestBuildWorkflows_PreservesNumericReferenceSemantics(t *testing.T) {
 	bindTestManifest(t, "myctl", "MYCTL_HOST")
 	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
 
@@ -595,7 +595,7 @@ func TestBuildWorkflows_PreservesLargeIntegerReferences(t *testing.T) {
 		paths = append(paths, r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/probe" {
-			_, _ = w.Write([]byte(`{"id":9007199254740993}`))
+			_, _ = w.Write([]byte(`{"id":9007199254740993,"decimal":1.0,"exponent":1e3}`))
 			return
 		}
 		_, _ = w.Write([]byte(`{"ok":true}`))
@@ -616,7 +616,11 @@ func TestBuildWorkflows_PreservesLargeIntegerReferences(t *testing.T) {
 					Params:   []ParamSpec{{Name: "id", Flag: "id", In: InPath, GoType: "int64", Required: true}},
 					Security: &SecurityHint{Public: true},
 				},
-				When:   []WorkflowCondition{{Value: "${steps.probe.id}", Operator: "in", Values: []string{"9007199254740993"}}},
+				When: []WorkflowCondition{
+					{Value: "${steps.probe.id}", Operator: "in", Values: []string{"9007199254740993"}},
+					{Value: "${steps.probe.decimal}", Operator: "in", Values: []string{"1"}},
+					{Value: "${steps.probe.exponent}", Operator: "in", Values: []string{"1000"}},
+				},
 				Params: map[string]string{"id": "${steps.probe.id}"},
 			},
 		},


### PR DESCRIPTION
## Summary

- normalize YAML special floats and null condition values using their typed semantics
- preserve intentional whitespace around `when.value` expressions
- retain exact JSON numbers across workflow steps and coerce them at the operation boundary

## Root cause

The conditional workflow path normalized ordinary numeric scalars but kept YAML spellings such as `.nan`, while runtime values use Go formatting such as `NaN`. Manifest normalization also trimmed quoted `when.value` expressions. Separately, prior-step JSON numbers were decoded into `float64`, so integers above `2^53` changed before condition comparison or parameter reuse.

These mismatches caused valid guarded steps to be silently skipped.

## Impact

Conditional workflows now compare the declared value without rewriting quoted whitespace, handle special typed YAML scalars consistently, and preserve large integer references when they flow into later conditions and operation parameters.

## Verification

- `make check`
- `go test -race -count=1 ./pkg/config ./pkg/runtime ./internal/lathecmd ./internal/codegen/render ./pkg/lathe`
- repeated the focused config and large-integer workflow regressions 20 times
- generated and executed a scratch downstream CLI covering `NaN`, quoted whitespace, and `9007199254740993` across two API steps

Follow-up to #112.
