### PR TITLE
feat(runtime): collect streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,38 @@ Command `shortcuts` add root-level commands that execute the same generated
 operation with preset values for existing parameters. Shortcut params may use
 the parameter name or flag name; invocation flags can still override the preset.
 
+For an SSE or NDJSON operation whose event semantics are not described by the
+API spec, an overlay can collect JSON frames into one stable result:
+
+```yaml
+commands:
+  run-job:
+    output:
+      streaming:
+        data: json
+        event_name_path: event
+        collect:
+          require_stop: true
+          stop_events: [done]
+          pause_events: [input_required]
+          error_events: [error]
+          fields:
+            - events: [chunk]
+              from: text
+              to: output
+              reduce: concat
+        live:
+          events: [chunk]
+          from: text
+```
+
+Reducers are fixed to `first`, `last`, `concat`, and `append`. `-o json` and
+`-o yaml` collect one document, `-o raw` preserves wire events, and `--stream`
+is generated only when `live` is configured. A pause event returns exit code 0
+with the collected result; workflows stop before their next step. Stream
+policies cannot call operations or branch and therefore do not replace the
+workflow DSL.
+
 Run codegen with an overlay directory:
 
 ```sh
@@ -447,6 +479,14 @@ body:
 | `--file path.json` | Load the request body from a JSON file. |
 | `--set key.path=value` | Build JSON from repeated key/value assignments. |
 | `--set-str key.path=value` | Build JSON while forcing the value to remain a string. |
+
+### Streaming Outputs
+
+OpenAPI and Swagger streaming media types produce raw incremental output with
+`-o raw`. When a stream collection overlay is present, structured formats
+return the collected document and an optional `--stream` flag prints only the
+configured live field as frames arrive. The complete policy is inspectable at
+`output.streaming.policy` in `commands show ... --json`.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -427,10 +427,11 @@ commands:
           from: text
 ```
 
-Reducers are fixed to `first`, `last`, `concat`, and `append`. `-o json` and
-`-o yaml` collect one document, `-o raw` preserves wire events, and `--stream`
-is generated only when `live` is configured. A pause event returns exit code 0
-with the collected result; workflows stop before their next step. Stream
+Reducers are fixed to `first`, `last`, `concat`, and `append`. Choose one output
+mode: `-o json` or `-o yaml` collects one document, `-o raw` preserves wire
+events, and `--stream` in the default table mode prints the configured live
+field. A pause event returns exit code 0 with the collected result; workflows
+stop before their next step. Stream
 policies cannot call operations or branch and therefore do not replace the
 workflow DSL.
 
@@ -484,9 +485,9 @@ body:
 
 OpenAPI and Swagger streaming media types produce raw incremental output with
 `-o raw`. When a stream collection overlay is present, structured formats
-return the collected document and an optional `--stream` flag prints only the
-configured live field as frames arrive. The complete policy is inspectable at
-`output.streaming.policy` in `commands show ... --json`.
+return the collected document; an optional `--stream` flag in the default table
+mode prints only the configured live field as frames arrive. The complete policy
+is inspectable at `output.streaming.policy` in `commands show ... --json`.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,7 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `Deprecated` | `deprecated` / proto option | bool + message | overlay > spec |
 | `Security` | `security` / proto option | override (post-v0.1) | overlay > spec |
 | `RequestBody.MediaType` | `consumes[0]` | override | overlay > spec |
+| `Output.Streaming.Policy` | streaming media type supplies transport only | JSON event collection and live projection | overlay > spec transport |
 | `Ignore` (command filter) | — | bool | overlay-only |
 
 ### ParamSpec level

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -28,7 +28,8 @@ file; when this page and the code disagree, trust the code and fix this page.
   `search "<intent>" --json`, and `commands schema --json`.
 - This is the agent-facing discovery contract and the source of truth for
   generated operation details: HTTP method and path template, auth
-  requirements, flags, body schema, output and pagination hints.
+  requirements, flags, body schema, output, pagination, and stream collection
+  hints.
 - `catalog.cli.capabilities` lists compiled first-party capabilities such as
   `skill.bundle`. Capability commands are not catalog operations.
 - Only generated API operation commands carry catalog entries. Framework

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -65,7 +65,11 @@ func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides m
 	if cliName == "" {
 		cliName = name
 	}
-	merged := MergeOverlayModule(specs, overlay.Module{Commands: overrides})
+	mod := overlay.Module{Commands: overrides}
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		return err
+	}
+	merged := MergeOverlayModule(specs, mod)
 	return renderModuleSpecs(name, cliName, merged)
 }
 
@@ -275,6 +279,71 @@ func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runti
 	return merged
 }
 
+func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) error {
+	for _, spec := range specs {
+		override, ok := mod.Commands[spec.Use]
+		if !ok || !overrideMatches(spec, override) || override.Output == nil || override.Output.Streaming == nil {
+			continue
+		}
+		if err := validateStreamingOverride(spec, *override.Output.Streaming); err != nil {
+			return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
+		}
+	}
+	return nil
+}
+
+func validateStreamingOverride(spec runtime.CommandSpec, stream overlay.StreamingOverride) error {
+	if spec.Output.Streaming == nil {
+		return fmt.Errorf("operation is not declared as streaming")
+	}
+	if spec.Output.Streaming.Strategy != "sse" && spec.Output.Streaming.Strategy != "ndjson" {
+		return fmt.Errorf("unsupported strategy %q", spec.Output.Streaming.Strategy)
+	}
+	if stream.Data != "json" {
+		return fmt.Errorf("data must be json")
+	}
+	if stream.Collect == nil {
+		return fmt.Errorf("collect is required")
+	}
+	if spec.Output.Streaming.Strategy == "ndjson" && stream.EventNamePath == "" {
+		return fmt.Errorf("event_name_path is required for ndjson")
+	}
+	if stream.Collect.RequireStop && len(stream.Collect.StopEvents)+len(stream.Collect.PauseEvents)+len(stream.Collect.ErrorEvents) == 0 {
+		return fmt.Errorf("require_stop needs a terminal event")
+	}
+	terminal := map[string]string{}
+	for kind, events := range map[string][]string{
+		"stop": stream.Collect.StopEvents, "pause": stream.Collect.PauseEvents, "error": stream.Collect.ErrorEvents,
+	} {
+		for _, event := range events {
+			if event == "" {
+				return fmt.Errorf("%s event must not be empty", kind)
+			}
+			if previous := terminal[event]; previous != "" {
+				return fmt.Errorf("event %q is both %s and %s", event, previous, kind)
+			}
+			terminal[event] = kind
+		}
+	}
+	for i, field := range stream.Collect.Fields {
+		if len(field.Events) == 0 || field.To == "" {
+			return fmt.Errorf("field %d needs events and to", i)
+		}
+		if (field.From == "") == (field.Value == "") {
+			return fmt.Errorf("field %d needs exactly one of from or value", i)
+		}
+		switch field.Reduce {
+		case "first", "last", "concat", "append":
+		default:
+			return fmt.Errorf("field %d has unsupported reducer %q", i, field.Reduce)
+		}
+	}
+	if stream.Live != nil && (len(stream.Live.Events) == 0 || stream.Live.From == "") {
+		return fmt.Errorf("live needs events and from")
+	}
+	return nil
+}
+
 func overrideMatches(spec runtime.CommandSpec, override overlay.Override) bool {
 	if override.Match.Method != "" && !strings.EqualFold(override.Match.Method, spec.Method) {
 		return false
@@ -302,6 +371,10 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	cloned.Params = append([]runtime.ParamSpec(nil), spec.Params...)
 	for i := range cloned.Params {
 		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
+	}
+	if spec.Output.Streaming != nil {
+		streaming := *spec.Output.Streaming
+		cloned.Output.Streaming = &streaming
 	}
 	return cloned
 }
@@ -401,6 +474,29 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 				spec.Params[j].Deprecated = true
 			}
 		}
