### PR TITLE
fix(codegen): honor non-200 success responses

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -356,12 +356,14 @@ func convertOp(op *operation, method, path string, pathParams []parameter, globa
 		if mt, ok := resp.Content["application/json"]; ok {
 			rs.Schema = convertSchema(mt.Schema)
 			rs.MediaType = "application/json"
-		} else {
-			for ct, mt := range resp.Content {
-				rs.Schema = convertSchema(mt.Schema)
-				rs.MediaType = ct
-				break
+		} else if len(resp.Content) > 0 {
+			mediaTypes := make([]string, 0, len(resp.Content))
+			for ct := range resp.Content {
+				mediaTypes = append(mediaTypes, ct)
 			}
+			sort.Strings(mediaTypes)
+			rs.MediaType = mediaTypes[0]
+			rs.Schema = convertSchema(resp.Content[mediaTypes[0]].Schema)
 		}
 		out.Responses[code] = rs
 	}

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -404,7 +404,14 @@ const requestBodyNonJSON = `{
             "application/xml": {"schema": {"type": "object", "properties": {"id": {"type": "string"}}}}
           }
         },
-        "responses": {}
+        "responses": {
+          "201": {
+            "content": {
+              "text/plain": {"schema": {"type": "object", "properties": {"message": {"type": "string"}}}},
+              "application/pdf": {"schema": {"type": "string"}}
+            }
+          }
+        }
       }
     }
   }

--- a/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
@@ -26,7 +26,17 @@
           "Items": null
         }
       },
-      "Responses": {},
+      "Responses": {
+        "201": {
+          "Schema": {
+            "Ref": "",
+            "Type": "string",
+            "Properties": null,
+            "Items": null
+          },
+          "MediaType": "application/pdf"
+        }
+      },
       "Produces": null,
       "Security": null
     }

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -475,8 +475,8 @@ func helpText(p rawir.RawParameter) string {
 }
 
 func deriveList(op rawir.RawOperation, defs map[string]*rawir.RawSchema) (string, string) {
-	r, ok := op.Responses["200"]
-	if !ok || r == nil || r.Schema == nil {
+	r := successfulResponse(op.Responses)
+	if r == nil || r.Schema == nil {
 		return "", ""
 	}
 	s := rawir.Resolve(r.Schema, defs)
@@ -659,7 +659,7 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 }
 
 func deriveResponseMediaType(op rawir.RawOperation) string {
-	if r, ok := op.Responses["200"]; ok && r != nil && r.MediaType != "" {
+	if r := successfulResponse(op.Responses); r != nil && r.MediaType != "" {
 		return r.MediaType
 	}
 	if len(op.Produces) > 0 {
@@ -711,8 +711,8 @@ func derivePagination(op rawir.RawOperation) *runtime.PaginationHint {
 	}
 
 	var tokenField string
-	r, ok := op.Responses["200"]
-	if ok && r != nil && r.Schema != nil && r.Schema.Properties != nil {
+	r := successfulResponse(op.Responses)
+	if r != nil && r.Schema != nil && r.Schema.Properties != nil {
 		for k := range r.Schema.Properties {
 			if paginationTokenFields[k] {
 				tokenField = k
@@ -741,12 +741,29 @@ func deriveStreaming(op rawir.RawOperation) *runtime.StreamingHint {
 			return &runtime.StreamingHint{Strategy: s}
 		}
 	}
-	if r, ok := op.Responses["200"]; ok && r != nil && r.MediaType != "" {
+	if r := successfulResponse(op.Responses); r != nil && r.MediaType != "" {
 		if s, ok := streamingMediaTypes[r.MediaType]; ok {
 			return &runtime.StreamingHint{Strategy: s}
 		}
 	}
 	return nil
+}
+
+func successfulResponse(responses map[string]*rawir.RawResponse) *rawir.RawResponse {
+	if response, ok := responses["200"]; ok {
+		return response
+	}
+	status := 300
+	var selected *rawir.RawResponse
+	for code, response := range responses {
+		candidate, err := strconv.Atoi(code)
+		if err != nil || candidate < 200 || candidate >= status {
+			continue
+		}
+		status = candidate
+		selected = response
+	}
+	return selected
 }
 
 func deriveSecurity(op rawir.RawOperation) *runtime.SecurityHint {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -659,8 +659,18 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 }
 
 func deriveResponseMediaType(op rawir.RawOperation) string {
-	if r := successfulResponse(op.Responses); r != nil && r.MediaType != "" {
-		return r.MediaType
+	if response, ok := op.Responses["200"]; ok {
+		if response != nil && response.MediaType != "" {
+			return response.MediaType
+		}
+	} else {
+		mediaType, consistent := commonSuccessMediaType(op.Responses)
+		if !consistent {
+			return ""
+		}
+		if mediaType != "" {
+			return mediaType
+		}
 	}
 	if len(op.Produces) > 0 {
 		return op.Produces[0]
@@ -756,14 +766,36 @@ func successfulResponse(responses map[string]*rawir.RawResponse) *rawir.RawRespo
 	status := 300
 	var selected *rawir.RawResponse
 	for code, response := range responses {
-		candidate, err := strconv.Atoi(code)
-		if err != nil || candidate < 200 || candidate >= status {
+		candidate, ok := explicitSuccessStatus(code)
+		if !ok || candidate >= status {
 			continue
 		}
 		status = candidate
 		selected = response
 	}
 	return selected
+}
+
+func commonSuccessMediaType(responses map[string]*rawir.RawResponse) (string, bool) {
+	var mediaType string
+	for code, response := range responses {
+		if _, ok := explicitSuccessStatus(code); !ok || response == nil || response.MediaType == "" {
+			continue
+		}
+		if mediaType == "" {
+			mediaType = response.MediaType
+			continue
+		}
+		if response.MediaType != mediaType {
+			return "", false
+		}
+	}
+	return mediaType, true
+}
+
+func explicitSuccessStatus(code string) (int, bool) {
+	status, err := strconv.Atoi(code)
+	return status, err == nil && status >= 200 && status < 300
 }
 
 func deriveSecurity(op rawir.RawOperation) *runtime.SecurityHint {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -2,6 +2,7 @@ package normalize
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -475,8 +476,8 @@ func helpText(p rawir.RawParameter) string {
 }
 
 func deriveList(op rawir.RawOperation, defs map[string]*rawir.RawSchema) (string, string) {
-	r := successfulResponse(op.Responses)
-	if r == nil || r.Schema == nil {
+	r, compatible := successfulResponse(op.Responses)
+	if !compatible || r == nil || r.Schema == nil {
 		return "", ""
 	}
 	s := rawir.Resolve(r.Schema, defs)
@@ -721,7 +722,10 @@ func derivePagination(op rawir.RawOperation) *runtime.PaginationHint {
 	}
 
 	var tokenField string
-	r := successfulResponse(op.Responses)
+	r, compatible := successfulResponse(op.Responses)
+	if !compatible {
+		return nil
+	}
 	if r != nil && r.Schema != nil && r.Schema.Properties != nil {
 		for k := range r.Schema.Properties {
 			if paginationTokenFields[k] {
@@ -751,17 +755,17 @@ func deriveStreaming(op rawir.RawOperation) *runtime.StreamingHint {
 			return &runtime.StreamingHint{Strategy: s}
 		}
 	}
-	if r := successfulResponse(op.Responses); r != nil && r.MediaType != "" {
-		if s, ok := streamingMediaTypes[r.MediaType]; ok {
+	if mediaType := deriveResponseMediaType(op); mediaType != "" {
+		if s, ok := streamingMediaTypes[mediaType]; ok {
 			return &runtime.StreamingHint{Strategy: s}
 		}
 	}
 	return nil
 }
 
-func successfulResponse(responses map[string]*rawir.RawResponse) *rawir.RawResponse {
+func successfulResponse(responses map[string]*rawir.RawResponse) (*rawir.RawResponse, bool) {
 	if response, ok := responses["200"]; ok {
-		return response
+		return response, true
 	}
 	status := 300
 	var selected *rawir.RawResponse
@@ -773,7 +777,26 @@ func successfulResponse(responses map[string]*rawir.RawResponse) *rawir.RawRespo
 		status = candidate
 		selected = response
 	}
-	return selected
+	if status == 300 {
+		return nil, true
+	}
+	var selectedSchema *rawir.RawSchema
+	if selected != nil {
+		selectedSchema = selected.Schema
+	}
+	for code, response := range responses {
+		if _, ok := explicitSuccessStatus(code); !ok {
+			continue
+		}
+		var schema *rawir.RawSchema
+		if response != nil {
+			schema = response.Schema
+		}
+		if !reflect.DeepEqual(schema, selectedSchema) {
+			return nil, false
+		}
+	}
+	return selected, true
 }
 
 func commonSuccessMediaType(responses map[string]*rawir.RawResponse) (string, bool) {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -476,6 +476,9 @@ func helpText(p rawir.RawParameter) string {
 }
 
 func deriveList(op rawir.RawOperation, defs map[string]*rawir.RawSchema) (string, string) {
+	if !supportsJSONOutput(deriveResponseMediaType(op)) {
+		return "", ""
+	}
 	r, compatible := successfulResponse(op.Responses)
 	if !compatible || r == nil || r.Schema == nil {
 		return "", ""
@@ -679,6 +682,15 @@ func deriveResponseMediaType(op rawir.RawOperation) string {
 	return ""
 }
 
+func supportsJSONOutput(mediaType string) bool {
+	mediaType, _, _ = strings.Cut(strings.ToLower(strings.TrimSpace(mediaType)), ";")
+	mediaType = strings.TrimSpace(mediaType)
+	if _, streaming := streamingMediaTypes[mediaType]; streaming {
+		return false
+	}
+	return mediaType == "" || mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
 var paginationTokenParams = map[string]bool{
 	"page_token": true, "pageToken": true,
 	"cursor": true, "after": true,
@@ -697,7 +709,7 @@ var paginationTokenFields = map[string]bool{
 }
 
 func derivePagination(op rawir.RawOperation) *runtime.PaginationHint {
-	if op.Method != "GET" {
+	if op.Method != "GET" || !supportsJSONOutput(deriveResponseMediaType(op)) {
 		return nil
 	}
 	var tokenParam, limitParam string

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -780,19 +780,11 @@ func successfulResponse(responses map[string]*rawir.RawResponse) (*rawir.RawResp
 	if status == 300 {
 		return nil, true
 	}
-	var selectedSchema *rawir.RawSchema
-	if selected != nil {
-		selectedSchema = selected.Schema
-	}
 	for code, response := range responses {
 		if _, ok := explicitSuccessStatus(code); !ok {
 			continue
 		}
-		var schema *rawir.RawSchema
-		if response != nil {
-			schema = response.Schema
-		}
-		if !reflect.DeepEqual(schema, selectedSchema) {
+		if !reflect.DeepEqual(response, selected) {
 			return nil, false
 		}
 	}

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -41,6 +41,22 @@ func TestNormalize_Golden(t *testing.T) {
 	}
 }
 
+func TestNormalize_HeterogeneousSuccessResponsesOmitDerivedOutputHints(t *testing.T) {
+	mod := listResponse()
+	op := &mod.Operations[0]
+	op.Parameters = []rawir.RawParameter{{Name: "page_token", In: "query", Type: "string"}}
+	op.Responses["201"].MediaType = "text/event-stream"
+	op.Responses["202"] = &rawir.RawResponse{
+		Schema:    &rawir.RawSchema{Type: "array", Items: &rawir.RawSchema{Type: "string"}},
+		MediaType: "application/zip",
+	}
+
+	out := Normalize(mod)[0].Output
+	if out.ListPath != "" || len(out.DefaultColumns) != 0 || out.ResponseMediaType != "" || out.Pagination != nil || out.Streaming != nil {
+		t.Fatalf("output hints = %+v, want no derived hints", out)
+	}
+}
+
 func minimalGet() *rawir.RawModule {
 	return &rawir.RawModule{
 		Name: "demo",
@@ -139,6 +155,7 @@ func listResponse() *rawir.RawModule {
 			Path:        "/items",
 			Responses: map[string]*rawir.RawResponse{
 				"201": {Schema: envelope, MediaType: "application/json"},
+				"202": {Schema: envelope, MediaType: "application/json"},
 			},
 		}},
 	}

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -57,6 +57,18 @@ func TestNormalize_HeterogeneousSuccessResponsesOmitDerivedOutputHints(t *testin
 	}
 }
 
+func TestNormalize_HeterogeneousSuccessMediaOmitJSONOutputHints(t *testing.T) {
+	mod := listResponse()
+	op := &mod.Operations[0]
+	op.Parameters = []rawir.RawParameter{{Name: "page_token", In: "query", Type: "string"}}
+	op.Responses["202"].MediaType = "application/xml"
+
+	out := Normalize(mod)[0].Output
+	if out.ListPath != "" || len(out.DefaultColumns) != 0 || out.Pagination != nil {
+		t.Fatalf("output hints = %+v, want no JSON-dependent hints", out)
+	}
+}
+
 func minimalGet() *rawir.RawModule {
 	return &rawir.RawModule{
 		Name: "demo",

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -138,7 +138,7 @@ func listResponse() *rawir.RawModule {
 			Method:      "GET",
 			Path:        "/items",
 			Responses: map[string]*rawir.RawResponse{
-				"200": {Schema: envelope},
+				"201": {Schema: envelope},
 			},
 		}},
 	}
@@ -334,9 +334,9 @@ func responseMediaType() *rawir.RawModule {
 			Parameters: []rawir.RawParameter{
 				{Name: "id", In: "path", Required: true, Type: "string"},
 			},
-			Produces: []string{"application/pdf"},
 			Responses: map[string]*rawir.RawResponse{
-				"200": {MediaType: "application/pdf"},
+				"201": {MediaType: "application/pdf"},
+				"202": {MediaType: "application/zip"},
 			},
 		}},
 	}

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -69,6 +69,19 @@ func TestNormalize_HeterogeneousSuccessMediaOmitJSONOutputHints(t *testing.T) {
 	}
 }
 
+func TestNormalize_NonJSONSuccessOmitsJSONOutputHints(t *testing.T) {
+	mod := listResponse()
+	op := &mod.Operations[0]
+	op.Parameters = []rawir.RawParameter{{Name: "page_token", In: "query", Type: "string"}}
+	op.Responses["201"].MediaType = "application/xml"
+	delete(op.Responses, "202")
+
+	out := Normalize(mod)[0].Output
+	if out.ListPath != "" || len(out.DefaultColumns) != 0 || out.Pagination != nil {
+		t.Fatalf("output hints = %+v, want no JSON-dependent hints", out)
+	}
+}
+
 func minimalGet() *rawir.RawModule {
 	return &rawir.RawModule{
 		Name: "demo",

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -138,7 +138,7 @@ func listResponse() *rawir.RawModule {
 			Method:      "GET",
 			Path:        "/items",
 			Responses: map[string]*rawir.RawResponse{
-				"201": {Schema: envelope},
+				"201": {Schema: envelope, MediaType: "application/json"},
 			},
 		}},
 	}

--- a/internal/codegen/normalize/testdata/list-response.golden.json
+++ b/internal/codegen/normalize/testdata/list-response.golden.json
@@ -20,7 +20,7 @@
         "id",
         "age"
       ],
-      "ResponseMediaType": "",
+      "ResponseMediaType": "application/json",
       "Pagination": null,
       "Streaming": null
     },

--- a/internal/codegen/normalize/testdata/response-media-type.golden.json
+++ b/internal/codegen/normalize/testdata/response-media-type.golden.json
@@ -29,7 +29,7 @@
     "Output": {
       "ListPath": "",
       "DefaultColumns": null,
-      "ResponseMediaType": "application/pdf",
+      "ResponseMediaType": "",
       "Pagination": null,
       "Streaming": null
     },


### PR DESCRIPTION
## Summary

- Select response metadata from HTTP 200 or the lowest explicit numeric 2xx response.
- Reuse the selected response for list inference, output media, pagination, and streaming hints.

## Verification

- `go test ./internal/codegen/normalize -run 'TestNormalize_Golden/(list-response|response-media-type|streaming-sse|pagination-cursor)' -count=100`
- `go test -race -count=1 ./internal/codegen/normalize`
- `make check`
- Generated downstream CLI: 201 upload response reports `application/json`.
- Generated downstream CLI: `__lathe verify --json` passed 31/31 checks.

## Compatibility

HTTP 200 remains preferred. Generated commands backed only by another explicit 2xx response now expose response-derived output hints. No catalog schema or command shape changes.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.