### PR TITLE
fix(codegen): honor OpenAPI server base paths

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -214,7 +214,7 @@ func resolveServerBasePath(servers []server, module, origin string) string {
 		fmt.Fprintf(os.Stderr, "warn: %s: unsupported server URL %q in %s (ignored)\n", module, servers[0].URL, origin)
 		return ""
 	}
-	return strings.TrimRight(u.Path, "/")
+	return strings.TrimRight(u.EscapedPath(), "/")
 }
 
 func unmarshalAuto(path string, data []byte, v any) error {

--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -18,6 +19,16 @@ type oas3Doc struct {
 	Paths      map[string]*pathItem  `json:"paths" yaml:"paths"`
 	Components *components           `json:"components,omitempty" yaml:"components,omitempty"`
 	Security   []map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers    []server              `json:"servers,omitempty" yaml:"servers,omitempty"`
+}
+
+type server struct {
+	URL       string                    `json:"url" yaml:"url"`
+	Variables map[string]serverVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
+}
+
+type serverVariable struct {
+	Default string `json:"default" yaml:"default"`
 }
 
 type components struct {
@@ -26,6 +37,7 @@ type components struct {
 
 type pathItem struct {
 	Parameters []parameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Servers    *[]server   `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Get        *operation  `json:"get,omitempty" yaml:"get,omitempty"`
 	Post       *operation  `json:"post,omitempty" yaml:"post,omitempty"`
 	Put        *operation  `json:"put,omitempty" yaml:"put,omitempty"`
@@ -42,6 +54,9 @@ type operation struct {
 	RequestBody *requestBody           `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 	Responses   map[string]response    `json:"responses" yaml:"responses"`
 	Security    *[]map[string][]string `json:"security,omitempty" yaml:"security,omitempty"`
+	Servers     *[]server              `json:"servers,omitempty" yaml:"servers,omitempty"`
+
+	serverBasePath string
 }
 
 type parameter struct {
@@ -158,9 +173,48 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 		if err := unmarshalAuto(p, data, &doc); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
+		applyServerBasePaths(&doc, src.Name, p)
 		mergeDoc(all, &doc, src.Name, p)
 	}
 	return toRawIR(src.Name, all), nil
+}
+
+func applyServerBasePaths(doc *oas3Doc, module, origin string) {
+	rootBasePath := resolveServerBasePath(doc.Servers, module, origin)
+	for _, item := range doc.Paths {
+		basePath := rootBasePath
+		if item.Servers != nil {
+			basePath = resolveServerBasePath(*item.Servers, module, origin)
+		}
+		for _, op := range []*operation{item.Get, item.Post, item.Put, item.Delete, item.Patch} {
+			if op == nil {
+				continue
+			}
+			op.serverBasePath = basePath
+			if op.Servers != nil {
+				op.serverBasePath = resolveServerBasePath(*op.Servers, module, origin)
+			}
+		}
+	}
+}
+
+func resolveServerBasePath(servers []server, module, origin string) string {
+	if len(servers) == 0 {
+		return ""
+	}
+	raw := strings.TrimSpace(servers[0].URL)
+	if raw == "" {
+		return ""
+	}
+	for name, variable := range servers[0].Variables {
+		raw = strings.ReplaceAll(raw, "{"+name+"}", variable.Default)
+	}
+	u, err := url.Parse(raw)
+	if err != nil || strings.ContainsAny(raw, "{}") || !u.IsAbs() && !strings.HasPrefix(raw, "/") {
+		fmt.Fprintf(os.Stderr, "warn: %s: unsupported server URL %q in %s (ignored)\n", module, servers[0].URL, origin)
+		return ""
+	}
+	return strings.TrimRight(u.Path, "/")
 }
 
 func unmarshalAuto(path string, data []byte, v any) error {
@@ -257,12 +311,13 @@ func toRawIR(name string, doc *oas3Doc) *rawir.RawModule {
 
 func convertOp(op *operation, method, path string, pathParams []parameter, globalSecurity []map[string][]string) rawir.RawOperation {
 	out := rawir.RawOperation{
-		OperationID: op.OperationID,
-		Summary:     op.Summary,
-		Description: op.Description,
-		Method:      method,
-		Path:        path,
-		Responses:   map[string]*rawir.RawResponse{},
+		OperationID:    op.OperationID,
+		Summary:        op.Summary,
+		Description:    op.Description,
+		Method:         method,
+		Path:           path,
+		ServerBasePath: op.serverBasePath,
+		Responses:      map[string]*rawir.RawResponse{},
 	}
 	if len(op.Tags) > 0 && op.Tags[0] != "" {
 		out.Group = op.Tags[0]

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -1,13 +1,16 @@
 package openapi3
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/lathe-cli/lathe/internal/codegen/normalize"
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
 	"github.com/lathe-cli/lathe/internal/testutil"
+	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
 func TestParse_Golden(t *testing.T) {
@@ -72,6 +75,121 @@ func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
 	if got := mod.Operations[0].Responses["200"].Schema.Properties["name"].Type; got != "string" {
 		t.Fatalf("property type = %q, want string", got)
 	}
+}
+
+func TestParse_ServerBasePathCompatibility(t *testing.T) {
+	tests := []struct {
+		name          string
+		server        string
+		variables     string
+		wantPath      string
+		wantUse       string
+		wantOperation string
+	}{
+		{
+			name:          "templated absolute URL",
+			server:        "https://{environment}.example.com/api/{version}",
+			variables:     `,"variables":{"environment":{"default":"prod"},"version":{"default":"v3"}}`,
+			wantPath:      "/api/v3/widgets",
+			wantUse:       "get-widgets",
+			wantOperation: "getWidgets",
+		},
+		{
+			name:          "ambiguous scheme-less URL",
+			server:        "api.example.com/v1",
+			wantPath:      "/widgets",
+			wantUse:       "get-widgets",
+			wantOperation: "getWidgets",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := fmt.Sprintf(`{
+  "openapi": "3.0.3",
+  "servers": [{"url": %q%s}],
+  "paths": {
+    "/widgets": {
+      "get": {"responses": {"200": {}}}
+    }
+  }
+}`, tt.server, tt.variables)
+			specs := parseNormalized(t, input)
+			if got := specs[0].PathTpl; got != tt.wantPath {
+				t.Fatalf("path = %q, want %q", got, tt.wantPath)
+			}
+			if got := specs[0].Use; got != tt.wantUse {
+				t.Fatalf("use = %q, want %q", got, tt.wantUse)
+			}
+			if got := specs[0].OperationID; got != tt.wantOperation {
+				t.Fatalf("operation id = %q, want %q", got, tt.wantOperation)
+			}
+		})
+	}
+}
+
+func TestParse_ServerOverridePrecedence(t *testing.T) {
+	input := `{
+  "openapi": "3.0.3",
+  "servers": [{"url": "/api/v1"}],
+  "paths": {
+    "/root": {
+      "get": {"operationId": "Root_Get", "responses": {"200": {}}}
+    },
+    "/health": {
+      "servers": [{"url": "/"}],
+      "get": {"operationId": "Health_Get", "responses": {"200": {}}}
+    },
+    "/widgets": {
+      "servers": [{"url": "/api/v2"}],
+      "get": {
+        "operationId": "Widget_Get",
+        "servers": [{"url": "/api/v3"}],
+        "responses": {"200": {}}
+      },
+      "post": {"operationId": "Widget_Create", "responses": {"200": {}}}
+    }
+  }
+}`
+	want := map[string]string{
+		"Root_Get":      "/api/v1/root",
+		"Health_Get":    "/health",
+		"Widget_Get":    "/api/v3/widgets",
+		"Widget_Create": "/api/v2/widgets",
+	}
+	for _, spec := range parseNormalized(t, input) {
+		if got := spec.PathTpl; got != want[spec.OperationID] {
+			t.Errorf("%s path = %q, want %q", spec.OperationID, got, want[spec.OperationID])
+		}
+		delete(want, spec.OperationID)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing operations: %v", want)
+	}
+}
+
+func parseNormalized(t *testing.T, input string) []runtime.CommandSpec {
+	t.Helper()
+	syncDir := t.TempDir()
+	inputPath := filepath.Join(syncDir, "openapi.json")
+	if err := os.WriteFile(inputPath, []byte(input), 0o644); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+
+	src := &sourceconfig.Source{
+		Name: "demo",
+		OpenAPI3: &sourceconfig.OpenAPI3Config{
+			Files: []string{"openapi.json"},
+		},
+	}
+	mod, err := Parse(src, syncDir)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	specs := normalize.Normalize(mod)
+	if len(specs) == 0 {
+		t.Fatal("Normalize produced no commands")
+	}
+	return specs
 }
 
 func TestParse_RejectsOpenAPI31MultiTypeUnion(t *testing.T) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -101,6 +101,20 @@ func TestParse_ServerBasePathCompatibility(t *testing.T) {
 			wantUse:       "get-widgets",
 			wantOperation: "getWidgets",
 		},
+		{
+			name:          "encoded path separator",
+			server:        "https://example.com/api%2Fv1",
+			wantPath:      "/api%2Fv1/widgets",
+			wantUse:       "get-widgets",
+			wantOperation: "getWidgets",
+		},
+		{
+			name:          "encoded query delimiter",
+			server:        "/api%3Ftenant",
+			wantPath:      "/api%3Ftenant/widgets",
+			wantUse:       "get-widgets",
+			wantOperation: "getWidgets",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -35,7 +35,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 			Short:       pickShort(op),
 			OperationID: opID,
 			Method:      op.Method,
-			PathTpl:     op.Path,
+			PathTpl:     joinBasePath(op.ServerBasePath, op.Path),
 		}
 		for _, pp := range op.Parameters {
 			switch pp.In {
@@ -83,6 +83,14 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 	})
 	disambiguateUse(specs)
 	return specs
+}
+
+func joinBasePath(basePath, operationPath string) string {
+	basePath = strings.TrimRight(basePath, "/")
+	if basePath == "" {
+		return operationPath
+	}
+	return "/" + strings.TrimLeft(basePath, "/") + "/" + strings.TrimLeft(operationPath, "/")
 }
 
 // synthOperationID builds a camelCase id like "getUsersId" from a method and

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -7,18 +7,19 @@ type RawModule struct {
 }
 
 type RawOperation struct {
-	Group       string
-	OperationID string
-	Summary     string
-	Description string
-	Method      string
-	Path        string
-	Parameters  []RawParameter
-	RequestBody *RawRequestBody
-	Responses   map[string]*RawResponse
-	Produces    []string
-	Security    []RawSecurityReq
-	Output      *RawOutputHints `json:",omitempty"`
+	Group          string
+	OperationID    string
+	Summary        string
+	Description    string
+	Method         string
+	Path           string
+	ServerBasePath string `json:",omitempty"`
+	Parameters     []RawParameter
+	RequestBody    *RawRequestBody
+	Responses      map[string]*RawResponse
+	Produces       []string
+	Security       []RawSecurityReq
+	Output         *RawOutputHints `json:",omitempty"`
 }
 
 type RawSecurityReq struct {


### PR DESCRIPTION
## Summary

- preserve OpenAPI server base paths through the raw IR instead of rewriting operation paths
- resolve server variable defaults and honor operation, path, then root server precedence
- keep generated command names and synthesized operation IDs stable while correcting HTTP path templates

## Verification

- `go test ./internal/codegen/backends/openapi3 -run 'TestParse_Server(BasePathCompatibility|OverridePrecedence)' -count=1`
- `make check`

## Compatibility

Generated OpenAPI 3 commands now prepend the selected server pathname to HTTP path templates. Command names and synthesized operation IDs remain based on the original operation path. Ambiguous scheme-less server URLs are ignored with a warning. There is no catalog schema version change.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] No documentation update is required; command syntax and workflows are unchanged.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.