+	}
+	if override.Output != nil && override.Output.Streaming != nil {
+		stream := override.Output.Streaming
+		collect := stream.Collect
+		policy := &runtime.StreamPolicy{DataFormat: stream.Data, EventNamePath: stream.EventNamePath}
+		if collect != nil {
+			policy.Collect = &runtime.StreamCollectHint{
+				RequireStop: collect.RequireStop,
+				StopEvents:  append([]string(nil), collect.StopEvents...),
+				PauseEvents: append([]string(nil), collect.PauseEvents...),
+				ErrorEvents: append([]string(nil), collect.ErrorEvents...),
+				Fields:      make([]runtime.StreamFieldRule, 0, len(collect.Fields)),
+			}
+			for _, field := range collect.Fields {
+				policy.Collect.Fields = append(policy.Collect.Fields, runtime.StreamFieldRule{
+					Events: append([]string(nil), field.Events...), From: field.From, Value: field.Value, To: field.To, Reduce: field.Reduce,
+				})
+			}
+		}
+		if stream.Live != nil {
+			policy.Live = &runtime.StreamLiveHint{Events: append([]string(nil), stream.Live.Events...), From: stream.Live.From}
+		}
+		spec.Output.Streaming.Policy = policy
 	}
 }
 
@@ -865,6 +961,45 @@ func streamingHintLiteral(hint *runtime.StreamingHint) string {
 	var b strings.Builder
 	b.WriteString("&runtime.StreamingHint{")
 	writeStringField(&b, "Strategy", hint.Strategy)
+	if hint.Policy != nil {
+		fmt.Fprintf(&b, "Policy: %s,", streamPolicyLiteral(hint.Policy))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func streamPolicyLiteral(policy *runtime.StreamPolicy) string {
+	var b strings.Builder
+	b.WriteString("&runtime.StreamPolicy{")
+	writeStringField(&b, "DataFormat", policy.DataFormat)
+	writeStringField(&b, "EventNamePath", policy.EventNamePath)
+	if policy.Collect != nil {
+		b.WriteString("Collect: &runtime.StreamCollectHint{")
+		writeBoolField(&b, "RequireStop", policy.Collect.RequireStop)
+		writeStringSliceField(&b, "StopEvents", policy.Collect.StopEvents)
+		writeStringSliceField(&b, "PauseEvents", policy.Collect.PauseEvents)
+		writeStringSliceField(&b, "ErrorEvents", policy.Collect.ErrorEvents)
+		if len(policy.Collect.Fields) > 0 {
+			b.WriteString("Fields: []runtime.StreamFieldRule{")
+			for _, field := range policy.Collect.Fields {
+				b.WriteString("runtime.StreamFieldRule{")
+				writeStringSliceField(&b, "Events", field.Events)
+				writeStringField(&b, "From", field.From)
+				writeStringField(&b, "Value", field.Value)
+				writeStringField(&b, "To", field.To)
+				writeStringField(&b, "Reduce", field.Reduce)
+				b.WriteString("},")
+			}
+			b.WriteString("},")
+		}
+		b.WriteString("},")
+	}
+	if policy.Live != nil {
+		b.WriteString("Live: &runtime.StreamLiveHint{")
+		writeStringSliceField(&b, "Events", policy.Live.Events)
+		writeStringField(&b, "From", policy.Live.From)
+		b.WriteString("},")
+	}
 	b.WriteByte('}')
 	return b.String()
 }
@@ -963,8 +1098,9 @@ func writeSchemaLiteral(b *strings.Builder, s *runtime.SchemaSpec) {
 }
 
 var moduleTmpl = template.Must(template.New("gen").Funcs(template.FuncMap{
-	"schemaLiteral":    schemaLiteral,
-	"stringMapLiteral": stringMapLiteral,
+	"schemaLiteral":      schemaLiteral,
+	"stringMapLiteral":   stringMapLiteral,
+	"outputHintsLiteral": outputHintsLiteral,
 }).Parse(`// Code generated by lathe codegen. DO NOT EDIT.
 
 package {{.Module}}
@@ -1087,22 +1223,7 @@ var Specs = []runtime.CommandSpec{
 			},
 			{{- end}}
 		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
-		Output: runtime.OutputHints{
-			{{- if $op.Output.ListPath}}ListPath: {{printf "%q" $op.Output.ListPath}},{{end}}
-			{{- if $op.Output.DefaultColumns}}DefaultColumns: []string{
-				{{- range $op.Output.DefaultColumns}}{{printf "%q" .}},{{end}}
-			},{{end}}
-			{{- if $op.Output.ResponseMediaType}}ResponseMediaType: {{printf "%q" $op.Output.ResponseMediaType}},{{end}}
-			{{- if $op.Output.Pagination}}Pagination: &runtime.PaginationHint{
-				Strategy: {{printf "%q" $op.Output.Pagination.Strategy}},
-				{{- if $op.Output.Pagination.TokenParam}}TokenParam: {{printf "%q" $op.Output.Pagination.TokenParam}},{{end}}
-				{{- if $op.Output.Pagination.TokenField}}TokenField: {{printf "%q" $op.Output.Pagination.TokenField}},{{end}}
-				{{- if $op.Output.Pagination.LimitParam}}LimitParam: {{printf "%q" $op.Output.Pagination.LimitParam}},{{end}}
-			},{{end}}
-			{{- if $op.Output.Streaming}}Streaming: &runtime.StreamingHint{
-				Strategy: {{printf "%q" $op.Output.Streaming.Strategy}},
-			},{{end}}
-		},
+		Output: {{outputHintsLiteral $op.Output}},
 		{{- end}}
 		{{- if $op.Security}}
 		Security: &runtime.SecurityHint{

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -473,6 +473,40 @@ func TestMergeOverlayModule_BulkDefaultsDoNotReplaceSpecDefaults(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayModule_StreamPolicy(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group: "Runs", Use: "run", Method: "POST", PathTpl: "/runs",
+		Output: runtime.OutputHints{Streaming: &runtime.StreamingHint{Strategy: "sse"}},
+	}}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"run": {Output: &overlay.OutputOverride{Streaming: &overlay.StreamingOverride{
+			Data: "json", EventNamePath: "kind",
+			Collect: &overlay.StreamCollect{
+				RequireStop: true, StopEvents: []string{"done"},
+				Fields: []overlay.StreamFieldRule{{Events: []string{"chunk"}, From: "text", To: "answer", Reduce: "concat"}},
+			},
+			Live: &overlay.StreamLive{Events: []string{"chunk"}, From: "text"},
+		}}},
+	}}
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		t.Fatalf("ValidateOverlayModule: %v", err)
+	}
+	merged := MergeOverlayModule(specs, mod)
+	policy := merged[0].Output.Streaming.Policy
+	if policy == nil || policy.Collect == nil || policy.Collect.Fields[0].Reduce != "concat" || policy.Live == nil {
+		t.Fatalf("policy = %#v", policy)
+	}
+	if specs[0].Output.Streaming.Policy != nil {
+		t.Fatal("merge mutated source spec")
+	}
+
+	bad := specs
+	bad[0].Output.Streaming = nil
+	if err := ValidateOverlayModule(bad, mod); err == nil || !strings.Contains(err.Error(), "not declared as streaming") {
+		t.Fatalf("validation error = %v", err)
+	}
+}
+
 func TestRenderModule_NilOverrides(t *testing.T) {
 	chdirWithGoMod(t)
 

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -522,7 +522,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- Do not guess flags or request body shape from command names.\n")
 	b.WriteString("- Do not execute directly from search results; confirm with `commands show` first.\n")
 	b.WriteString("- Prefer `-o json` for machine-readable command output unless the user asks for human-readable output.\n")
-	b.WriteString("- For collected streams, `-o json` returns one stable document; use `--stream` only when catalog `output.streaming.policy.live` is present, and `-o raw` only for wire events.\n")
+	b.WriteString("- For collected streams, choose one mode: `-o json` for one stable document, `--stream` in the default output mode when catalog `output.streaming.policy.live` is present, or `-o raw` for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
 	return b.String()
@@ -575,7 +575,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--set key.path=value`: build JSON with type inference for booleans, null, integers, and floats.\n")
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
 	b.WriteString("## Output\n\n")
-	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. Collected streams return one document for JSON and YAML; use `--stream` only when `output.streaming.policy.live` is present, and use raw only when wire events are required.\n\n")
+	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("## Auth\n\n")
 	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -522,6 +522,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- Do not guess flags or request body shape from command names.\n")
 	b.WriteString("- Do not execute directly from search results; confirm with `commands show` first.\n")
 	b.WriteString("- Prefer `-o json` for machine-readable command output unless the user asks for human-readable output.\n")
+	b.WriteString("- For collected streams, `-o json` returns one stable document; use `--stream` only when catalog `output.streaming.policy.live` is present, and `-o raw` only for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
 	return b.String()
@@ -555,7 +556,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `body`: request body requirement and media type.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
 	b.WriteString("- `examples`: runnable examples with optional body shape, output hints, and follow-up commands.\n")
-	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints.\n")
+	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints; a streaming policy describes collection, terminal outcomes, and optional live projection.\n")
 	b.WriteString("- `notes`, `prerequisites`, and `known_errors`: overlay-provided operation context that is not inferred from the API spec.\n\n")
 	b.WriteString("## Command Detail\n\n")
 	fmt.Fprintf(&b, "Run `%s commands show <path...> --json` before executing an unfamiliar command. This is the source of truth for flags, body, auth, HTTP path, and output hints.\n\n", cli)
@@ -574,7 +575,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--set key.path=value`: build JSON with type inference for booleans, null, integers, and floats.\n")
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
 	b.WriteString("## Output\n\n")
-	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`.\n\n")
+	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. Collected streams return one document for JSON and YAML; use `--stream` only when `output.streaming.policy.live` is present, and use raw only when wire events are required.\n\n")
 	b.WriteString("## Auth\n\n")
 	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
@@ -985,7 +986,14 @@ func outputSummary(out runtime.OutputHints) string {
 		parts = append(parts, "pagination `"+out.Pagination.Strategy+"`")
 	}
 	if out.Streaming != nil {
-		parts = append(parts, "streaming `"+out.Streaming.Strategy+"`")
+		streaming := "streaming `" + out.Streaming.Strategy + "`"
+		if out.Streaming.Policy != nil {
+			streaming += ", collected"
+			if out.Streaming.Policy.Live != nil {
+				streaming += ", live `--stream`"
+			}
+		}
+		parts = append(parts, streaming)
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -231,6 +231,9 @@ func buildGeneratedApp(cfg *sourceconfig.Config, overlays map[string]overlay.Mod
 		}
 
 		specs := normalize.Normalize(mod)
+		if err := render.ValidateOverlayModule(specs, overlays[src.Name]); err != nil {
+			return nil, fmt.Errorf("source %q overlay: %w", src.Name, err)
+		}
 		specs = render.MergeOverlayModule(specs, overlays[src.Name])
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("source %q produced no commands: check its entry/file list, expose policy, and overlay ignore rules", src.Name)

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -25,6 +25,39 @@ type Override struct {
 	Notes         []string                 `yaml:"notes"`
 	Prerequisites []string                 `yaml:"prerequisites"`
 	KnownErrors   []KnownError             `yaml:"known_errors"`
+	Output        *OutputOverride          `yaml:"output"`
+}
+
+type OutputOverride struct {
+	Streaming *StreamingOverride `yaml:"streaming"`
+}
+
+type StreamingOverride struct {
+	Data          string         `yaml:"data"`
+	EventNamePath string         `yaml:"event_name_path"`
+	Collect       *StreamCollect `yaml:"collect"`
+	Live          *StreamLive    `yaml:"live"`
+}
+
+type StreamCollect struct {
+	RequireStop bool              `yaml:"require_stop"`
+	StopEvents  []string          `yaml:"stop_events"`
+	PauseEvents []string          `yaml:"pause_events"`
+	ErrorEvents []string          `yaml:"error_events"`
+	Fields      []StreamFieldRule `yaml:"fields"`
+}
+
+type StreamFieldRule struct {
+	Events []string `yaml:"events"`
+	From   string   `yaml:"from"`
+	Value  string   `yaml:"value"`
+	To     string   `yaml:"to"`
+	Reduce string   `yaml:"reduce"`
+}
+
+type StreamLive struct {
+	Events []string `yaml:"events"`
+	From   string   `yaml:"from"`
 }
 
 type OperationMatch struct {

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -121,6 +121,9 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			if liveStream && format != "table" {
 				return fmt.Errorf("live stream output does not support -o %s", format)
 			}
+			if liveStream && waitPoll {
+				return fmt.Errorf("live stream output does not support wait polling")
+			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
 				return err
 			}
@@ -156,7 +159,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			clientOpts.UserAgent = cmd.Root().Use
 
 			output := operationOutput{}
-			if s.Output.Streaming != nil && format == "raw" {
+			if s.Output.Streaming != nil && format == "raw" && !waitPoll {
 				output.raw = cmd.OutOrStdout()
 			} else if liveStream && format == "table" {
 				output.live = cmd.OutOrStdout()

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -108,6 +108,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	var maxPages int
 	var waitPoll bool
 	var dryRun bool
+	var liveStream bool
 
 	cmd := &cobra.Command{
 		Use:     s.Use,
@@ -116,6 +117,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		Long:    s.Long,
 		Example: s.Example,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
 				return err
 			}
@@ -150,7 +152,13 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			}
 			clientOpts.UserAgent = cmd.Root().Use
 
-			result, err := InvokeOperation(cmd.Context(), s, OperationInput{
+			output := operationOutput{}
+			if s.Output.Streaming != nil && format == "raw" {
+				output.raw = cmd.OutOrStdout()
+			} else if liveStream && format == "table" {
+				output.live = cmd.OutOrStdout()
+			}
+			result, err := invokeOperation(cmd.Context(), s, OperationInput{
 				Values:         vals,
 				Changed:        operationChangedFlags(cmd, s.Params),
 				FileBody:       fileBody,
@@ -164,15 +172,17 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				PaginateAll: paginateAll,
 				MaxPages:    maxPages,
 				Wait:        waitPoll,
-			})
+			}, output)
 			if err != nil {
 				return err
 			}
 			if result.DryRun != nil {
 				return writeDryRun(*result.DryRun, cmd.OutOrStdout())
 			}
-			format, _ := cmd.Root().PersistentFlags().GetString("output")
-			return FormatOutput(result.Data, format, os.Stdout, s.Output)
+			if output.raw != nil || output.live != nil {
+				return nil
+			}
+			return FormatOutput(result.Data, format, cmd.OutOrStdout(), s.Output)
 		},
 	}
 
@@ -204,6 +214,9 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	}
 	if s.Method == "POST" || s.Method == "PUT" || s.Method == "DELETE" || s.Method == "PATCH" {
 		cmd.Flags().BoolVar(&waitPoll, controlFlagName(cmd, "wait"), false, "poll until long-running operation completes")
+	}
+	if s.Output.Streaming != nil && s.Output.Streaming.Policy != nil && s.Output.Streaming.Policy.Live != nil {
+		cmd.Flags().BoolVar(&liveStream, controlFlagName(cmd, "stream"), false, "print configured stream fields as they arrive")
 	}
 	cmd.Flags().BoolVar(&dryRun, controlFlagName(cmd, "dry-run"), false, "print resolved request JSON without sending it")
 	cmd.Hidden = s.Hidden

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -118,6 +118,9 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		Example: s.Example,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if liveStream && format != "table" {
+				return fmt.Errorf("live stream output does not support -o %s", format)
+			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
 				return err
 			}
@@ -216,7 +219,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		cmd.Flags().BoolVar(&waitPoll, controlFlagName(cmd, "wait"), false, "poll until long-running operation completes")
 	}
 	if s.Output.Streaming != nil && s.Output.Streaming.Policy != nil && s.Output.Streaming.Policy.Live != nil {
-		cmd.Flags().BoolVar(&liveStream, controlFlagName(cmd, "stream"), false, "print configured stream fields as they arrive")
+		cmd.Flags().BoolVar(&liveStream, controlFlagName(cmd, "stream"), false, "print configured stream fields as they arrive (requires -o table)")
 	}
 	cmd.Flags().BoolVar(&dryRun, controlFlagName(cmd, "dry-run"), false, "print resolved request JSON without sending it")
 	cmd.Hidden = s.Hidden

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -26,6 +28,20 @@ func mustBuild(t *testing.T, root *cobra.Command, service string, specs []Comman
 		t.Fatalf("Build(%q): %v", service, err)
 	}
 }
+
+type observedWriter struct {
+	buf   bytes.Buffer
+	once  sync.Once
+	wrote chan struct{}
+}
+
+func (w *observedWriter) Write(p []byte) (int, error) {
+	n, err := w.buf.Write(p)
+	w.once.Do(func() { close(w.wrote) })
+	return n, err
+}
+
+func (w *observedWriter) String() string { return w.buf.String() }
 
 func TestBuild_RejectsExistingRootCommandConflict(t *testing.T) {
 	root := newRootWithModuleGroup()
@@ -122,6 +138,65 @@ func TestBuild_EmptySpecsMountsEmptyService(t *testing.T) {
 	svc := mustFindChild(t, root, "demo")
 	if len(svc.Commands()) != 0 {
 		t.Errorf("empty specs should yield no subcommands under demo; got %v", cmdNames(svc.Commands()))
+	}
+}
+
+func TestBuild_RawStreamingWritesBeforeResponseCloses(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	firstSent := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+		close(firstSent)
+		select {
+		case <-release:
+			_, _ = io.WriteString(w, "data: second\n\n")
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	out := &observedWriter{wrote: make(chan struct{})}
+	root := newRootWithModuleGroup()
+	root.SetOut(out)
+	root.SetErr(io.Discard)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group:    "Events",
+		Use:      "watch",
+		Method:   http.MethodGet,
+		PathTpl:  "/events",
+		Output:   OutputHints{Streaming: &StreamingHint{Strategy: "sse"}},
+		Security: &SecurityHint{Public: true},
+	}})
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "events", "watch", "-o", "raw"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- root.Execute() }()
+	select {
+	case <-firstSent:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("server did not send first event")
+	}
+	select {
+	case <-out.wrote:
+	case <-time.After(200 * time.Millisecond):
+		close(release)
+		<-errCh
+		t.Fatal("command produced no output before the streaming response closed")
+	}
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := out.String(); got != "data: first\n\ndata: second\n\n" {
+		t.Fatalf("output = %q", got)
 	}
 }
 

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -200,6 +200,41 @@ func TestBuild_RawStreamingWritesBeforeResponseCloses(t *testing.T) {
 	}
 }
 
