### PR TITLE
fix(security): harden generation and runtime boundaries

### DIFF
--- a/examples/graphql/go.mod
+++ b/examples/graphql/go.mod
@@ -1,6 +1,6 @@
 module example/graphql
 
-go 1.25.7
+go 1.25.13
 
 require (
 	github.com/lathe-cli/lathe v0.0.0
@@ -10,8 +10,8 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/examples/graphql/go.sum
+++ b/examples/graphql/go.sum
@@ -7,10 +7,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
-golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/petstore/go.mod
+++ b/examples/petstore/go.mod
@@ -1,6 +1,6 @@
 module example/petstore
 
-go 1.25.7
+go 1.25.13
 
 require (
 	github.com/lathe-cli/lathe v0.0.0
@@ -10,8 +10,8 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/examples/petstore/go.sum
+++ b/examples/petstore/go.sum
@@ -7,10 +7,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
-golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/examples/richapi/go.mod
+++ b/examples/richapi/go.mod
@@ -1,6 +1,6 @@
 module example/richapi
 
-go 1.25.7
+go 1.25.13
 
 require (
 	github.com/lathe-cli/lathe v0.0.0
@@ -10,8 +10,8 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/term v0.43.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 

--- a/examples/richapi/go.sum
+++ b/examples/richapi/go.sum
@@ -7,10 +7,10 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
-golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lathe-cli/lathe
 
-go 1.25.7
+go 1.25.13
 
 require (
 	github.com/lathe-cli/kitup/go v0.1.3

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -140,18 +140,37 @@ func flatPathConflict(specs []runtime.CommandSpec) (string, bool) {
 }
 
 func validateCommandPaths(specs []runtime.CommandSpec) error {
-	seen := map[string]runtime.CommandSpec{}
-	for _, spec := range specs {
+	type commandName struct {
+		spec  runtime.CommandSpec
+		alias bool
+		index int
+	}
+	seen := map[string]commandName{}
+	for specIndex, spec := range specs {
 		group := rootCommandName(spec.Group)
 		use := commandUseName(spec.Use)
 		if group == "" || use == "" {
 			return fmt.Errorf("command %q has empty generated path", commandIdentity(spec))
 		}
-		cmdPath := group + " " + use
-		if prev, ok := seen[cmdPath]; ok {
-			return fmt.Errorf("command path %q conflicts between %s and %s", cmdPath, commandDebugIdentity(prev), commandDebugIdentity(spec))
+		names := append([]string{use}, spec.Aliases...)
+		for i, raw := range names {
+			name := commandUseName(raw)
+			if name == "" {
+				return fmt.Errorf("command %q has empty alias", commandIdentity(spec))
+			}
+			cmdPath := group + " " + name
+			if prev, ok := seen[cmdPath]; ok {
+				if prev.index == specIndex {
+					continue
+				}
+				kind := "command path"
+				if i > 0 || prev.alias {
+					kind = "command alias path"
+				}
+				return fmt.Errorf("%s %q conflicts between %s and %s", kind, cmdPath, commandDebugIdentity(prev.spec), commandDebugIdentity(spec))
+			}
+			seen[cmdPath] = commandName{spec: spec, alias: i > 0, index: specIndex}
 		}
-		seen[cmdPath] = spec
 	}
 	return nil
 }

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -709,6 +709,17 @@ func TestResolveFlatCommandPath(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `command path "repos create" conflicts`) {
 		t.Fatalf("expected renamed command conflict error, got %v", err)
 	}
+
+	aliased := MergeOverlay([]runtime.CommandSpec{
+		{Group: "Users", Use: "get-user", OperationID: "Users_GetUser", Method: "GET", PathTpl: "/users/{id}"},
+		{Group: "Users", Use: "remove-user", OperationID: "Users_RemoveUser", Method: "DELETE", PathTpl: "/users/{id}"},
+	}, map[string]overlay.Override{
+		"remove-user": {Aliases: []string{"get-user"}},
+	})
+	_, err = ResolveFlatCommandPath("namespaced", 1, aliased)
+	if err == nil || !strings.Contains(err.Error(), "alias") {
+		t.Fatalf("expected canonical command alias conflict error, got %v", err)
+	}
 }
 
 func TestRewriteCommandExamples_NormalizesMultiWordGroupPaths(t *testing.T) {

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -117,6 +117,9 @@ func Load(path string) (*Config, error) {
 	}
 	baseDir := filepath.Dir(path)
 	for name, src := range cfg.Sources {
+		if err := validateSourceID(name); err != nil {
+			return nil, err
+		}
 		src.Name = name
 		if err := validate(src, baseDir); err != nil {
 			return nil, fmt.Errorf("source %q: %w", name, err)
@@ -195,6 +198,11 @@ func validate(s *Source, baseDir string) error {
 		if err := validateRelPathList("proto.entries", s.Proto.Entries); err != nil {
 			return err
 		}
+		for _, entry := range s.Proto.Entries {
+			if strings.HasPrefix(entry, "-") || strings.HasPrefix(entry, "@") {
+				return fmt.Errorf("proto.entries contains protoc control argument %q", entry)
+			}
+		}
 		if err := validateRelPathList("proto.import_roots", s.Proto.ImportRoots); err != nil {
 			return err
 		}
@@ -227,6 +235,16 @@ func validate(s *Source, baseDir string) error {
 		return fmt.Errorf("unknown backend %q", s.Backend)
 	}
 	return rejectForeignBlocks(s)
+}
+
+func validateSourceID(name string) error {
+	if err := ValidateRelPath("source ID", name); err != nil {
+		return err
+	}
+	if name == "." || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("unsafe path source ID: %q", name)
+	}
+	return nil
 }
 
 func validateProtoDependencies(deps []ProtoDependency) error {

--- a/internal/sourceconfig/sources_test.go
+++ b/internal/sourceconfig/sources_test.go
@@ -103,6 +103,24 @@ func TestLoad_AcceptsImmutableTag(t *testing.T) {
 	}
 }
 
+func TestLoad_RejectsTraversingSourceID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sources.yaml")
+	body := `sources:
+  "../outside":
+    local_path: .
+    backend: openapi3
+    openapi3:
+      files: [api.yaml]
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed yaml: %v", err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "source ID") {
+		t.Fatalf("Load error = %v, want unsafe source ID rejection", err)
+	}
+}
+
 func TestLoad_AcceptsLocalPathWithoutPinnedTag(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "specs", "sources.yaml")
@@ -590,6 +608,35 @@ func TestLoad_AcceptsFullSHA(t *testing.T) {
 	}
 	if _, err := Load(path); err != nil {
 		t.Fatalf("Load: %v", err)
+	}
+}
+
+func TestLoad_RejectsProtoEntryThatLooksLikeProtocOption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sources.yaml")
+	body := `sources:
+  demo:
+    local_path: .
+    backend: proto
+    proto:
+      staging:
+        - from: .
+          to: api
+      entries: ["--descriptor_set_out=/tmp/out.pb"]
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed yaml: %v", err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "proto.entries") {
+		t.Fatalf("Load error = %v, want protoc option rejection", err)
+	}
+
+	body = strings.Replace(body, "--descriptor_set_out=/tmp/out.pb", "@args.proto", 1)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed response file yaml: %v", err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "proto.entries") {
+		t.Fatalf("Load error = %v, want protoc response file rejection", err)
 	}
 }
 

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -33,8 +33,12 @@ func Build(root *cobra.Command, service string, specs []CommandSpec) error {
 	if findChildCommand(root, service) != nil {
 		return fmt.Errorf("module command %q conflicts with an existing root command", service)
 	}
+	groups, err := buildGroups(service, specs)
+	if err != nil {
+		return err
+	}
 	svc := &cobra.Command{Use: service, Short: service + " API", GroupID: ModuleGroupID}
-	for _, group := range buildGroups(service, specs) {
+	for _, group := range groups {
 		svc.AddCommand(group)
 	}
 	if err := ValidateShortcuts(specs, rootCommandNames(root, svc)); err != nil {
@@ -45,7 +49,10 @@ func Build(root *cobra.Command, service string, specs []CommandSpec) error {
 }
 
 func BuildFlat(root *cobra.Command, service string, specs []CommandSpec) error {
-	groups := buildGroups(service, specs)
+	groups, err := buildGroups(service, specs)
+	if err != nil {
+		return err
+	}
 	seen := map[string]bool{}
 	for _, group := range groups {
 		group.GroupID = ModuleGroupID
@@ -65,8 +72,9 @@ func BuildFlat(root *cobra.Command, service string, specs []CommandSpec) error {
 	return mountShortcuts(root, specs)
 }
 
-func buildGroups(service string, specs []CommandSpec) []*cobra.Command {
+func buildGroups(service string, specs []CommandSpec) ([]*cobra.Command, error) {
 	groups := map[string]*cobra.Command{}
+	commandPaths := map[string]*cobra.Command{}
 	ordered := make([]*cobra.Command, 0)
 	for i := range specs {
 		s := specs[i]
@@ -77,10 +85,17 @@ func buildGroups(service string, specs []CommandSpec) []*cobra.Command {
 			ordered = append(ordered, g)
 		}
 		c := buildCmd(s)
+		for _, name := range append([]string{c.Name()}, c.Aliases...) {
+			path := g.Name() + " " + name
+			if existing := commandPaths[path]; existing != nil && existing != c {
+				return nil, fmt.Errorf("command name or alias %q conflicts between %q and %q in group %q", name, existing.Name(), c.Name(), g.Name())
+			}
+			commandPaths[path] = c
+		}
 		AttachCatalogCommand(c, service, s)
 		g.AddCommand(c)
 	}
-	return ordered
+	return ordered, nil
 }
 
 func buildCmd(s CommandSpec) *cobra.Command {
@@ -286,7 +301,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 func redactedDryRunHeaders(headers map[string][]string) map[string]string {
 	out := make(map[string]string, len(headers))
 	for k, vs := range headers {
-		out[k] = redactDebugHeader(k, strings.Join(vs, ", "))
+		out[k] = redactDebugHeader(k, strings.Join(vs, ", "), nil)
 	}
 	return out
 }

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -180,6 +180,26 @@ func TestBuildFlat_RejectsGeneratedGroupNameConflict(t *testing.T) {
 	}
 }
 
+func TestBuild_RejectsAliasThatShadowsCanonicalCommand(t *testing.T) {
+	root := newRootWithModuleGroup()
+	err := Build(root, "demo", []CommandSpec{
+		{Group: "Users", Use: "get-user", Method: "GET", PathTpl: "/users/{id}"},
+		{Group: "Users", Use: "remove-user", Aliases: []string{"get-user"}, Method: "DELETE", PathTpl: "/users/{id}"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "alias") {
+		t.Fatalf("Build error = %v, want alias conflict", err)
+	}
+
+	root = newRootWithModuleGroup()
+	err = Build(root, "demo", []CommandSpec{
+		{Group: "Users API", Use: "remove-user", Aliases: []string{"get-user"}, Method: "DELETE", PathTpl: "/users/{id}"},
+		{Group: "Users", Use: "get-user", Method: "GET", PathTpl: "/users/{id}"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "alias") {
+		t.Fatalf("Build error = %v, want normalized group alias conflict", err)
+	}
+}
+
 func TestBuild_BodyFlagsAttachedWhenHasBody(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:       "Users",
@@ -355,6 +375,9 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 		Params: []ParamSpec{
 			{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true},
 			{Name: "limit", Flag: "limit", In: InQuery, GoType: "int64"},
+			{Name: "opaque", Flag: "opaque", In: InQuery, GoType: "string", Format: "password"},
+			{Name: "page_token", Flag: "page-token", In: InQuery, GoType: "string"},
+			{Name: "key", Flag: "key", In: InQuery, GoType: "string"},
 			{Name: "Authorization", Flag: "authorization", In: InHeader, GoType: "string"},
 		},
 		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
@@ -370,6 +393,9 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 		"--hostname", srv.URL,
 		"--id", "u 1",
 		"--limit", "5",
+		"--opaque", "dry-run-query-secret",
+		"--page-token", "cursor-1",
+		"--key", "dry-run-key-secret",
 		"--authorization", "Bearer secret",
 		"--set", "name=alice",
 		"--set", "password=hunter2",
@@ -405,8 +431,11 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 	if out.Method != "POST" {
 		t.Fatalf("method = %q, want POST", out.Method)
 	}
-	if out.URL != srv.URL+"/users/u%201?limit=5" {
+	if out.URL != srv.URL+"/users/u%201?key=%2A%2A%2A&limit=5&opaque=%2A%2A%2A&page_token=cursor-1" {
 		t.Fatalf("url = %q", out.URL)
+	}
+	if strings.Contains(stdout.String(), "dry-run-query-secret") || strings.Contains(stdout.String(), "dry-run-key-secret") {
+		t.Fatalf("dry-run leaked query credential: %s", stdout.String())
 	}
 	if out.Headers["Authorization"] != "***" {
 		t.Fatalf("authorization header = %q", out.Headers["Authorization"])

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -25,6 +25,8 @@ type ClientOptions struct {
 	MaxRetries  int
 	UserAgent   string
 	Accept      string
+
+	sensitiveQueryParams map[string]bool
 }
 
 // BaseURL normalizes a user-facing hostname into an absolute URL base.
@@ -64,7 +66,7 @@ func HTTPClient(opts ClientOptions) *http.Client {
 		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug, safeMethodsOnly: safeMethodsOnly}
 	}
 	if opts.Debug {
-		transport = &debugTransport{inner: transport}
+		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams}
 	}
 	return &http.Client{
 		Timeout:   timeout,
@@ -173,10 +175,10 @@ func newRequest(ctx context.Context, method, u string, body []byte, contentType 
 
 func doRawFullOnce(req *http.Request, opts ClientOptions) (*RawResult, error) {
 	method := req.Method
-	u := req.URL.String()
+	u := redactDebugURL(req.URL, opts.sensitiveQueryParams)
 	resp, err := HTTPClient(opts).Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", method, u, err)
+		return nil, fmt.Errorf("%s %s: %w", method, u, redactClientError(err, opts.sensitiveQueryParams))
 	}
 	defer resp.Body.Close()
 
@@ -194,6 +196,19 @@ func doRawFullOnce(req *http.Request, opts ClientOptions) (*RawResult, error) {
 		}
 	}
 	return &RawResult{Body: data, StatusCode: resp.StatusCode, Header: resp.Header}, nil
+}
+
+func redactClientError(err error, sensitive map[string]bool) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return err
+	}
+	redacted := *urlErr
+	redacted.URL = redactDebugURLString(redacted.URL, sensitive)
+	if urlErr.Err != nil && strings.HasPrefix(urlErr.Err.Error(), "failed to parse Location header ") {
+		redacted.Err = errors.New("failed to parse Location header")
+	}
+	return &redacted
 }
 
 func DoRaw(ctx context.Context, hostname, method, path string, body any, opts ClientOptions) ([]byte, error) {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -27,6 +27,7 @@ type ClientOptions struct {
 	Accept      string
 
 	sensitiveQueryParams map[string]bool
+	checkRedirect        func(*http.Request, []*http.Request) error
 }
 
 // BaseURL normalizes a user-facing hostname into an absolute URL base.
@@ -69,8 +70,9 @@ func HTTPClient(opts ClientOptions) *http.Client {
 		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams}
 	}
 	return &http.Client{
-		Timeout:   timeout,
-		Transport: transport,
+		Timeout:       timeout,
+		Transport:     transport,
+		CheckRedirect: opts.checkRedirect,
 	}
 }
 

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -77,6 +78,82 @@ func TestDoRaw_4xxReturnsHTTPError(t *testing.T) {
 	}
 	if string(he.Body) != `{"error":"not found"}` {
 		t.Errorf("HTTPError.Body = %s", he.Body)
+	}
+}
+
+func TestInvokeOperation_RedactsQueryCredentialFromHTTPError(t *testing.T) {
+	const secret = "ordinary-error-secret"
+	var gotSecret string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSecret = r.URL.Query().Get("key")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := InvokeOperation(context.Background(), CommandSpec{
+		Method:  "GET",
+		PathTpl: "/fail",
+		Params: []ParamSpec{{
+			Name: "key", Flag: "key", In: InQuery, GoType: "string",
+		}},
+	}, OperationInput{
+		Values:  map[string]any{"key": secret},
+		Changed: map[string]bool{"key": true},
+	}, OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}})
+	if err == nil {
+		t.Fatal("InvokeOperation returned nil error")
+	}
+	if gotSecret != secret {
+		t.Fatalf("server query credential = %q", gotSecret)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("HTTP error leaked query credential: %v", err)
+	}
+}
+
+func TestInvokeOperation_RedactsQueryCredentialFromTransportError(t *testing.T) {
+	const secret = "transport-error-secret"
+	_, err := InvokeOperation(context.Background(), CommandSpec{
+		Method:  "GET",
+		PathTpl: "/fail",
+		Params: []ParamSpec{{
+			Name: "opaque", Flag: "opaque", In: InQuery, GoType: "string", Format: "password",
+		}},
+	}, OperationInput{
+		Values:  map[string]any{"opaque": secret},
+		Changed: map[string]bool{"opaque": true},
+	}, OperationOptions{
+		Hostname: "example.com",
+		Client: ClientOptions{
+			MaxRetries: -1,
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("dial failed")
+			}),
+		},
+	})
+	if err == nil {
+		t.Fatal("InvokeOperation returned nil error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("transport error leaked query credential: %v", err)
+	}
+}
+
+func TestDoRaw_RedactsMalformedRedirectLocation(t *testing.T) {
+	const password = "redirect-userinfo-secret"
+	const signature = "redirect-signature-secret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://user:"+password+"%zz@example.com/path?sig="+signature)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := DoRaw(context.Background(), srv.URL, http.MethodGet, "/", nil, ClientOptions{MaxRetries: -1})
+	if err == nil {
+		t.Fatal("DoRaw returned nil error")
+	}
+	if strings.Contains(err.Error(), password) || strings.Contains(err.Error(), signature) {
+		t.Fatalf("redirect error leaked Location credential: %v", err)
 	}
 }
 

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -18,13 +19,14 @@ const (
 )
 
 type debugTransport struct {
-	inner http.RoundTripper
+	inner                http.RoundTripper
+	sensitiveQueryParams map[string]bool
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, req.URL)
+	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, redactDebugURL(req.URL, d.sensitiveQueryParams))
 	for k, vs := range req.Header {
-		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", ")))
+		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
 	}
 	if req.Body != nil && isTextContent(req.Header.Get("Content-Type")) {
 		body, restored := peekBody(req.Body, maxDebugReqBody)
@@ -44,7 +46,7 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	fmt.Fprintf(os.Stderr, "< %s (%s)\n", resp.Status, elapsed)
 	for k, vs := range resp.Header {
-		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", ")))
+		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
 	}
 	if isTextContent(resp.Header.Get("Content-Type")) {
 		body, restored := peekBody(resp.Body, maxDebugRespBody)
@@ -54,6 +56,60 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	fmt.Fprintln(os.Stderr)
 
 	return resp, nil
+}
+
+func redactDebugURL(u *url.URL, sensitive map[string]bool) string {
+	if u == nil {
+		return ""
+	}
+	redacted := *u
+	redacted.RawQuery = redactDebugQuery(redacted.RawQuery, sensitive)
+	return redacted.Redacted()
+}
+
+func redactDebugQuery(raw string, sensitive map[string]bool) string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool { return r == '&' || r == ';' })
+	changed := false
+	for i, part := range parts {
+		name, _, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		decoded, err := url.QueryUnescape(name)
+		if err != nil {
+			decoded = name
+		}
+		if sensitive[strings.ToLower(decoded)] || isSensitiveDebugQueryName(decoded) {
+			parts[i] = name + "=" + url.QueryEscape("***")
+			changed = true
+		}
+	}
+	if !changed {
+		return raw
+	}
+	return strings.Join(parts, "&")
+}
+
+func isSensitiveDebugQueryName(name string) bool {
+	n := sensitiveNameKey(name)
+	switch n {
+	case "authorization", "proxyauthorization", "token", "key", "apikey", "xapikey", "accesstoken", "idtoken", "refreshtoken", "authtoken", "oauthtoken", "bearertoken", "privatekey", "sessiontoken", "securitytoken", "xamzsecuritytoken", "sig":
+		return true
+	}
+	for _, marker := range []string{"secret", "password", "credential", "signature"} {
+		if strings.Contains(n, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func redactDebugURLString(raw string, sensitive map[string]bool) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "<invalid URL>"
+	}
+	return redactDebugURL(parsed, sensitive)
 }
 
 type bodyReader struct {
@@ -75,7 +131,10 @@ func isTextContent(ct string) bool {
 	return false
 }
 
-func redactDebugHeader(name, value string) string {
+func redactDebugHeader(name, value string, sensitive map[string]bool) string {
+	if strings.EqualFold(name, "location") || strings.EqualFold(name, "content-location") {
+		return redactDebugURLString(value, sensitive)
+	}
 	if isSensitiveDebugName(name) {
 		return "***"
 	}
@@ -85,10 +144,10 @@ func redactDebugHeader(name, value string) string {
 func isSensitiveDebugName(name string) bool {
 	n := strings.ToLower(name)
 	switch n {
-	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key":
+	case "authorization", "proxy-authorization", "cookie", "set-cookie", "x-api-key", "sig":
 		return true
 	}
-	for _, marker := range []string{"token", "key", "secret", "password", "credential"} {
+	for _, marker := range []string{"token", "key", "secret", "password", "credential", "signature"} {
 		if strings.Contains(n, marker) {
 			return true
 		}

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -97,6 +97,34 @@ func TestDebugTransport_RedactsSensitiveHeaders(t *testing.T) {
 	}
 }
 
+func TestDebugTransport_RedactsQueryCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/jobs?opaque=response-query-secret")
+		w.Header().Set("Content-Location", "https://user:response-userinfo-secret%zz@example.com/jobs?sig=response-malformed-secret")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+	dt := &debugTransport{inner: http.DefaultTransport, sensitiveQueryParams: map[string]bool{"opaque": true}}
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/api?key=debug-key-secret&authorization=debug-authorization-secret&X-Amz-Signature=debug-signature-secret&name=alice", nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	for _, leaked := range []string{"debug-key-secret", "debug-authorization-secret", "debug-signature-secret", "response-query-secret", "response-malformed-secret", "response-userinfo-secret"} {
+		if strings.Contains(out, leaked) {
+			t.Fatalf("debug output leaked %q:\n%s", leaked, out)
+		}
+	}
+	if !strings.Contains(out, "name=alice") {
+		t.Fatalf("debug output lost non-sensitive query:\n%s", out)
+	}
+}
+
 func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -148,6 +148,12 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 		if !operationChanged(input, p) {
 			continue
 		}
+		if p.In == InQuery && isSensitiveStringParam(p) {
+			if clientOpts.sensitiveQueryParams == nil {
+				clientOpts.sensitiveQueryParams = map[string]bool{}
+			}
+			clientOpts.sensitiveQueryParams[strings.ToLower(p.Name)] = true
+		}
 		v, _, err := operationValue(input, p)
 		if err != nil {
 			return "", nil, ClientOptions{}, err
@@ -222,7 +228,7 @@ func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path strin
 	}
 	return DryRunRequest{
 		Method:  req.Method,
-		URL:     req.URL.String(),
+		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams),
 		Headers: redactedDryRunHeaders(req.Header),
 		Body:    redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
 		Auth:    dryRunAuthForSpec(s),

--- a/pkg/runtime/poll.go
+++ b/pkg/runtime/poll.go
@@ -40,6 +40,12 @@ func PollUntilDone(ctx context.Context, hostname, location string, opts ClientOp
 			return ""
 		}
 	}
+	opts.checkRedirect = func(req *http.Request, _ []*http.Request) error {
+		if !strings.EqualFold(req.URL.Scheme, baseURL.Scheme) || !strings.EqualFold(req.URL.Hostname(), baseURL.Hostname()) || port(req.URL) != port(baseURL) {
+			return fmt.Errorf("cross-host polling redirect %q", redactDebugURL(req.URL, opts.sensitiveQueryParams))
+		}
+		return nil
+	}
 	deadline := time.Now().Add(timeout)
 	backoff := pollInitBackoff
 

--- a/pkg/runtime/poll.go
+++ b/pkg/runtime/poll.go
@@ -50,14 +50,13 @@ func PollUntilDone(ctx context.Context, hostname, location string, opts ClientOp
 
 		loc, err := url.Parse(location)
 		if err != nil {
-			return nil, fmt.Errorf("parse polling location: %w", err)
+			return nil, fmt.Errorf("parse polling location: %w", redactClientError(err, opts.sensitiveQueryParams))
 		}
-		if loc.IsAbs() || loc.Host != "" {
-			if !strings.EqualFold(loc.Scheme, baseURL.Scheme) || !strings.EqualFold(loc.Hostname(), baseURL.Hostname()) || port(loc) != port(baseURL) {
-				return nil, fmt.Errorf("cross-host polling location %q", location)
-			}
-			location = loc.RequestURI()
+		resolved := baseURL.ResolveReference(loc)
+		if !strings.EqualFold(resolved.Scheme, baseURL.Scheme) || !strings.EqualFold(resolved.Hostname(), baseURL.Hostname()) || port(resolved) != port(baseURL) {
+			return nil, fmt.Errorf("cross-host polling location %q", redactDebugURLString(location, opts.sensitiveQueryParams))
 		}
+		location = resolved.RequestURI()
 		r, err := DoRawFull(ctx, hostname, "GET", location, nil, opts)
 		if err != nil {
 			return nil, err

--- a/pkg/runtime/poll_test.go
+++ b/pkg/runtime/poll_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -93,15 +94,47 @@ func TestPollUntilDone_AcceptsDefaultPortAbsoluteLocation(t *testing.T) {
 }
 
 func TestPollUntilDone_RejectsCrossHostAbsoluteLocation(t *testing.T) {
+	const querySecret = "poll-location-secret"
+	const password = "poll-userinfo-secret"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Location", "https://example.com/status")
+		w.Header().Set("Location", "https://user:"+password+"@example.com/status?sig="+querySecret)
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer srv.Close()
 
-	_, err := PollUntilDone(context.Background(), srv.URL, "/status", ClientOptions{Timeout: 5 * time.Second}, 30*time.Second)
-	if err == nil || err.Error() != `cross-host polling location "https://example.com/status"` {
+	opts := ClientOptions{Timeout: 5 * time.Second}
+	_, err := PollUntilDone(context.Background(), srv.URL, "/status", opts, 30*time.Second)
+	if err == nil || !strings.Contains(err.Error(), "cross-host polling location") {
 		t.Fatalf("PollUntilDone error = %v, want cross-host polling location", err)
+	}
+	if strings.Contains(err.Error(), querySecret) || strings.Contains(err.Error(), password) {
+		t.Fatalf("PollUntilDone error leaked Location credential: %v", err)
+	}
+	if !strings.Contains(err.Error(), "user:xxxxx@example.com") {
+		t.Fatalf("PollUntilDone error did not redact userinfo password: %v", err)
+	}
+}
+
+func TestPollUntilDone_RelativeLocationCannotChangeAuthority(t *testing.T) {
+	var gotHost, gotPath, gotAuth string
+	opts := ClientOptions{
+		Auth: BearerAuth{Token: "secret"},
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			gotHost = r.URL.Host
+			gotPath = r.URL.Path
+			gotAuth = r.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+		}),
+	}
+
+	if _, err := PollUntilDone(context.Background(), "trusted.example", "@attacker.example/status", opts, 30*time.Second); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+	if gotHost != "trusted.example" || gotPath != "/@attacker.example/status" {
+		t.Fatalf("poll target = %q%s, want trusted.example/@attacker.example/status", gotHost, gotPath)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("same-origin authorization = %q", gotAuth)
 	}
 }
 

--- a/pkg/runtime/poll_test.go
+++ b/pkg/runtime/poll_test.go
@@ -115,6 +115,33 @@ func TestPollUntilDone_RejectsCrossHostAbsoluteLocation(t *testing.T) {
 	}
 }
 
+func TestPollUntilDone_RejectsCrossHostRedirect(t *testing.T) {
+	reached := make(chan string, 1)
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached <- r.Header.Get("X-API-Key")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer attacker.Close()
+
+	trusted := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attacker.URL+"/status", http.StatusFound)
+	}))
+	defer trusted.Close()
+
+	_, err := PollUntilDone(context.Background(), trusted.URL, "/status", ClientOptions{
+		Auth:    APIKeyAuth{Key: "secret"},
+		Timeout: 5 * time.Second,
+	}, 30*time.Second)
+	if err == nil {
+		t.Error("PollUntilDone followed a cross-host redirect")
+	}
+	select {
+	case key := <-reached:
+		t.Errorf("cross-host redirect received X-API-Key %q", key)
+	default:
+	}
+}
+
 func TestPollUntilDone_RelativeLocationCannotChangeAuthority(t *testing.T) {
 	var gotHost, gotPath, gotAuth string
 	opts := ClientOptions{


### PR DESCRIPTION
### What's changed?

- Reject unsafe source IDs and protoc control arguments before sync or generation.
- Prevent operation aliases from shadowing canonical commands.
- Keep polling on the configured origin and redact sensitive URL data from errors, debug logs, and dry-run output.
- Upgrade Go to 1.25.13 and refresh example module dependencies.

### Why

- Prevent path traversal, unintended protoc output, polling SSRF with credential forwarding, query credential disclosure, and destructive command alias hijacking.
- Remove reachable standard-library vulnerabilities reported against Go 1.25.7.

### Verification

- `make check`
- `go test -race -count=1 ./...`
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` in the root module and all three example modules (0 reachable vulnerabilities)