### PR TITLE
fix(runtime): allow dry-run without stored credentials

### DIFF
--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -127,7 +127,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			var clientOpts ClientOptions
 			var err error
 			refreshAuth := !dryRun
-			if s.Security != nil && s.Security.Public {
+			if dryRun || (s.Security != nil && s.Security.Public) {
 				hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
 			} else {
 				hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -386,7 +386,7 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 			DefaultColumns:    []string{"id", "name"},
 			ResponseMediaType: "application/vnd.demo+json",
 		},
-		Security: &SecurityHint{Public: true},
+		Security: &SecurityHint{Scopes: []string{"users:write"}},
 	}})
 	root.SetArgs([]string{
 		"demo", "users", "create-user",
@@ -460,7 +460,7 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 	if envVar["key"] != "MANUAL_DRY_RUN" || envVar["value"] != "***" {
 		t.Fatalf("envVar = %#v", envVar)
 	}
-	if out.Auth.Required || !out.Auth.Public {
+	if !out.Auth.Required || out.Auth.Public {
 		t.Fatalf("auth = %+v", out.Auth)
 	}
 	if out.Output.ListPath != "data.items" || out.Output.ResponseMediaType != "application/vnd.demo+json" || !reflect.DeepEqual(out.Output.DefaultColumns, []string{"id", "name"}) {


### PR DESCRIPTION
### What's changed?

- Allow protected generated commands to resolve `--dry-run` without stored credentials.
- Reuse existing dry-run coverage to verify the request is resolved without network I/O and remains marked as auth-required.

### Why

- Dry-run does not send a request or refresh credentials, so requiring a stored host credential prevented request inspection for unauthenticated setups.

### Verification

- `go test ./pkg/runtime -run TestBuild_DryRunPrintsResolvedRequestWithoutSending -count=1`
- `make check`
- `go test -race ./...`

Closes #116