+func TestBuild_RejectsLiveStreamWithJSONOutput(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "{\"kind\":\"done\"}\n")
+	}))
+	defer srv.Close()
+
+	root := newRootWithModuleGroup()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group:   "Events",
+		Use:     "watch",
+		Method:  http.MethodGet,
+		PathTpl: "/events",
+		Output: OutputHints{Streaming: &StreamingHint{Strategy: "ndjson", Policy: &StreamPolicy{
+			DataFormat:    "json",
+			EventNamePath: "kind",
+			Collect:       &StreamCollectHint{RequireStop: true, StopEvents: []string{"done"}},
+			Live:          &StreamLiveHint{Events: []string{"chunk"}, From: "text"},
+		}}},
+		Security: &SecurityHint{Public: true},
+	}})
+	root.SetArgs([]string{"--hostname", srv.URL, "-o", "json", "demo", "events", "watch", "--stream"})
+
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "live stream output does not support -o json") {
+		t.Fatalf("expected incompatible output error, got %v", err)
+	}
+}
+
 func TestBuildFlat_PopulatesRootGroupTree(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:   "Users",

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -200,24 +200,20 @@ func TestBuild_RawStreamingWritesBeforeResponseCloses(t *testing.T) {
 	}
 }
 
-func TestBuild_RejectsLiveStreamWithJSONOutput(t *testing.T) {
+func TestBuild_StreamOutputFlagCombinations(t *testing.T) {
 	bindTestManifest(t, "myctl", "MYCTL_HOST")
 	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
 
+	response := "{\"kind\":\"done\"}\n"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, "{\"kind\":\"done\"}\n")
+		_, _ = io.WriteString(w, response)
 	}))
 	defer srv.Close()
 
