### PR TITLE
feat(runtime): encode multipart form uploads

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -449,7 +449,8 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 		return nil
 	}
 	out := &rawir.RawSchema{
-		Type: string(s.Type),
+		Type:   string(s.Type),
+		Format: s.Format,
 	}
 	if s.Ref != "" {
 		if strings.HasPrefix(s.Ref, oas3RefPrefix) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -74,6 +75,56 @@ func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
 	}
 	if got := mod.Operations[0].Responses["200"].Schema.Properties["name"].Type; got != "string" {
 		t.Fatalf("property type = %q, want string", got)
+	}
+}
+
+func TestParse_MultipartBodyFields(t *testing.T) {
+	input := `{
+  "openapi": "3.0.3",
+  "paths": {
+    "/uploads": {
+      "post": {
+        "operationId": "Upload_Create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {"$ref": "#/components/schemas/UploadForm"}
+            }
+          }
+        },
+        "responses": {"201": {}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UploadForm": {
+        "type": "object",
+        "required": ["file"],
+        "properties": {
+          "file": {"type": "string", "format": "binary"},
+          "purpose": {"type": "string"}
+        }
+      }
+    }
+  }
+}`
+	spec := parseNormalized(t, input)[0]
+	if spec.RequestBody == nil || spec.RequestBody.MediaType != "multipart/form-data" {
+		t.Fatalf("request body = %#v", spec.RequestBody)
+	}
+	want := map[string]runtime.ParamSpec{
+		"file":    {Name: "file", Flag: "file", In: runtime.InFormData, GoType: "string", Help: "file (formData, required, binary, local file path)", Required: true, Format: "binary"},
+		"purpose": {Name: "purpose", Flag: "purpose", In: runtime.InFormData, GoType: "string", Help: "purpose (formData)"},
+	}
+	if len(spec.Params) != len(want) {
+		t.Fatalf("params = %#v", spec.Params)
+	}
+	for _, param := range spec.Params {
+		if !reflect.DeepEqual(param, want[param.Name]) {
+			t.Errorf("param %q = %#v, want %#v", param.Name, param, want[param.Name])
+		}
 	}
 }
 

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -85,6 +85,9 @@ func TestParse_MultipartBodyFields(t *testing.T) {
     "/uploads": {
       "post": {
         "operationId": "Upload_Create",
+        "parameters": [
+          {"name": "purpose", "in": "query", "schema": {"type": "string"}}
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -115,15 +118,17 @@ func TestParse_MultipartBodyFields(t *testing.T) {
 		t.Fatalf("request body = %#v", spec.RequestBody)
 	}
 	want := map[string]runtime.ParamSpec{
-		"file":    {Name: "file", Flag: "file", In: runtime.InFormData, GoType: "string", Help: "file (formData, required, binary, local file path)", Required: true, Format: "binary"},
-		"purpose": {Name: "purpose", Flag: "purpose", In: runtime.InFormData, GoType: "string", Help: "purpose (formData)"},
+		"formData:file":    {Name: "file", Flag: "file", In: runtime.InFormData, GoType: "string", Help: "file (formData, required, binary, local file path)", Required: true, Format: "binary"},
+		"formData:purpose": {Name: "purpose", Flag: "body-purpose", In: runtime.InFormData, GoType: "string", Help: "purpose (formData)"},
+		"query:purpose":    {Name: "purpose", Flag: "purpose", In: runtime.InQuery, GoType: "string", Help: "purpose (query)"},
 	}
 	if len(spec.Params) != len(want) {
 		t.Fatalf("params = %#v", spec.Params)
 	}
 	for _, param := range spec.Params {
-		if !reflect.DeepEqual(param, want[param.Name]) {
-			t.Errorf("param %q = %#v, want %#v", param.Name, param, want[param.Name])
+		key := param.In + ":" + param.Name
+		if !reflect.DeepEqual(param, want[key]) {
+			t.Errorf("param %q = %#v, want %#v", key, param, want[key])
 		}
 	}
 }

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -61,6 +61,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 				Template:  op.RequestBody.Template,
 				MergePath: op.RequestBody.MergePath,
 			}
+			spec.Params = append(spec.Params, multipartBodyParams(op.RequestBody, mod.Schemas)...)
 		}
 		lp, itemRef := deriveList(op, mod.Schemas)
 		spec.Output.ListPath = lp
@@ -434,6 +435,11 @@ func headerParam(p rawir.RawParameter) runtime.ParamSpec {
 }
 
 func formDataParam(p rawir.RawParameter) runtime.ParamSpec {
+	format := p.Format
+	if p.Type == "file" && format == "" {
+		format = "binary"
+	}
+	p.Format = format
 	ps := runtime.ParamSpec{
 		Name:       p.Name,
 		Flag:       camelToKebab(p.Name),
@@ -442,7 +448,7 @@ func formDataParam(p rawir.RawParameter) runtime.ParamSpec {
 		Required:   p.Required,
 		Default:    p.Default,
 		Enum:       p.Enum,
-		Format:     p.Format,
+		Format:     format,
 		Deprecated: p.Deprecated,
 	}
 	switch p.Type {
@@ -454,6 +460,53 @@ func formDataParam(p rawir.RawParameter) runtime.ParamSpec {
 		ps.GoType = "string"
 	}
 	return ps
+}
+
+func multipartBodyParams(body *rawir.RawRequestBody, defs map[string]*rawir.RawSchema) []runtime.ParamSpec {
+	mediaType, _, err := mime.ParseMediaType(body.MediaType)
+	if err != nil || mediaType != "multipart/form-data" {
+		return nil
+	}
+	schema := rawir.Resolve(body.Schema, defs)
+	if schema == nil || schema.Type != "object" || len(schema.Properties) == 0 {
+		return nil
+	}
+	required := make(map[string]bool, len(schema.Required))
+	for _, name := range schema.Required {
+		required[name] = true
+	}
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]runtime.ParamSpec, 0, len(names))
+	for _, name := range names {
+		property := rawir.Resolve(schema.Properties[name], defs)
+		if property == nil || !multipartScalar(property) {
+			return nil
+		}
+		out = append(out, formDataParam(rawir.RawParameter{
+			Name:     name,
+			In:       "formData",
+			Required: required[name],
+			Type:     property.Type,
+			Format:   property.Format,
+		}))
+	}
+	return out
+}
+
+func multipartScalar(schema *rawir.RawSchema) bool {
+	if schema.Format == "binary" {
+		return schema.Type == "" || schema.Type == "string"
+	}
+	switch schema.Type {
+	case "string", "integer", "boolean":
+		return true
+	default:
+		return false
+	}
 }
 
 func helpText(p rawir.RawParameter) string {
@@ -469,6 +522,9 @@ func helpText(p rawir.RawParameter) string {
 	}
 	if p.Format != "" {
 		parts = append(parts, p.Format)
+	}
+	if p.In == "formData" && p.Format == "binary" {
+		parts = append(parts, "local file path")
 	}
 	if len(p.Enum) > 0 {
 		parts = append(parts, "one of: "+strings.Join(p.Enum, "|"))

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -61,7 +61,9 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 				Template:  op.RequestBody.Template,
 				MergePath: op.RequestBody.MergePath,
 			}
-			spec.Params = append(spec.Params, multipartBodyParams(op.RequestBody, mod.Schemas)...)
+			bodyParams := multipartBodyParams(op.RequestBody, mod.Schemas)
+			disambiguateMultipartParamFlags(spec.Params, bodyParams)
+			spec.Params = append(spec.Params, bodyParams...)
 		}
 		lp, itemRef := deriveList(op, mod.Schemas)
 		spec.Output.ListPath = lp
@@ -506,6 +508,25 @@ func multipartScalar(schema *rawir.RawSchema) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func disambiguateMultipartParamFlags(existing, body []runtime.ParamSpec) {
+	used := make(map[string]bool, len(existing)+len(body))
+	for _, param := range existing {
+		used[param.Flag] = true
+	}
+	for i := range body {
+		flag := body[i].Flag
+		if used[flag] {
+			base := "body-" + flag
+			flag = base
+			for suffix := 2; used[flag]; suffix++ {
+				flag = fmt.Sprintf("%s-%d", base, suffix)
+			}
+			body[i].Flag = flag
+		}
+		used[flag] = true
 	}
 }
 

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -69,6 +69,7 @@ type RawPaginationHint struct {
 type RawSchema struct {
 	Ref        string
 	Type       string
+	Format     string `json:",omitempty"`
 	Properties map[string]*RawSchema
 	Required   []string `json:",omitempty"`
 	Items      *RawSchema

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -252,9 +252,10 @@ func controlFlagName(cmd *cobra.Command, name string) string {
 }
 
 func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequestBody bool) {
+	key := boundParamKey(p)
 	if p.In == InPath {
 		v := new(string)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().StringVar(v, p.Flag, p.Default, p.Help)
 		addSafeInputFlags(cmd, p)
 		if p.Default == "" && !isSensitiveStringParam(p) {
@@ -268,7 +269,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 	switch p.GoType {
 	case "int64":
 		v := new(int64)
-		vals[p.Name] = v
+		vals[key] = v
 		var def int64
 		if p.Default != "" {
 			def, _ = strconv.ParseInt(p.Default, 10, 64)
@@ -276,7 +277,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 		cmd.Flags().Int64Var(v, p.Flag, def, p.Help)
 	case "float64":
 		v := new(float64)
-		vals[p.Name] = v
+		vals[key] = v
 		var def float64
 		if p.Default != "" {
 			def, _ = strconv.ParseFloat(p.Default, 64)
@@ -284,28 +285,28 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 		cmd.Flags().Float64Var(v, p.Flag, def, p.Help)
 	case "bool":
 		v := new(bool)
-		vals[p.Name] = v
+		vals[key] = v
 		def := p.Default == "true"
 		cmd.Flags().BoolVar(v, p.Flag, def, p.Help)
 	case "[]int64":
 		v := new([]int64)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().Int64SliceVar(v, p.Flag, nil, p.Help)
 	case "[]float64":
 		v := new([]float64)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().Float64SliceVar(v, p.Flag, nil, p.Help)
 	case "[]bool":
 		v := new([]bool)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().BoolSliceVar(v, p.Flag, nil, p.Help)
 	case "[]string":
 		v := new([]string)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().StringSliceVar(v, p.Flag, nil, p.Help)
 	default:
 		v := new(string)
-		vals[p.Name] = v
+		vals[key] = v
 		cmd.Flags().StringVar(v, p.Flag, p.Default, p.Help)
 		addSafeInputFlags(cmd, p)
 	}
@@ -412,7 +413,7 @@ func resolveSafeInputFlags(cmd *cobra.Command, params []ParamSpec, vals map[stri
 		if value == "" {
 			return fmt.Errorf("--%s value is empty", p.Flag)
 		}
-		*vals[p.Name].(*string) = value
+		*vals[boundParamKey(p)].(*string) = value
 	}
 	return nil
 }
@@ -603,11 +604,10 @@ func flagChangedOrDefault(cmd *cobra.Command, p ParamSpec) bool {
 }
 
 func operationChangedFlags(cmd *cobra.Command, params []ParamSpec) map[string]bool {
-	changed := make(map[string]bool, len(params)*2)
+	changed := make(map[string]bool, len(params))
 	for _, p := range params {
 		if flagChangedOrDefault(cmd, p) {
-			changed[p.Name] = true
-			changed[p.Flag] = true
+			changed[boundParamKey(p)] = true
 		}
 	}
 	return changed

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -144,7 +144,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return err
 			}
 
-			hasFile := s.RequestBody != nil && cmd.Flags().Changed(bodyFileFlag)
+			hasFile := bodyFileFlag != "" && cmd.Flags().Changed(bodyFileFlag)
 			var fileBody []byte
 			if hasFile {
 				fileBody, err = ReadBody(bodyFile)
@@ -195,7 +195,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	for i := range s.Params {
 		bindParamFlag(cmd, vals, s.Params[i], s.RequestBody != nil)
 	}
-	if s.RequestBody != nil {
+	if s.RequestBody != nil && !hasFormDataParams(s.Params) {
 		bodyFileFlag = controlFlagName(cmd, "file")
 		bodySetFlag := controlFlagName(cmd, "set")
 		bodyStringSetFlag := controlFlagName(cmd, "set-str")
@@ -328,6 +328,9 @@ func redactedDryRunHeaders(headers map[string][]string) map[string]string {
 func redactedDryRunBody(contentType string, body []byte) any {
 	if len(body) == 0 {
 		return nil
+	}
+	if isMultipartMediaType(contentType) {
+		return fmt.Sprintf("<multipart body omitted: %d bytes>", len(body))
 	}
 	redacted := redactDebugBody(contentType, body)
 	if strings.HasPrefix(contentType, "application/json") {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -455,6 +456,97 @@ func TestBuild_FileSendsRequestBodyMediaType(t *testing.T) {
 	}
 	if gotContentType != "text/plain" {
 		t.Errorf("Content-Type = %q, want text/plain", gotContentType)
+	}
+}
+
+func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	type capture struct {
+		contentType string
+		disposition string
+		filename    string
+		fileType    string
+		fileBody    string
+		purpose     string
+		err         error
+	}
+	var got capture
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.contentType = r.Header.Get("Content-Type")
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			got.err = err
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer func() { _ = r.MultipartForm.RemoveAll() }()
+		got.purpose = r.FormValue("purpose")
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			got.err = err
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		defer file.Close()
+		body, err := io.ReadAll(file)
+		if err != nil {
+			got.err = err
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		got.disposition = header.Header.Get("Content-Disposition")
+		got.filename = header.Filename
+		got.fileType = header.Header.Get("Content-Type")
+		got.fileBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"file-1"}`))
+	}))
+	defer srv.Close()
+
+	filePath := t.TempDir() + "/sample.png"
+	if err := os.WriteFile(filePath, []byte("file-content"), 0o600); err != nil {
+		t.Fatalf("write upload: %v", err)
+	}
+
+	root := newRootWithModuleGroup()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group:   "Uploads",
+		Use:     "create",
+		Method:  http.MethodPost,
+		PathTpl: "/uploads",
+		Params: []ParamSpec{
+			{Name: "file", Flag: "file", In: InFormData, GoType: "string", Required: true, Format: "binary"},
+			{Name: "purpose", Flag: "purpose", In: InFormData, GoType: "string"},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "multipart/form-data"},
+		Security:    &SecurityHint{Public: true},
+	}})
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "uploads", "create", "--file", filePath, "--purpose", "knowledge"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got.err != nil {
+		t.Fatalf("parse multipart: %v", got.err)
+	}
+	if !strings.HasPrefix(got.contentType, "multipart/form-data; boundary=") {
+		t.Errorf("Content-Type = %q", got.contentType)
+	}
+	if got.filename != "sample.png" || got.fileType != "image/png" || got.fileBody != "file-content" {
+		t.Errorf("file = filename %q, type %q, body %q", got.filename, got.fileType, got.fileBody)
+	}
+	disposition, dispositionParams, err := mime.ParseMediaType(got.disposition)
+	if err != nil || disposition != "form-data" || dispositionParams["name"] != "file" || dispositionParams["filename"] != "sample.png" {
+		t.Errorf("Content-Disposition = %q: %v", got.disposition, err)
+	}
+	if got.purpose != "knowledge" {
+		t.Errorf("purpose = %q", got.purpose)
 	}
 }
 

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -469,19 +469,21 @@ func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
 		filename    string
 		fileType    string
 		fileBody    string
-		purpose     string
+		queryValue  string
+		bodyValue   string
 		err         error
 	}
 	var got capture
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		got.contentType = r.Header.Get("Content-Type")
+		got.queryValue = r.URL.Query().Get("purpose")
 		if err := r.ParseMultipartForm(1 << 20); err != nil {
 			got.err = err
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		defer func() { _ = r.MultipartForm.RemoveAll() }()
-		got.purpose = r.FormValue("purpose")
+		got.bodyValue = strings.Join(r.MultipartForm.Value["purpose"], ",")
 		file, header, err := r.FormFile("file")
 		if err != nil {
 			got.err = err
@@ -521,13 +523,14 @@ func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
 		Method:  http.MethodPost,
 		PathTpl: "/uploads",
 		Params: []ParamSpec{
+			{Name: "purpose", Flag: "purpose", In: InQuery, GoType: "string"},
 			{Name: "file", Flag: "file", In: InFormData, GoType: "string", Required: true, Format: "binary"},
-			{Name: "purpose", Flag: "purpose", In: InFormData, GoType: "string"},
+			{Name: "purpose", Flag: "body-purpose", In: InFormData, GoType: "string"},
 		},
 		RequestBody: &RequestBody{Required: true, MediaType: "multipart/form-data"},
 		Security:    &SecurityHint{Public: true},
 	}})
-	root.SetArgs([]string{"--hostname", srv.URL, "demo", "uploads", "create", "--file", filePath, "--purpose", "knowledge"})
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "uploads", "create", "--file", filePath, "--purpose", "query", "--body-purpose", "body"})
 
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -545,8 +548,8 @@ func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
 	if err != nil || disposition != "form-data" || dispositionParams["name"] != "file" || dispositionParams["filename"] != "sample.png" {
 		t.Errorf("Content-Disposition = %q: %v", got.disposition, err)
 	}
-	if got.purpose != "knowledge" {
-		t.Errorf("purpose = %q", got.purpose)
+	if got.queryValue != "query" || got.bodyValue != "body" {
+		t.Errorf("purpose = query %q, body %q", got.queryValue, got.bodyValue)
 	}
 }
 

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -187,9 +186,9 @@ func encodeMultipartForm(form multipartForm) ([]byte, string, error) {
 	sort.Strings(fileNames)
 	for _, name := range fileNames {
 		path := form.Files[name]
-		file, err := os.Open(path)
+		data, err := ReadBody(path)
 		if err != nil {
-			return nil, "", fmt.Errorf("open multipart file %q: %w", path, err)
+			return nil, "", fmt.Errorf("read multipart file %q: %w", path, err)
 		}
 		header := make(textproto.MIMEHeader)
 		header.Set("Content-Disposition", mime.FormatMediaType("form-data", map[string]string{
@@ -202,14 +201,10 @@ func encodeMultipartForm(form multipartForm) ([]byte, string, error) {
 		header.Set("Content-Type", contentType)
 		part, partErr := w.CreatePart(header)
 		if partErr == nil {
-			_, partErr = io.Copy(part, file)
+			_, partErr = part.Write(data)
 		}
-		closeErr := file.Close()
 		if partErr != nil {
 			return nil, "", fmt.Errorf("write multipart file %q: %w", path, partErr)
-		}
-		if closeErr != nil {
-			return nil, "", fmt.Errorf("close multipart file %q: %w", path, closeErr)
 		}
 	}
 	if err := w.Close(); err != nil {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -8,8 +8,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -106,6 +112,11 @@ func doRawFull(ctx context.Context, hostname, method, path string, body any, opt
 
 type responseConsumer func(io.Reader) ([]byte, error)
 
+type multipartForm struct {
+	Fields url.Values
+	Files  map[string]string
+}
+
 func doRawFullConsume(ctx context.Context, hostname, method, path string, body any, opts ClientOptions, consume responseConsumer) (*RawResult, error) {
 	req, bodyBytes, contentType, err := resolveRequest(ctx, hostname, method, path, body, opts)
 	if err != nil {
@@ -141,6 +152,8 @@ func encodeRequestBody(body any) ([]byte, string, error) {
 			return b, "application/json", nil
 		case url.Values:
 			return []byte(b.Encode()), "application/x-www-form-urlencoded", nil
+		case multipartForm:
+			return encodeMultipartForm(b)
 		default:
 			raw, err := json.Marshal(b)
 			if err != nil {
@@ -150,6 +163,64 @@ func encodeRequestBody(body any) ([]byte, string, error) {
 		}
 	}
 	return nil, "", nil
+}
+
+func encodeMultipartForm(form multipartForm) ([]byte, string, error) {
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	fieldNames := make([]string, 0, len(form.Fields))
+	for name := range form.Fields {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+	for _, name := range fieldNames {
+		for _, value := range form.Fields[name] {
+			if err := w.WriteField(name, value); err != nil {
+				return nil, "", fmt.Errorf("write multipart field %q: %w", name, err)
+			}
+		}
+	}
+	fileNames := make([]string, 0, len(form.Files))
+	for name := range form.Files {
+		fileNames = append(fileNames, name)
+	}
+	sort.Strings(fileNames)
+	for _, name := range fileNames {
+		path := form.Files[name]
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, "", fmt.Errorf("open multipart file %q: %w", path, err)
+		}
+		header := make(textproto.MIMEHeader)
+		header.Set("Content-Disposition", mime.FormatMediaType("form-data", map[string]string{
+			"name": name, "filename": filepath.Base(path),
+		}))
+		contentType := mime.TypeByExtension(strings.ToLower(filepath.Ext(path)))
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+		header.Set("Content-Type", contentType)
+		part, partErr := w.CreatePart(header)
+		if partErr == nil {
+			_, partErr = io.Copy(part, file)
+		}
+		closeErr := file.Close()
+		if partErr != nil {
+			return nil, "", fmt.Errorf("write multipart file %q: %w", path, partErr)
+		}
+		if closeErr != nil {
+			return nil, "", fmt.Errorf("close multipart file %q: %w", path, closeErr)
+		}
+	}
+	if err := w.Close(); err != nil {
+		return nil, "", fmt.Errorf("close multipart body: %w", err)
+	}
+	return body.Bytes(), w.FormDataContentType(), nil
+}
+
+func isMultipartMediaType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	return err == nil && mediaType == "multipart/form-data"
 }
 
 func resolveRequest(ctx context.Context, hostname, method, path string, body any, opts ClientOptions) (*http.Request, []byte, string, error) {

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -127,6 +127,7 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 	q := url.Values{}
 	hdrs := map[string]string{}
 	form := url.Values{}
+	files := map[string]string{}
 	vars := map[string]any{}
 	for _, p := range s.Params {
 		switch p.In {
@@ -168,7 +169,11 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 			if err != nil {
 				return "", nil, ClientOptions{}, err
 			}
-			form.Set(p.Name, operationStringValue(v))
+			if p.Format == "binary" {
+				files[p.Name] = operationStringValue(v)
+			} else {
+				form.Set(p.Name, operationStringValue(v))
+			}
 			continue
 		}
 		if !operationChanged(input, p) {
@@ -201,14 +206,14 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 		path = path + "?" + enc
 	}
 
-	body, err := resolveOperationBody(s, input, form, vars)
+	body, err := resolveOperationBody(s, input, form, files, vars)
 	if err != nil {
 		return "", nil, ClientOptions{}, err
 	}
 	if err := validateRequiredVariableParams(s, body); err != nil {
 		return "", nil, ClientOptions{}, err
 	}
-	if body != nil && s.RequestBody != nil && s.RequestBody.MediaType != "" {
+	if body != nil && s.RequestBody != nil && s.RequestBody.MediaType != "" && !isMultipartMediaType(s.RequestBody.MediaType) {
 		hdrs["Content-Type"] = s.RequestBody.MediaType
 	}
 
@@ -219,7 +224,10 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 	return path, body, clientOpts, nil
 }
 
-func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, vars map[string]any) (any, error) {
+func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, files map[string]string, vars map[string]any) (any, error) {
+	if len(files) > 0 || (isMultipartMediaType(requestBodyMediaType(s)) && (len(form) > 0 || s.RequestBody.Required && hasFormDataParams(s.Params))) {
+		return multipartForm{Fields: form, Files: files}, nil
+	}
 	if len(form) > 0 {
 		return form, nil
 	}
@@ -245,6 +253,22 @@ func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, 
 	default:
 		return nil, nil
 	}
+}
+
+func requestBodyMediaType(s CommandSpec) string {
+	if s.RequestBody == nil {
+		return ""
+	}
+	return s.RequestBody.MediaType
+}
+
+func hasFormDataParams(params []ParamSpec) bool {
+	for _, param := range params {
+		if param.In == InFormData {
+			return true
+		}
+	}
+	return false
 }
 
 func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path string, body any, opts ClientOptions) (DryRunRequest, error) {

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -336,7 +336,10 @@ func operationChanged(input OperationInput, p ParamSpec) bool {
 		return true
 	}
 	if input.Changed != nil {
-		return input.Changed[p.Name] || input.Changed[p.Flag]
+		return input.Changed[boundParamKey(p)] || input.Changed[p.Name] || input.Changed[p.Flag]
+	}
+	if _, ok := input.Values[boundParamKey(p)]; ok {
+		return true
 	}
 	if _, ok := input.Values[p.Name]; ok {
 		return true
@@ -348,7 +351,10 @@ func operationChanged(input OperationInput, p ParamSpec) bool {
 }
 
 func operationValue(input OperationInput, p ParamSpec) (any, bool, error) {
-	v, ok := input.Values[p.Name]
+	v, ok := input.Values[boundParamKey(p)]
+	if !ok {
+		v, ok = input.Values[p.Name]
+	}
 	if !ok {
 		v, ok = input.Values[p.Flag]
 	}
@@ -363,6 +369,10 @@ func operationValue(input OperationInput, p ParamSpec) (any, bool, error) {
 		return nil, false, err
 	}
 	return out, true, nil
+}
+
+func boundParamKey(p ParamSpec) string {
+	return p.In + "\x00" + p.Flag
 }
 
 func coerceOperationValue(v any, p ParamSpec) (any, error) {


### PR DESCRIPTION
## Summary

- derive scalar `multipart/form-data` fields from OpenAPI request body schemas
- expose binary fields as local file path flags while preserving regular form fields
- encode files with a dynamic boundary, filename, MIME type, and `Content-Disposition`
- omit multipart bytes from dry-run output and keep existing JSON/urlencoded behavior unchanged

## Verification

- `go test -count=20 ./internal/codegen/backends/openapi3 ./internal/codegen/normalize ./pkg/runtime`
- `make check`
- `go test -race ./...`
- generated Dify CLI: `__lathe verify --json` passed 31/31
- generated Dify loopback upload parsed the file part with `boundary=true`, `Content-Disposition`, filename, MIME, and file bytes

Cloud upload was not run because macOS Keychain access required an interactive unlock; the attempted process and isolated credential directory were removed without sending a cloud request.
