### PR TITLE
fix(codegen): infer compatible success response hints

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -357,10 +357,17 @@ func convertOp(op *operation, method, path string, pathParams []parameter, globa
 			rs.Schema = convertSchema(mt.Schema)
 			rs.MediaType = "application/json"
 		} else {
-			for ct, mt := range resp.Content {
-				rs.Schema = convertSchema(mt.Schema)
-				rs.MediaType = ct
-				break
+			mediaTypes := make([]string, 0, len(resp.Content))
+			for mediaType := range resp.Content {
+				if mediaType != "" {
+					mediaTypes = append(mediaTypes, mediaType)
+				}
+			}
+			sort.Strings(mediaTypes)
+			if len(mediaTypes) > 0 {
+				mediaType := mediaTypes[0]
+				rs.Schema = convertSchema(resp.Content[mediaType].Schema)
+				rs.MediaType = mediaType
 			}
 		}
 		out.Responses[code] = rs

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -77,6 +77,51 @@ func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
 	}
 }
 
+func TestParse_ResponseContentSelectionIsDeterministic(t *testing.T) {
+	syncDir := t.TempDir()
+	input := `{
+  "openapi": "3.0.3",
+  "paths": {
+    "/exports": {
+      "get": {
+        "operationId": "Export_Get",
+        "responses": {
+          "201": {
+            "content": {
+              "text/plain": {"schema": {"type": "string"}},
+              "application/xml": {
+                "schema": {"type": "object", "properties": {"id": {"type": "string"}}}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(syncDir, "openapi.json"), []byte(input), 0o644); err != nil {
+		t.Fatalf("seed input: %v", err)
+	}
+	src := &sourceconfig.Source{
+		Name:     "demo",
+		OpenAPI3: &sourceconfig.OpenAPI3Config{Files: []string{"openapi.json"}},
+	}
+
+	for i := 0; i < 100; i++ {
+		mod, err := Parse(src, syncDir)
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		response := mod.Operations[0].Responses["201"]
+		if response.MediaType != "application/xml" {
+			t.Fatalf("iteration %d: media type = %q, want application/xml", i, response.MediaType)
+		}
+		if response.Schema == nil || response.Schema.Type != "object" || response.Schema.Properties["id"] == nil {
+			t.Fatalf("iteration %d: schema = %#v, want application/xml schema", i, response.Schema)
+		}
+	}
+}
+
 func TestParse_ServerBasePathCompatibility(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -2,6 +2,8 @@ package normalize
 
 import (
 	"fmt"
+	"mime"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,7 +68,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 			spec.Output.DefaultColumns = defaultColumns(itemRef, mod.Schemas)
 		}
 		spec.Output.ResponseMediaType = deriveResponseMediaType(op)
-		spec.Output.Pagination = derivePagination(op)
+		spec.Output.Pagination = derivePagination(op, mod.Schemas)
 		spec.Output.Streaming = deriveStreaming(op)
 		applyRawOutputHints(&spec, op.Output)
 		spec.Security = deriveSecurity(op)
@@ -475,11 +477,11 @@ func helpText(p rawir.RawParameter) string {
 }
 
 func deriveList(op rawir.RawOperation, defs map[string]*rawir.RawSchema) (string, string) {
-	r, ok := op.Responses["200"]
-	if !ok || r == nil || r.Schema == nil {
+	schema := compatibleResponseSchema(op, defs)
+	if schema == nil {
 		return "", ""
 	}
-	s := rawir.Resolve(r.Schema, defs)
+	s := rawir.Resolve(schema, defs)
 	if s == nil {
 		return "", ""
 	}
@@ -659,13 +661,35 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 }
 
 func deriveResponseMediaType(op rawir.RawOperation) string {
-	if r, ok := op.Responses["200"]; ok && r != nil && r.MediaType != "" {
-		return r.MediaType
+	responses := successResponses(op)
+	if len(responses) == 0 {
+		return ""
 	}
-	if len(op.Produces) > 0 {
-		return op.Produces[0]
+	if r, ok := op.Responses["200"]; ok {
+		if r != nil && r.MediaType != "" {
+			return r.MediaType
+		}
+		if len(op.Produces) > 0 {
+			return op.Produces[0]
+		}
+		return ""
 	}
-	return ""
+
+	mediaType := ""
+	for _, response := range responses {
+		mediaTypes := responseMediaTypes(op, response)
+		if len(mediaTypes) != 1 {
+			return ""
+		}
+		if mediaType == "" {
+			mediaType = mediaTypes[0]
+			continue
+		}
+		if mediaType != mediaTypes[0] {
+			return ""
+		}
+	}
+	return mediaType
 }
 
 var paginationTokenParams = map[string]bool{
@@ -685,8 +709,12 @@ var paginationTokenFields = map[string]bool{
 	"cursor": true,
 }
 
-func derivePagination(op rawir.RawOperation) *runtime.PaginationHint {
+func derivePagination(op rawir.RawOperation, defs map[string]*rawir.RawSchema) *runtime.PaginationHint {
 	if op.Method != "GET" {
+		return nil
+	}
+	schema := compatibleResponseSchema(op, defs)
+	if schema == nil {
 		return nil
 	}
 	var tokenParam, limitParam string
@@ -711,9 +739,13 @@ func derivePagination(op rawir.RawOperation) *runtime.PaginationHint {
 	}
 
 	var tokenField string
-	r, ok := op.Responses["200"]
-	if ok && r != nil && r.Schema != nil && r.Schema.Properties != nil {
-		for k := range r.Schema.Properties {
+	if schema = rawir.Resolve(schema, defs); schema != nil {
+		keys := make([]string, 0, len(schema.Properties))
+		for k := range schema.Properties {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
 			if paginationTokenFields[k] {
 				tokenField = k
 				break
@@ -736,17 +768,114 @@ var streamingMediaTypes = map[string]string{
 }
 
 func deriveStreaming(op rawir.RawOperation) *runtime.StreamingHint {
-	for _, ct := range op.Produces {
-		if s, ok := streamingMediaTypes[ct]; ok {
-			return &runtime.StreamingHint{Strategy: s}
+	responses := successResponses(op)
+	if len(responses) == 0 {
+		return nil
+	}
+	strategy := ""
+	for _, response := range responses {
+		mediaTypes := responseMediaTypes(op, response)
+		if len(mediaTypes) == 0 {
+			return nil
+		}
+		for _, mediaType := range mediaTypes {
+			current := streamingStrategy(mediaType)
+			if current == "" {
+				return nil
+			}
+			if strategy == "" {
+				strategy = current
+				continue
+			}
+			if strategy != current {
+				return nil
+			}
 		}
 	}
-	if r, ok := op.Responses["200"]; ok && r != nil && r.MediaType != "" {
-		if s, ok := streamingMediaTypes[r.MediaType]; ok {
-			return &runtime.StreamingHint{Strategy: s}
+	return &runtime.StreamingHint{Strategy: strategy}
+}
+
+func successResponses(op rawir.RawOperation) []*rawir.RawResponse {
+	if response, ok := op.Responses["200"]; ok {
+		return []*rawir.RawResponse{response}
+	}
+	codes := make([]string, 0, len(op.Responses))
+	for code := range op.Responses {
+		if len(code) != 3 {
+			continue
+		}
+		status, err := strconv.Atoi(code)
+		if err == nil && status >= 200 && status <= 299 {
+			codes = append(codes, code)
 		}
 	}
-	return nil
+	sort.Strings(codes)
+	responses := make([]*rawir.RawResponse, 0, len(codes))
+	for _, code := range codes {
+		responses = append(responses, op.Responses[code])
+	}
+	return responses
+}
+
+func responseMediaTypes(op rawir.RawOperation, response *rawir.RawResponse) []string {
+	if response != nil && response.MediaType != "" {
+		return []string{response.MediaType}
+	}
+	seen := map[string]bool{}
+	var mediaTypes []string
+	for _, mediaType := range op.Produces {
+		if mediaType != "" && !seen[mediaType] {
+			seen[mediaType] = true
+			mediaTypes = append(mediaTypes, mediaType)
+		}
+	}
+	return mediaTypes
+}
+
+func compatibleResponseSchema(op rawir.RawOperation, defs map[string]*rawir.RawSchema) *rawir.RawSchema {
+	responses := successResponses(op)
+	if len(responses) == 0 {
+		return nil
+	}
+	var schema *rawir.RawSchema
+	var normalized *runtime.SchemaSpec
+	for _, response := range responses {
+		if response == nil || response.Schema == nil {
+			return nil
+		}
+		for _, mediaType := range responseMediaTypes(op, response) {
+			if !isJSONMediaType(mediaType) || streamingStrategy(mediaType) != "" {
+				return nil
+			}
+		}
+		current := runtimeSchema(response.Schema, defs, map[string]bool{})
+		if schema == nil {
+			schema = response.Schema
+			normalized = current
+			continue
+		}
+		if !reflect.DeepEqual(normalized, current) {
+			return nil
+		}
+	}
+	return schema
+}
+
+func isJSONMediaType(mediaType string) bool {
+	mediaType = baseMediaType(mediaType)
+	return mediaType == "application/json" || strings.HasPrefix(mediaType, "application/") && strings.HasSuffix(mediaType, "+json")
+}
+
+func streamingStrategy(mediaType string) string {
+	return streamingMediaTypes[baseMediaType(mediaType)]
+}
+
+func baseMediaType(mediaType string) string {
+	base, _, err := mime.ParseMediaType(mediaType)
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(base)
 }
 
 func deriveSecurity(op rawir.RawOperation) *runtime.SecurityHint {

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -1,10 +1,12 @@
 package normalize
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 	"github.com/lathe-cli/lathe/internal/testutil"
+	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
 // Each case supplies a constructed rawir.RawModule and asserts the
@@ -37,6 +39,210 @@ func TestNormalize_Golden(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			specs := Normalize(tc.input())
 			testutil.AssertNamedJSONGolden(t, tc.name, specs)
+		})
+	}
+}
+
+func TestNormalize_SuccessResponseHints(t *testing.T) {
+	listSchema := func(listPath string) *rawir.RawSchema {
+		return &rawir.RawSchema{
+			Type: "object",
+			Properties: map[string]*rawir.RawSchema{
+				listPath:          {Type: "array", Items: &rawir.RawSchema{Ref: rawir.RefPrefix + "Item"}},
+				"next_page_token": {Type: "string"},
+			},
+		}
+	}
+	response := func(mediaType, listPath string) *rawir.RawResponse {
+		return &rawir.RawResponse{MediaType: mediaType, Schema: listSchema(listPath)}
+	}
+	normalize := func(responses map[string]*rawir.RawResponse, produces ...string) runtime.OutputHints {
+		t.Helper()
+		mod := &rawir.RawModule{
+			Name: "demo",
+			Schemas: map[string]*rawir.RawSchema{
+				"Item": {Type: "object", Properties: map[string]*rawir.RawSchema{
+					"id":   {Type: "string"},
+					"name": {Type: "string"},
+				}},
+			},
+			Operations: []rawir.RawOperation{{
+				Group:       "Items",
+				OperationID: "Items_List",
+				Method:      "GET",
+				Path:        "/items",
+				Parameters: []rawir.RawParameter{
+					{Name: "page_token", In: "query", Type: "string"},
+					{Name: "limit", In: "query", Type: "integer"},
+				},
+				Responses: responses,
+				Produces:  produces,
+			}},
+		}
+		return Normalize(mod)[0].Output
+	}
+
+	jsonHints := runtime.OutputHints{
+		ListPath:          "items",
+		DefaultColumns:    []string{"name", "id"},
+		ResponseMediaType: "application/json",
+		Pagination: &runtime.PaginationHint{
+			Strategy:   "cursor",
+			TokenParam: "page_token",
+			TokenField: "next_page_token",
+			LimitParam: "limit",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		responses map[string]*rawir.RawResponse
+		produces  []string
+		want      runtime.OutputHints
+	}{
+		{
+			name: "200 remains authoritative",
+			responses: map[string]*rawir.RawResponse{
+				"200": response("application/json", "items"),
+				"201": response("text/event-stream", "data"),
+			},
+			want: jsonHints,
+		},
+		{
+			name: "200 keeps produces fallback",
+			responses: map[string]*rawir.RawResponse{
+				"200": response("", "items"),
+				"201": response("application/xml", "data"),
+			},
+			produces: []string{"application/json"},
+			want:     jsonHints,
+		},
+		{
+			name:      "lone 201 matches 200",
+			responses: map[string]*rawir.RawResponse{"201": response("application/json", "items")},
+			want:      jsonHints,
+		},
+		{
+			name: "identical JSON schemas retain hints",
+			responses: map[string]*rawir.RawResponse{
+				"201": response("application/json", "items"),
+				"202": response("application/json", "items"),
+			},
+			want: jsonHints,
+		},
+		{
+			name: "compatible JSON media retain schema hints only",
+			responses: map[string]*rawir.RawResponse{
+				"201": response("application/json", "items"),
+				"202": response("application/vnd.demo+json", "items"),
+			},
+			want: runtime.OutputHints{
+				ListPath:       jsonHints.ListPath,
+				DefaultColumns: jsonHints.DefaultColumns,
+				Pagination:     jsonHints.Pagination,
+			},
+		},
+		{
+			name: "incompatible schemas omit schema hints",
+			responses: map[string]*rawir.RawResponse{
+				"201": response("application/json", "items"),
+				"202": response("application/json", "data"),
+			},
+			want: runtime.OutputHints{ResponseMediaType: "application/json"},
+		},
+		{
+			name: "mixed JSON and streaming media omit unsafe hints",
+			responses: map[string]*rawir.RawResponse{
+				"201": response("application/json", "items"),
+				"202": response("text/event-stream", "items"),
+			},
+		},
+		{
+			name: "mixed streaming strategies omit streaming hint",
+			responses: map[string]*rawir.RawResponse{
+				"201": {MediaType: "text/event-stream"},
+				"202": {MediaType: "application/x-ndjson"},
+			},
+		},
+		{
+			name: "compatible streaming strategies retain streaming hint",
+			responses: map[string]*rawir.RawResponse{
+				"201": {MediaType: "application/x-ndjson"},
+				"202": {MediaType: "application/stream+json"},
+			},
+			want: runtime.OutputHints{Streaming: &runtime.StreamingHint{Strategy: "ndjson"}},
+		},
+		{
+			name: "homogeneous streaming responses retain streaming hint",
+			responses: map[string]*rawir.RawResponse{
+				"201": {MediaType: "text/event-stream"},
+				"202": {MediaType: "text/event-stream"},
+			},
+			want: runtime.OutputHints{
+				ResponseMediaType: "text/event-stream",
+				Streaming:         &runtime.StreamingHint{Strategy: "sse"},
+			},
+		},
+		{
+			name:      "non JSON schema does not expose JSON hints",
+			responses: map[string]*rawir.RawResponse{"201": response("application/xml", "items")},
+			want:      runtime.OutputHints{ResponseMediaType: "application/xml"},
+		},
+		{
+			name: "missing schema invalidates schema hints",
+			responses: map[string]*rawir.RawResponse{
+				"201": response("application/json", "items"),
+				"204": {MediaType: "application/json"},
+			},
+			want: runtime.OutputHints{ResponseMediaType: "application/json"},
+		},
+		{
+			name:      "unknown media preserves schema hints",
+			responses: map[string]*rawir.RawResponse{"201": response("", "items")},
+			want: runtime.OutputHints{
+				ListPath:       jsonHints.ListPath,
+				DefaultColumns: jsonHints.DefaultColumns,
+				Pagination:     jsonHints.Pagination,
+			},
+		},
+		{
+			name:      "single produces media applies to explicit 201",
+			responses: map[string]*rawir.RawResponse{"201": response("", "items")},
+			produces:  []string{"application/json"},
+			want:      jsonHints,
+		},
+		{
+			name:      "mixed produces media invalidates JSON hints",
+			responses: map[string]*rawir.RawResponse{"201": response("", "items")},
+			produces:  []string{"application/json", "application/xml"},
+		},
+		{
+			name: "non explicit and non success keys are ignored",
+			responses: map[string]*rawir.RawResponse{
+				"201":     response("application/json", "items"),
+				"default": response("application/xml", "data"),
+				"2XX":     response("text/event-stream", "data"),
+				"300":     response("application/xml", "data"),
+				"success": response("application/xml", "data"),
+			},
+			want: jsonHints,
+		},
+		{
+			name: "produces alone is not a success response",
+			responses: map[string]*rawir.RawResponse{
+				"default": response("application/json", "items"),
+				"2XX":     response("application/json", "items"),
+			},
+			produces: []string{"application/json"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalize(tt.responses, tt.produces...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Output = %#v, want %#v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/codegen/normalize/testdata/minimal-get.golden.json
+++ b/internal/codegen/normalize/testdata/minimal-get.golden.json
@@ -42,12 +42,7 @@
       "ListPath": "",
       "DefaultColumns": null,
       "ResponseMediaType": "",
-      "Pagination": {
-        "Strategy": "cursor",
-        "TokenParam": "",
-        "TokenField": "",
-        "LimitParam": "limit"
-      },
+      "Pagination": null,
       "Streaming": null
     },
     "Security": null


### PR DESCRIPTION
## Summary

- keep an explicit `200` response authoritative; otherwise infer output capabilities across explicit numeric `2xx` responses
- retain only compatible response media, JSON schema/list/pagination, and streaming hints instead of selecting one response and guessing
- make OpenAPI response content selection deterministic while keeping media type and schema from the same representation

## Verification

- `go test -count=50 ./internal/codegen/normalize ./internal/codegen/backends/openapi3`
- `go test -race ./internal/codegen/normalize ./internal/codegen/backends/openapi3`
- `make check`
- generated CLI `__lathe verify --json`: 31/31 checks passed
- generated `201` upload operation exposes `response_media_type: application/json`

## Compatibility

Generated command shape and catalog schema are unchanged. Existing explicit `200` responses remain authoritative. Operations without `200` can now expose capabilities shared by their explicit numeric `2xx` responses; conflicting capabilities are omitted. Pagination is no longer inferred when no compatible success-response schema exists.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] No documentation update is required; command syntax and workflows are unchanged.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.