-	root := newRootWithModuleGroup()
-	root.SetOut(io.Discard)
-	root.SetErr(io.Discard)
-	root.PersistentFlags().String("hostname", "", "")
-	root.PersistentFlags().StringP("output", "o", "table", "")
-	mustBuild(t, root, "demo", []CommandSpec{{
+	spec := CommandSpec{
 		Group:   "Events",
 		Use:     "watch",
-		Method:  http.MethodGet,
+		Method:  http.MethodPost,
 		PathTpl: "/events",
 		Output: OutputHints{Streaming: &StreamingHint{Strategy: "ndjson", Policy: &StreamPolicy{
 			DataFormat:    "json",
@@ -226,12 +222,42 @@ func TestBuild_RejectsLiveStreamWithJSONOutput(t *testing.T) {
 			Live:          &StreamLiveHint{Events: []string{"chunk"}, From: "text"},
 		}}},
 		Security: &SecurityHint{Public: true},
-	}})
-	root.SetArgs([]string{"--hostname", srv.URL, "-o", "json", "demo", "events", "watch", "--stream"})
+	}
+	cases := []struct {
+		name       string
+		args       []string
+		wantErr    string
+		wantOutput string
+	}{
+		{name: "live with json", args: []string{"-o", "json", "demo", "events", "watch", "--stream"}, wantErr: "live stream output does not support -o json"},
+		{name: "live with wait", args: []string{"demo", "events", "watch", "--stream", "--wait"}, wantErr: "live stream output does not support wait polling"},
+		{name: "raw with wait", args: []string{"-o", "raw", "demo", "events", "watch", "--wait"}, wantOutput: response},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			root := newRootWithModuleGroup()
+			root.SetOut(&out)
+			root.SetErr(io.Discard)
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "table", "")
+			mustBuild(t, root, "demo", []CommandSpec{spec})
+			root.SetArgs(append([]string{"--hostname", srv.URL}, tc.args...))
 
-	err := root.Execute()
-	if err == nil || !strings.Contains(err.Error(), "live stream output does not support -o json") {
-		t.Fatalf("expected incompatible output error, got %v", err)
+			err := root.Execute()
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected %q error, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if out.String() != tc.wantOutput {
+				t.Fatalf("output = %q, want %q", out.String(), tc.wantOutput)
+			}
+		})
 	}
 }
 

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 12
+const CatalogSchemaVersion = 13
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -142,7 +142,8 @@ type CatalogPagination struct {
 }
 
 type CatalogStreaming struct {
-	Strategy string `json:"strategy"`
+	Strategy string        `json:"strategy"`
+	Policy   *StreamPolicy `json:"policy,omitempty"`
 }
 
 type SearchResult struct {
@@ -534,7 +535,7 @@ func catalogStreaming(s *StreamingHint) *CatalogStreaming {
 	if s == nil {
 		return nil
 	}
-	return &CatalogStreaming{Strategy: s.Strategy}
+	return &CatalogStreaming{Strategy: s.Strategy, Policy: s.Policy}
 }
 
 func catalogAuth(security *SecurityHint) CatalogAuth {

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -38,7 +38,11 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 				DefaultColumns:    []string{"id", "name"},
 				ResponseMediaType: "application/json",
 				Pagination:        &PaginationHint{Strategy: "cursor", TokenParam: "page_token", TokenField: "next_page_token", LimitParam: "limit"},
-				Streaming:         &StreamingHint{Strategy: "sse"},
+				Streaming: &StreamingHint{Strategy: "sse", Policy: &StreamPolicy{
+					DataFormat: "json", EventNamePath: "kind",
+					Collect: &StreamCollectHint{RequireStop: true, StopEvents: []string{"done"}},
+					Live:    &StreamLiveHint{Events: []string{"chunk"}, From: "text"},
+				}},
 			},
 			Security:      &SecurityHint{Scopes: []string{"users:read"}},
 			Notes:         []string{"Use the canonical user ID."},
@@ -106,6 +110,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if cmd.Output.Streaming == nil || cmd.Output.Streaming.Strategy != "sse" {
 		t.Fatalf("streaming = %+v", cmd.Output.Streaming)
+	}
+	if cmd.Output.Streaming.Policy == nil || cmd.Output.Streaming.Policy.Collect == nil || !cmd.Output.Streaming.Policy.Collect.RequireStop {
+		t.Fatalf("streaming policy = %+v", cmd.Output.Streaming.Policy)
 	}
 	if !reflect.DeepEqual(cmd.Notes, []string{"Use the canonical user ID."}) {
 		t.Fatalf("notes = %#v", cmd.Notes)
@@ -458,8 +465,8 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 
 	catalog := BuildCatalog(root, CatalogOptions{})
-	if catalog.CatalogSchemaVersion != 12 {
-		t.Fatalf("schema version = %d, want 12", catalog.CatalogSchemaVersion)
+	if catalog.CatalogSchemaVersion != 13 {
+		t.Fatalf("schema version = %d, want 13", catalog.CatalogSchemaVersion)
 	}
 	var step *CatalogWorkflowStep
 	for i, entry := range catalog.Commands {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -46,8 +46,12 @@ func BaseURL(hostname string) (string, error) {
 
 // HTTPClient returns an http.Client configured per opts.
 func HTTPClient(opts ClientOptions) *http.Client {
+	return httpClient(opts, false)
+}
+
+func httpClient(opts ClientOptions, streaming bool) *http.Client {
 	timeout := opts.Timeout
-	if timeout == 0 {
+	if timeout == 0 && !streaming {
 		timeout = 30 * time.Second
 	}
 	transport := opts.Transport
@@ -67,7 +71,7 @@ func HTTPClient(opts ClientOptions) *http.Client {
 		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug, safeMethodsOnly: safeMethodsOnly}
 	}
 	if opts.Debug {
-		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams}
+		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming}
 	}
 	return &http.Client{
 		Timeout:       timeout,
@@ -83,13 +87,33 @@ type RawResult struct {
 }
 
 func DoRawFull(ctx context.Context, hostname, method, path string, body any, opts ClientOptions) (*RawResult, error) {
+	return doRawFull(ctx, hostname, method, path, body, opts, nil)
+}
+
+func doRawFull(ctx context.Context, hostname, method, path string, body any, opts ClientOptions, stream io.Writer) (*RawResult, error) {
+	var consume responseConsumer
+	if stream != nil {
+		consume = func(r io.Reader) ([]byte, error) {
+			_, err := io.Copy(stream, r)
+			if err != nil {
+				return nil, fmt.Errorf("stream response: %w", err)
+			}
+			return nil, nil
+		}
+	}
+	return doRawFullConsume(ctx, hostname, method, path, body, opts, consume)
+}
+
+type responseConsumer func(io.Reader) ([]byte, error)
+
+func doRawFullConsume(ctx context.Context, hostname, method, path string, body any, opts ClientOptions, consume responseConsumer) (*RawResult, error) {
 	req, bodyBytes, contentType, err := resolveRequest(ctx, hostname, method, path, body, opts)
 	if err != nil {
 		return nil, err
 	}
 	u := req.URL.String()
 
-	result, err := doRawFullOnce(req, opts)
+	result, err := doRawFullOnce(req, opts, consume)
 	if err == nil {
 		return result, nil
 	}
@@ -107,7 +131,7 @@ func DoRawFull(ctx context.Context, hostname, method, path string, body any, opt
 	if err != nil {
 		return nil, err
 	}
-	return doRawFullOnce(req, opts)
+	return doRawFullOnce(req, opts, consume)
 }
 
 func encodeRequestBody(body any) ([]byte, string, error) {
@@ -175,27 +199,38 @@ func newRequest(ctx context.Context, method, u string, body []byte, contentType 
 	return req, nil
 }
 
-func doRawFullOnce(req *http.Request, opts ClientOptions) (*RawResult, error) {
+func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsumer) (*RawResult, error) {
 	method := req.Method
 	u := redactDebugURL(req.URL, opts.sensitiveQueryParams)
-	resp, err := HTTPClient(opts).Do(req)
+	resp, err := httpClient(opts, consume != nil).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %w", method, u, redactClientError(err, opts.sensitiveQueryParams))
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read response: %w", err)
+		}
 		return nil, &HTTPError{
 			Method: method,
 			URL:    u,
 			Status: resp.StatusCode,
 			Body:   data,
 		}
+	}
+	if consume != nil {
+		data, err := consume(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		return &RawResult{Body: data, StatusCode: resp.StatusCode, Header: resp.Header}, nil
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
 	}
 	return &RawResult{Body: data, StatusCode: resp.StatusCode, Header: resp.Header}, nil
 }

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -250,3 +250,43 @@ func TestDoRaw_RefreshesAuthAndRetriesOnceOn401(t *testing.T) {
 		t.Fatalf("authorization sequence = %#v", seen)
 	}
 }
+
+func TestDoRawFull_StreamCancellationClosesResponse(t *testing.T) {
+	firstSent := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+		close(firstSent)
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := doRawFull(ctx, srv.URL, http.MethodGet, "/events", nil, ClientOptions{Timeout: 5 * time.Second}, io.Discard)
+		errCh <- err
+	}()
+	select {
+	case <-firstSent:
+	case <-time.After(time.Second):
+		t.Fatal("server did not send first event")
+	}
+	cancel()
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("server request context was not canceled")
+	}
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("stream error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stream call did not return after cancellation")
+	}
+}

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -21,6 +21,7 @@ const (
 type debugTransport struct {
 	inner                http.RoundTripper
 	sensitiveQueryParams map[string]bool
+	streaming            bool
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -48,7 +49,7 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	for k, vs := range resp.Header {
 		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
 	}
-	if isTextContent(resp.Header.Get("Content-Type")) {
+	if isTextContent(resp.Header.Get("Content-Type")) && (!d.streaming || resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		body, restored := peekBody(resp.Body, maxDebugRespBody)
 		resp.Body = restored
 		dumpBody(os.Stderr, "<", redactDebugBody(resp.Header.Get("Content-Type"), body), maxDebugRespBody)

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -9,18 +9,21 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func captureStderr(t *testing.T) *os.File {
 	t.Helper()
+	original := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stderr = w
 	t.Cleanup(func() {
-		w.Close()
-		os.Stderr = os.NewFile(2, "/dev/stderr")
+		os.Stderr = original
+		_ = w.Close()
+		_ = r.Close()
 	})
 	return r
 }
@@ -228,6 +231,66 @@ func TestDebugTransport_PreservesResponseBody(t *testing.T) {
 
 	if string(body) != `{"data":1}` {
 		t.Errorf("response body = %q, want %q", string(body), `{"data":1}`)
+	}
+}
+
+func TestDebugTransport_DoesNotPeekStreamingResponse(t *testing.T) {
+	firstSent := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+		close(firstSent)
+		select {
+		case <-release:
+			_, _ = io.WriteString(w, "data: second\n\n")
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	stderr := captureStderr(t)
+	dt := &debugTransport{inner: http.DefaultTransport, streaming: true}
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	respCh := make(chan *http.Response, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		resp, err := dt.RoundTrip(req)
+		respCh <- resp
+		errCh <- err
+	}()
+	select {
+	case <-firstSent:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("server did not send first event")
+	}
+
+	var resp *http.Response
+	select {
+	case resp = <-respCh:
+	case <-time.After(200 * time.Millisecond):
+		close(release)
+		<-respCh
+		t.Fatal("debug transport waited for the streaming response to close")
+	}
+	if err := <-errCh; err != nil {
+		close(release)
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	close(release)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_ = resp.Body.Close()
+	out := readStderr(t, stderr)
+	if string(body) != "data: first\n\ndata: second\n\n" {
+		t.Fatalf("response body = %q", body)
+	}
+	if strings.Contains(out, "[body") {
+		t.Fatalf("debug output unexpectedly dumped streaming body:\n%s", out)
 	}
 }
 

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -29,9 +29,15 @@ type OperationOptions struct {
 }
 
 type OperationResult struct {
-	Data   []byte
-	DryRun *DryRunRequest
+	Data    []byte
+	DryRun  *DryRunRequest
+	Outcome string
 }
+
+const (
+	OperationOutcomeCompleted = "completed"
+	OperationOutcomePaused    = "paused"
+)
 
 type DryRunRequest struct {
 	Method  string            `json:"method"`
@@ -49,6 +55,15 @@ type DryRunAuth struct {
 }
 
 func InvokeOperation(ctx context.Context, s CommandSpec, input OperationInput, opts OperationOptions) (OperationResult, error) {
+	return invokeOperation(ctx, s, input, opts, operationOutput{})
+}
+
+type operationOutput struct {
+	raw  io.Writer
+	live io.Writer
+}
+
+func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, opts OperationOptions, output operationOutput) (OperationResult, error) {
 	path, body, clientOpts, err := resolveOperationRequest(s, input, opts.Client)
 	if err != nil {
 		return OperationResult{}, err
@@ -58,10 +73,11 @@ func InvokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		if err != nil {
 			return OperationResult{}, err
 		}
-		return OperationResult{DryRun: &out}, nil
+		return OperationResult{DryRun: &out, Outcome: OperationOutcomeCompleted}, nil
 	}
 
 	var data []byte
+	outcome := OperationOutcomeCompleted
 	if opts.PaginateAll && s.Output.Pagination != nil {
 		maxPages := opts.MaxPages
 		if maxPages == 0 {
@@ -80,13 +96,23 @@ func InvokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		} else if err == nil {
 			data = r.Body
 		}
+	} else if output.raw != nil {
+		_, err = doRawFull(ctx, opts.Hostname, s.Method, path, body, clientOpts, output.raw)
+	} else if s.Output.Streaming != nil && s.Output.Streaming.Policy != nil && s.Output.Streaming.Policy.Collect != nil {
+		var result *RawResult
+		result, err = doRawFullConsume(ctx, opts.Hostname, s.Method, path, body, clientOpts, func(r io.Reader) ([]byte, error) {
+			return collectStream(r, s.Output.Streaming, output.live, &outcome)
+		})
+		if err == nil {
+			data = result.Body
+		}
 	} else {
 		data, err = DoRaw(ctx, opts.Hostname, s.Method, path, body, clientOpts)
 	}
 	if err != nil {
 		return OperationResult{}, err
 	}
-	return OperationResult{Data: data}, nil
+	return OperationResult{Data: data, Outcome: outcome}, nil
 }
 
 func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts ClientOptions) (string, any, ClientOptions, error) {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -102,6 +102,35 @@ type PaginationHint struct {
 
 type StreamingHint struct {
 	Strategy string
+	Policy   *StreamPolicy `json:"Policy,omitempty"`
+}
+
+type StreamPolicy struct {
+	DataFormat    string             `json:"data_format"`
+	EventNamePath string             `json:"event_name_path,omitempty"`
+	Collect       *StreamCollectHint `json:"collect"`
+	Live          *StreamLiveHint    `json:"live,omitempty"`
+}
+
+type StreamCollectHint struct {
+	RequireStop bool              `json:"require_stop,omitempty"`
+	StopEvents  []string          `json:"stop_events,omitempty"`
+	PauseEvents []string          `json:"pause_events,omitempty"`
+	ErrorEvents []string          `json:"error_events,omitempty"`
+	Fields      []StreamFieldRule `json:"fields,omitempty"`
+}
+
+type StreamFieldRule struct {
+	Events []string `json:"events"`
+	From   string   `json:"from,omitempty"`
+	Value  string   `json:"value,omitempty"`
+	To     string   `json:"to"`
+	Reduce string   `json:"reduce"`
+}
+
+type StreamLiveHint struct {
+	Events []string `json:"events"`
+	From   string   `json:"from"`
 }
 
 type SecurityHint struct {

--- a/pkg/runtime/stream.go
+++ b/pkg/runtime/stream.go
@@ -1,0 +1,219 @@
+package runtime
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+var errStreamTerminal = errors.New("stream terminal event")
+
+func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *string) ([]byte, error) {
+	policy := hint.Policy
+	if policy.DataFormat != "json" {
+		return nil, fmt.Errorf("unsupported stream data format %q", policy.DataFormat)
+	}
+	collected := map[string]any{}
+	stopped := false
+	handle := func(transportEvent string, data []byte) error {
+		var payload any
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return NewLatheError(CodeAPIError, ExitAPIError, fmt.Errorf("decode %s stream event: %w", hint.Strategy, err))
+		}
+		event := transportEvent
+		if event == "" && policy.EventNamePath != "" {
+			if value, ok := getNestedPath(payload, policy.EventNamePath); ok {
+				event, _ = value.(string)
+			}
+		}
+		for _, field := range policy.Collect.Fields {
+			if !slices.Contains(field.Events, event) {
+				continue
+			}
+			value, ok := streamFieldValue(payload, field)
+			if ok {
+				if err := reduceStreamField(collected, field, value); err != nil {
+					return NewLatheError(CodeAPIError, ExitAPIError, err)
+				}
+			}
+		}
+		if live != nil && policy.Live != nil && slices.Contains(policy.Live.Events, event) {
+			if value, ok := streamValue(payload, policy.Live.From); ok {
+				if err := writeStreamValue(live, value); err != nil {
+					return fmt.Errorf("write live stream: %w", err)
+				}
+			}
+		}
+		if slices.Contains(policy.Collect.ErrorEvents, event) {
+			return NewLatheError(CodeAPIError, ExitAPIError, streamEventError(event, payload))
+		}
+		if slices.Contains(policy.Collect.PauseEvents, event) {
+			*outcome = OperationOutcomePaused
+			stopped = true
+			return errStreamTerminal
+		}
+		if slices.Contains(policy.Collect.StopEvents, event) {
+			stopped = true
+			return errStreamTerminal
+		}
+		return nil
+	}
+
+	var err error
+	switch hint.Strategy {
+	case "sse":
+		err = readSSE(r, handle)
+	case "ndjson":
+		err = readNDJSON(r, handle)
+	default:
+		err = fmt.Errorf("unsupported stream strategy %q", hint.Strategy)
+	}
+	if err != nil && !errors.Is(err, errStreamTerminal) {
+		return nil, err
+	}
+	if policy.Collect.RequireStop && !stopped {
+		return nil, NewLatheError(CodeAPIError, ExitAPIError, fmt.Errorf("%s stream ended without a terminal event", hint.Strategy))
+	}
+	return json.Marshal(collected)
+}
+
+func readSSE(r io.Reader, handle func(string, []byte) error) error {
+	reader := bufio.NewReader(r)
+	var event string
+	var data [][]byte
+	dispatch := func() error {
+		if len(data) == 0 {
+			event = ""
+			return nil
+		}
+		err := handle(event, bytes.Join(data, []byte{'\n'}))
+		event = ""
+		data = data[:0]
+		return err
+	}
+	for {
+		line, err := reader.ReadString('\n')
+		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if line == "" {
+			if dispatchErr := dispatch(); dispatchErr != nil {
+				return dispatchErr
+			}
+		} else if !strings.HasPrefix(line, ":") {
+			field, value, _ := strings.Cut(line, ":")
+			value = strings.TrimPrefix(value, " ")
+			switch field {
+			case "event":
+				event = value
+			case "data":
+				data = append(data, []byte(value))
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return dispatch()
+			}
+			return fmt.Errorf("read sse stream: %w", err)
+		}
+	}
+}
+
+func readNDJSON(r io.Reader, handle func(string, []byte) error) error {
+	reader := bufio.NewReader(r)
+	for {
+		line, err := reader.ReadBytes('\n')
+		line = bytes.TrimSpace(line)
+		if len(line) > 0 {
+			if handleErr := handle("", line); handleErr != nil {
+				return handleErr
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("read ndjson stream: %w", err)
+		}
+	}
+}
+
+func streamFieldValue(payload any, field StreamFieldRule) (any, bool) {
+	if field.From == "" {
+		return field.Value, true
+	}
+	return streamValue(payload, field.From)
+}
+
+func streamValue(payload any, path string) (any, bool) {
+	if path == "$" {
+		return payload, true
+	}
+	return getNestedPath(payload, path)
+}
+
+func reduceStreamField(collected map[string]any, field StreamFieldRule, value any) error {
+	existing, exists := getNestedPath(collected, field.To)
+	switch field.Reduce {
+	case "first":
+		if exists {
+			return nil
+		}
+	case "last":
+	case "concat":
+		part, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("stream field %q concat value is %T, want string", field.To, value)
+		}
+		if exists {
+			prefix, ok := existing.(string)
+			if !ok {
+				return fmt.Errorf("stream field %q concat target is %T, want string", field.To, existing)
+			}
+			value = prefix + part
+		}
+	case "append":
+		items := []any{}
+		if exists {
+			var ok bool
+			items, ok = existing.([]any)
+			if !ok {
+				return fmt.Errorf("stream field %q append target is %T, want array", field.To, existing)
+			}
+		}
+		value = append(items, value)
+	default:
+		return fmt.Errorf("stream field %q has unsupported reducer %q", field.To, field.Reduce)
+	}
+	if err := setNestedPath(collected, field.To, value); err != nil {
+		return fmt.Errorf("stream field %q: %w", field.To, err)
+	}
+	return nil
+}
+
+func writeStreamValue(w io.Writer, value any) error {
+	if text, ok := value.(string); ok {
+		_, err := io.WriteString(w, text)
+		return err
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+func streamEventError(event string, payload any) error {
+	for _, path := range []string{"message", "error"} {
+		if value, ok := getNestedPath(payload, path); ok {
+			if text, ok := value.(string); ok && text != "" {
+				return fmt.Errorf("stream event %q: %s", event, text)
+			}
+		}
+	}
+	return fmt.Errorf("stream event %q reported an error", event)
+}

--- a/pkg/runtime/stream.go
+++ b/pkg/runtime/stream.go
@@ -84,6 +84,31 @@ func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *st
 
 func readSSE(r io.Reader, handle func(string, []byte) error) error {
 	reader := bufio.NewReader(r)
+	skipLF := false
+	readLine := func() (string, error) {
+		var line []byte
+		for {
+			b, err := reader.ReadByte()
+			if err != nil {
+				return string(line), err
+			}
+			if skipLF {
+				skipLF = false
+				if b == '\n' {
+					continue
+				}
+			}
+			switch b {
+			case '\r':
+				skipLF = true
+				return string(line), nil
+			case '\n':
+				return string(line), nil
+			default:
+				line = append(line, b)
+			}
+		}
+	}
 	var event string
 	var data [][]byte
 	dispatch := func() error {
@@ -97,8 +122,7 @@ func readSSE(r io.Reader, handle func(string, []byte) error) error {
 		return err
 	}
 	for {
-		line, err := reader.ReadString('\n')
-		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		line, err := readLine()
 		if line == "" {
 			if dispatchErr := dispatch(); dispatchErr != nil {
 				return dispatchErr

--- a/pkg/runtime/stream_test.go
+++ b/pkg/runtime/stream_test.go
@@ -17,12 +17,12 @@ func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
 	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		_, _ = io.WriteString(w, "event: chunk\ndata: {\"kind\":\"ignored\",\"text\":\"hel\",\"mode\":\"chat\"}\n\n")
+		_, _ = io.WriteString(w, "event: chunk\rdata: {\"kind\":\"ignored\",\"text\":\"hel\",\"mode\":\"chat\"}\r\r")
 		w.(http.Flusher).Flush()
 		close(firstSent)
 		select {
 		case <-release:
-			_, _ = io.WriteString(w, "data: {\"kind\":\"chunk\",\"text\":\"lo\"}\n\ndata: {\"kind\":\"done\",\"id\":\"msg-1\"}\n\n")
+			_, _ = io.WriteString(w, "data: {\"kind\":\"chunk\",\"text\":\"lo\"}\r\rdata: {\"kind\":\"done\",\"id\":\"msg-1\"}\r\r")
 		case <-r.Context().Done():
 		}
 	}))
@@ -79,6 +79,32 @@ func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
 	want := map[string]any{"answer": "hello", "message_id": "msg-1", "mode": "chat"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("result = %#v, want %#v", got, want)
+	}
+}
+
+func TestReadSSE_AcceptsStandardLineEndings(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		end  string
+	}{
+		{name: "crlf", end: "\r\n"},
+		{name: "cr", end: "\r"},
+		{name: "lf", end: "\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var event, data string
+			input := "event: chunk" + tc.end + "data: hello" + tc.end + tc.end
+			err := readSSE(strings.NewReader(input), func(gotEvent string, gotData []byte) error {
+				event, data = gotEvent, string(gotData)
+				return nil
+			})
+			if err != nil {
+				t.Fatalf("readSSE: %v", err)
+			}
+			if event != "chunk" || data != "hello" {
+				t.Fatalf("event = %q, data = %q", event, data)
+			}
+		})
 	}
 }
 

--- a/pkg/runtime/stream_test.go
+++ b/pkg/runtime/stream_test.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
+	firstSent := make(chan struct{})
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: chunk\ndata: {\"kind\":\"ignored\",\"text\":\"hel\",\"mode\":\"chat\"}\n\n")
+		w.(http.Flusher).Flush()
+		close(firstSent)
+		select {
+		case <-release:
+			_, _ = io.WriteString(w, "data: {\"kind\":\"chunk\",\"text\":\"lo\"}\n\ndata: {\"kind\":\"done\",\"id\":\"msg-1\"}\n\n")
+		case <-r.Context().Done():
+		}
+	}))
+	defer srv.Close()
+
+	hint := &StreamingHint{Strategy: "sse", Policy: &StreamPolicy{
+		DataFormat: "json", EventNamePath: "kind",
+		Collect: &StreamCollectHint{
+			RequireStop: true,
+			StopEvents:  []string{"done"},
+			Fields: []StreamFieldRule{
+				{Events: []string{"chunk"}, From: "text", To: "answer", Reduce: "concat"},
+				{Events: []string{"chunk"}, From: "mode", To: "mode", Reduce: "first"},
+				{Events: []string{"done"}, From: "id", To: "message_id", Reduce: "last"},
+			},
+		},
+		Live: &StreamLiveHint{Events: []string{"chunk"}, From: "text"},
+	}}
+	out := &observedWriter{wrote: make(chan struct{})}
+	resultCh := make(chan OperationResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := invokeOperation(context.Background(), CommandSpec{
+			Method: "GET", PathTpl: "/events", Output: OutputHints{Streaming: hint},
+		}, OperationInput{}, OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}}, operationOutput{live: out})
+		resultCh <- result
+		errCh <- err
+	}()
+	select {
+	case <-firstSent:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("server did not send the first event")
+	}
+	select {
+	case <-out.wrote:
+	case <-time.After(200 * time.Millisecond):
+		close(release)
+		<-errCh
+		t.Fatal("live projection did not write before the response closed")
+	}
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("invokeOperation: %v", err)
+	}
+	result := <-resultCh
+	if result.Outcome != OperationOutcomeCompleted || out.String() != "hello" {
+		t.Fatalf("outcome = %q, live = %q", result.Outcome, out.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(result.Data, &got); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	want := map[string]any{"answer": "hello", "message_id": "msg-1", "mode": "chat"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result = %#v, want %#v", got, want)
+	}
+}
+
+func TestCollectStream_RejectsMissingRequiredStop(t *testing.T) {
+	hint := &StreamingHint{Strategy: "ndjson", Policy: &StreamPolicy{
+		DataFormat: "json", EventNamePath: "kind",
+		Collect: &StreamCollectHint{RequireStop: true, StopEvents: []string{"done"}},
+	}}
+	outcome := OperationOutcomeCompleted
+	if _, err := collectStream(strings.NewReader("{\"kind\":\"chunk\"}\n"), hint, nil, &outcome); err == nil {
+		t.Fatal("expected missing terminal event error")
+	}
+
+	hint.Policy.Collect.RequireStop = false
+	hint.Policy.Collect.ErrorEvents = []string{"failed"}
+	_, err := collectStream(strings.NewReader("{\"kind\":\"failed\",\"message\":\"run failed\"}\n"), hint, nil, &outcome)
+	if classified := ClassifyError(err); classified == nil || classified.ExitCode != ExitAPIError {
+		t.Fatalf("error = %v, classified = %#v", err, classified)
+	}
+}

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -173,6 +173,12 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 			return fail(err)
 		}
 		state.steps[step.ID] = workflowStepValue(opResult.Data)
+		if opResult.Outcome == OperationOutcomePaused {
+			stepResult.Status = OperationOutcomePaused
+			result.Status = OperationOutcomePaused
+			result.Steps = append(result.Steps, stepResult)
+			return result, opResult.Data, nil
+		}
 		result.Steps = append(result.Steps, stepResult)
 	}
 	if strings.TrimSpace(spec.OutputFrom) == "" {

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -130,6 +130,56 @@ func TestBuildWorkflows_StopsOnFailedStep(t *testing.T) {
 	}
 }
 
+func TestBuildWorkflows_StopsOnPausedStream(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/pause" {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "data: {\"kind\":\"checkpoint\",\"token\":\"resume-1\"}\n\n")
+			return
+		}
+		_, _ = w.Write([]byte(`{"unexpected":true}`))
+	}))
+	defer srv.Close()
+
+	streaming := &StreamingHint{Strategy: "sse", Policy: &StreamPolicy{
+		DataFormat: "json", EventNamePath: "kind",
+		Collect: &StreamCollectHint{
+			RequireStop: true,
+			PauseEvents: []string{"checkpoint"},
+			Fields: []StreamFieldRule{
+				{Events: []string{"checkpoint"}, Value: "paused", To: "status", Reduce: "last"},
+				{Events: []string{"checkpoint"}, From: "token", To: "resume_token", Reduce: "last"},
+			},
+		},
+	}}
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use: "deploy",
+		Steps: []WorkflowStepSpec{
+			{ID: "wait", Operation: CommandSpec{Method: "GET", PathTpl: "/pause", Security: &SecurityHint{Public: true}, Output: OutputHints{Streaming: streaming}}},
+			{ID: "after", Operation: publicGetSpec("after", "/after")},
+		},
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !reflect.DeepEqual(paths, []string{"/pause"}) {
+		t.Fatalf("paths = %#v", paths)
+	}
+	if strings.TrimSpace(stdout.String()) != `{"resume_token":"resume-1","status":"paused"}` {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestBuildWorkflows_RejectsInvalidInputEnum(t *testing.T) {
 	root := newWorkflowRoot(io.Discard)
 	if err := BuildWorkflows(root, []WorkflowSpec{{


### PR DESCRIPTION
## Summary

- Stream successful response bodies for operations declared as streaming instead of buffering the full response.
- Add opt-in overlay policies for collecting JSON SSE or NDJSON events with fixed reducers, projecting live output with `--stream`, and returning a paused workflow outcome.
- Validate stream policies during code generation and expose the resulting contract through the runtime catalog, generated Skill, and documentation without product-specific event semantics.

## Verification

- `make check`
- `go test -race ./...`
- `go test ./pkg/runtime ./internal/codegen/render -run 'Test(InvokeOperation_CollectsAndProjectsSSE|CollectStream_RejectsMissingRequiredStop|Build_RawStreamingWritesBeforeResponseCloses|DoRawFull_StreamCancellationClosesResponse|DebugTransport_DoesNotPeekStreamingResponse|BuildWorkflows_StopsOnPausedStream|MergeOverlayModule_StreamPolicy)$' -count=500`
- Generated CLI smoke against `cloud.dify.ai`: contract verification passed 31/31, list and describe commands succeeded, collected chat output returned `lathe-cloud-ok`, and live projection emitted 40 chunks with first output arriving before completion.

## Compatibility

Existing operations are unchanged unless streaming is declared or an overlay stream policy is configured. Raw streaming remains available as the generic fallback. The additive streaming contract advances the runtime catalog schema to version 13.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
