### PR TITLE
feat(auth): configure OAuth device flows

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -67,6 +67,14 @@ auth:
     start_path: /auth/device/start
     token_path: /auth/device/token
     refresh_path: /auth/device/refresh
+    start_request:
+      client_id: acmectl
+      device_label: ${device_label}
+    poll_request:
+      client_id: acmectl
+      device_code: ${device_code}
+    poll_response:
+      access_token: token
   validate:
     method: GET
     path: /api/v1/whoami
@@ -86,11 +94,18 @@ and multiple modules use `<cli> <module> <group> <operation>`. Set it to
 module flat path and fail codegen on root command conflicts.
 
 `auth.login.type: oauth_device` enables `auth login --device-auth` and
-`auth login --auth-type oauth`. The service must provide `start_path` and
-`token_path` endpoints using OAuth 2.0 device-flow fields (`device_code`,
-`verification_uri`, optional `user_code`, `interval`, `expires_in`, and later
-`access_token`). `refresh_path` is optional; when present, generated commands
-refresh expired bearer tokens before execution.
+`auth login --auth-type oauth`. In an interactive terminal the verification
+URL opens in a browser by default; use `--no-browser` for a manual flow.
+
+`start_request` and `poll_request` replace the default JSON request bodies.
+Values may be literals or the exact placeholders `${hostname}`, `${provider}`,
+`${device_label}`, and, in `poll_request`, `${device_code}`. Empty placeholder
+values are omitted. `poll_response` maps runtime fields to JSON paths; omitted
+entries use `access_token`, `refresh_token`, `expires_in`, `status`, `error`,
+`user.email`, and `user.name`. The start response uses the standard device
+fields (`device_code`, `verification_uri`, optional `user_code`, `interval`,
+and `expires_in`). `refresh_path` remains standard OAuth and is optional; when
+present, generated commands refresh expired bearer tokens before execution.
 
 `auth.default_type` controls `auth login` when `--auth-type` is omitted and
 defaults to `bearer`; `oauth` requires an `auth.login` block. For API key login,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -295,9 +295,19 @@ func maybeOpenBrowser(rawURL string, noBrowser bool) {
 		name = "rundll32"
 		args = []string{"url.dll,FileProtocolHandler", rawURL}
 	}
-	if err := exec.Command(name, args...).Run(); err != nil {
+	if err := startBrowserCommand(name, args...); err != nil {
 		fmt.Fprintf(os.Stderr, "Browser could not be opened (%v); open the URL above manually.\n", err)
 	}
+}
+
+func startBrowserCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// xdg-open may stay attached to the browser, so reap it without delaying token polling.
+	go func() { _ = cmd.Wait() }()
+	return nil
 }
 
 func browserSkipReason(noBrowser bool) string {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"os/exec"
+	goruntime "runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -42,12 +46,13 @@ type oauthDeviceStartResponse struct {
 }
 
 type oauthDeviceTokenResponse struct {
-	Status       string            `json:"status"`
-	Error        string            `json:"error"`
-	AccessToken  string            `json:"access_token"`
-	RefreshToken string            `json:"refresh_token"`
-	ExpiresIn    int64             `json:"expires_in"`
-	User         map[string]string `json:"user"`
+	Status       string
+	Error        string
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int64
+	UserEmail    string
+	UserName     string
 }
 
 func rootString(cmd *cobra.Command, name string) string {
@@ -60,15 +65,28 @@ func rootBool(cmd *cobra.Command, name string) bool {
 	return v
 }
 
-func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, provider string, insecure bool) (config.HostEntry, error) {
+func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, provider string, insecure, noBrowser bool) (config.HostEntry, error) {
 	login := m.Auth.Login
 	if login == nil || login.Type != config.AuthLoginOAuthDevice {
 		return config.HostEntry{}, errors.New("auth.login with type oauth_device is required for --auth-type oauth")
 	}
-	body := map[string]string{"hostname": hostname}
 	provider = strings.TrimSpace(provider)
+	deviceHostname, _ := os.Hostname()
+	if deviceHostname == "" {
+		deviceHostname = "unknown-host"
+	}
+	deviceLabel := m.CLI.Name + " on " + deviceHostname
+	fallback := map[string]string{"hostname": hostname}
 	if provider != "" {
-		body["provider"] = provider
+		fallback["provider"] = provider
+	}
+	body, err := oauthDeviceRequest(login.StartRequest, fallback, map[string]string{
+		config.AuthLoginHostname:    hostname,
+		config.AuthLoginProvider:    provider,
+		config.AuthLoginDeviceLabel: deviceLabel,
+	})
+	if err != nil {
+		return config.HostEntry{}, err
 	}
 	data, err := runtime.DoRaw(cmd.Context(), hostname, "POST", login.StartPath, body, runtime.ClientOptions{Insecure: insecure, Timeout: 10 * time.Second})
 	if err != nil {
@@ -81,9 +99,9 @@ func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, p
 	if start.DeviceCode == "" {
 		return config.HostEntry{}, errors.New("oauth start response missing device_code")
 	}
-	verificationURL := start.VerificationURIComplete
+	verificationURL := start.VerificationURI
 	if verificationURL == "" {
-		verificationURL = start.VerificationURI
+		verificationURL = start.VerificationURIComplete
 	}
 	if verificationURL == "" {
 		return config.HostEntry{}, errors.New("oauth start response missing verification_uri")
@@ -92,7 +110,12 @@ func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, p
 	if start.UserCode != "" {
 		fmt.Fprintf(os.Stderr, "Code: %s\n", start.UserCode)
 	}
-	token, err := pollOAuthDeviceToken(cmd, hostname, login.TokenPath, start, insecure)
+	openURL := start.VerificationURIComplete
+	if openURL == "" {
+		openURL = verificationURL
+	}
+	maybeOpenBrowser(openURL, noBrowser)
+	token, err := pollOAuthDeviceToken(cmd, hostname, login, start, provider, deviceLabel, insecure)
 	if err != nil {
 		return config.HostEntry{}, err
 	}
@@ -107,16 +130,14 @@ func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, p
 	if token.ExpiresIn > 0 {
 		entry.OAuthExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second).Unix()
 	}
-	if token.User != nil {
-		entry.User = token.User["email"]
-		if entry.User == "" {
-			entry.User = token.User["name"]
-		}
+	entry.User = token.UserEmail
+	if entry.User == "" {
+		entry.User = token.UserName
 	}
 	return entry, nil
 }
 
-func pollOAuthDeviceToken(cmd *cobra.Command, hostname string, tokenPath string, start oauthDeviceStartResponse, insecure bool) (oauthDeviceTokenResponse, error) {
+func pollOAuthDeviceToken(cmd *cobra.Command, hostname string, login *config.AuthLogin, start oauthDeviceStartResponse, provider, deviceLabel string, insecure bool) (oauthDeviceTokenResponse, error) {
 	expiresIn := start.ExpiresIn
 	if expiresIn <= 0 {
 		expiresIn = 600
@@ -126,16 +147,25 @@ func pollOAuthDeviceToken(cmd *cobra.Command, hostname string, tokenPath string,
 		interval = 5
 	}
 	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)
+	body, err := oauthDeviceRequest(login.PollRequest, map[string]string{"device_code": start.DeviceCode}, map[string]string{
+		config.AuthLoginHostname:    hostname,
+		config.AuthLoginProvider:    provider,
+		config.AuthLoginDeviceLabel: deviceLabel,
+		config.AuthLoginDeviceCode:  start.DeviceCode,
+	})
+	if err != nil {
+		return oauthDeviceTokenResponse{}, err
+	}
 	for {
 		if time.Now().After(deadline) {
 			return oauthDeviceTokenResponse{}, errors.New("oauth login expired")
 		}
-		data, err := runtime.DoRaw(cmd.Context(), hostname, "POST", tokenPath, map[string]string{
-			"device_code": start.DeviceCode,
-		}, runtime.ClientOptions{Insecure: insecure, Timeout: 10 * time.Second})
+		data, err := runtime.DoRaw(cmd.Context(), hostname, "POST", login.TokenPath, body, runtime.ClientOptions{Insecure: insecure, Timeout: 10 * time.Second})
 		var token oauthDeviceTokenResponse
 		if len(data) > 0 {
-			if decodeErr := json.Unmarshal(data, &token); decodeErr != nil {
+			var decodeErr error
+			token, decodeErr = decodeOAuthDeviceToken(data, login.PollResponse)
+			if decodeErr != nil {
 				if err != nil {
 					return oauthDeviceTokenResponse{}, fmt.Errorf("poll oauth login: %w", err)
 				}
@@ -187,12 +217,112 @@ func pollOAuthDeviceToken(cmd *cobra.Command, hostname string, tokenPath string,
 	}
 }
 
+func oauthDeviceRequest(configured, fallback, values map[string]string) (map[string]string, error) {
+	if len(configured) == 0 {
+		return fallback, nil
+	}
+	body := make(map[string]string, len(configured))
+	for field, value := range configured {
+		if resolved, ok := values[value]; ok {
+			if resolved != "" {
+				body[field] = resolved
+			}
+			continue
+		}
+		if strings.Contains(value, "${") {
+			return nil, fmt.Errorf("auth.login request field %q has unsupported placeholder %q", field, value)
+		}
+		body[field] = value
+	}
+	return body, nil
+}
+
+func decodeOAuthDeviceToken(data []byte, fields config.AuthLoginPollResponse) (oauthDeviceTokenResponse, error) {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return oauthDeviceTokenResponse{}, err
+	}
+	expiresIn, err := oauthInt64(raw, oauthField(fields.ExpiresIn, "expires_in"))
+	if err != nil {
+		return oauthDeviceTokenResponse{}, err
+	}
+	return oauthDeviceTokenResponse{
+		Status:       pluckString(raw, oauthField(fields.Status, "status")),
+		Error:        pluckString(raw, oauthField(fields.Error, "error")),
+		AccessToken:  pluckString(raw, oauthField(fields.AccessToken, "access_token")),
+		RefreshToken: pluckString(raw, oauthField(fields.RefreshToken, "refresh_token")),
+		ExpiresIn:    expiresIn,
+		UserEmail:    pluckString(raw, oauthField(fields.UserEmail, "user.email")),
+		UserName:     pluckString(raw, oauthField(fields.UserName, "user.name")),
+	}, nil
+}
+
+func oauthField(configured, fallback string) string {
+	if configured != "" {
+		return configured
+	}
+	return fallback
+}
+
+func oauthInt64(raw any, path string) (int64, error) {
+	value, ok := pluck(raw, path)
+	if !ok || value == nil {
+		return 0, nil
+	}
+	n, err := strconv.ParseInt(fmt.Sprint(value), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("oauth token response field %q must be an integer", path)
+	}
+	return n, nil
+}
+
+func maybeOpenBrowser(rawURL string, noBrowser bool) {
+	if reason := browserSkipReason(noBrowser); reason != "" {
+		fmt.Fprintf(os.Stderr, "Browser not opened (%s); open the URL above manually.\n", reason)
+		return
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		fmt.Fprintln(os.Stderr, "Browser not opened (verification URL is not HTTP(S)); open the URL above manually.")
+		return
+	}
+	name := "xdg-open"
+	args := []string{rawURL}
+	switch goruntime.GOOS {
+	case "darwin":
+		name = "open"
+	case "windows":
+		name = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", rawURL}
+	}
+	if err := exec.Command(name, args...).Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Browser could not be opened (%v); open the URL above manually.\n", err)
+	}
+}
+
+func browserSkipReason(noBrowser bool) string {
+	if noBrowser {
+		return "--no-browser requested"
+	}
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" {
+		return "SSH session detected"
+	}
+	if goruntime.GOOS == "linux" && os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+		return "headless Linux detected"
+	}
+	if !term.IsTerminal(int(os.Stdout.Fd())) || !term.IsTerminal(int(os.Stderr.Fd())) {
+		return "non-interactive terminal"
+	}
+	return ""
+}
+
 func newLogin(m *config.Manifest) *cobra.Command {
 	var (
 		authType     string
 		provider     string
 		withToken    bool
 		deviceAuth   bool
+		noBrowser    bool
 		skipValidate bool
 	)
 	cmd := &cobra.Command{
@@ -276,7 +406,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					return errors.New("--with-token cannot be used with --auth-type oauth")
 				}
 				var err error
-				entry, err = oauthDeviceLogin(cmd, m, hostname, provider, insecure)
+				entry, err = oauthDeviceLogin(cmd, m, hostname, provider, insecure, noBrowser)
 				if err != nil {
 					return err
 				}
@@ -324,6 +454,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 	cmd.Flags().StringVar(&provider, "provider", "", "OAuth provider hint passed to the service")
 	cmd.Flags().BoolVar(&withToken, "with-token", false, "Read token/key from stdin")
 	cmd.Flags().BoolVar(&deviceAuth, "device-auth", false, "Use OAuth device login")
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Do not open a browser for OAuth device login")
 	cmd.Flags().BoolVar(&skipValidate, "skip-validate", false, "Do not validate credentials against the server")
 	return cmd
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -99,9 +99,9 @@ func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, p
 	if start.DeviceCode == "" {
 		return config.HostEntry{}, errors.New("oauth start response missing device_code")
 	}
-	verificationURL := start.VerificationURI
+	verificationURL := start.VerificationURIComplete
 	if verificationURL == "" {
-		verificationURL = start.VerificationURIComplete
+		verificationURL = start.VerificationURI
 	}
 	if verificationURL == "" {
 		return config.HostEntry{}, errors.New("oauth start response missing verification_uri")
@@ -218,7 +218,7 @@ func pollOAuthDeviceToken(cmd *cobra.Command, hostname string, login *config.Aut
 }
 
 func oauthDeviceRequest(configured, fallback, values map[string]string) (map[string]string, error) {
-	if len(configured) == 0 {
+	if configured == nil {
 		return fallback, nil
 	}
 	body := make(map[string]string, len(configured))

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -93,6 +94,69 @@ func TestOAuthDeviceLoginSavesBearerHost(t *testing.T) {
 	}
 	if entry.AuthType != "bearer" || entry.LoginType != config.AuthLoginOAuthDevice || entry.LoginProvider != "github" || entry.OAuthToken != "access-1" || entry.OAuthRefreshToken != "refresh-1" || entry.User != "octo@example.com" || entry.OAuthExpiresAt == 0 {
 		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestOAuthDeviceLoginUsesManifestWireMapping(t *testing.T) {
+	var startBody, pollBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			if err := json.NewDecoder(r.Body).Decode(&startBody); err != nil {
+				t.Errorf("decode start body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"device_code":      "device-1",
+				"user_code":        "ABCD",
+				"verification_uri": "https://example.com/device",
+				"expires_in":       60,
+			})
+		case "/token":
+			if err := json.NewDecoder(r.Body).Decode(&pollBody); err != nil {
+				t.Errorf("decode poll body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]string{"token": "access-1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+		Auth: config.AuthInfo{Login: &config.AuthLogin{
+			Type:         config.AuthLoginOAuthDevice,
+			StartPath:    "/start",
+			TokenPath:    "/token",
+			StartRequest: map[string]string{"client_id": "demo-cli", "device_label": "${device_label}"},
+			PollRequest:  map[string]string{"client_id": "demo-cli", "device_code": "${device_code}"},
+			PollResponse: config.AuthLoginPollResponse{AccessToken: "token"},
+		}},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", srv.URL, "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--device-auth", "--no-browser", "--skip-validate"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if startBody["client_id"] != "demo-cli" || !strings.HasPrefix(startBody["device_label"], "demo on ") || len(startBody) != 2 {
+		t.Fatalf("start body = %#v", startBody)
+	}
+	if pollBody["client_id"] != "demo-cli" || pollBody["device_code"] != "device-1" || len(pollBody) != 2 {
+		t.Fatalf("poll body = %#v", pollBody)
+	}
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	entry, ok := hosts.Get(srv.URL)
+	if !ok || entry.OAuthToken != "access-1" {
+		t.Fatalf("entry = %+v, found = %v", entry, ok)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -160,6 +160,18 @@ func TestOAuthDeviceLoginUsesManifestWireMapping(t *testing.T) {
 	}
 }
 
+func TestOAuthDeviceRequestDistinguishesOmittedAndEmpty(t *testing.T) {
+	fallback := map[string]string{"device_code": "device-1"}
+	omitted, err := oauthDeviceRequest(nil, fallback, nil)
+	if err != nil || omitted["device_code"] != "device-1" {
+		t.Fatalf("omitted request = %#v, error = %v", omitted, err)
+	}
+	empty, err := oauthDeviceRequest(map[string]string{}, fallback, nil)
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("explicit empty request = %#v, error = %v", empty, err)
+	}
+}
+
 func TestAPIKeyLoginUsesManifestDefaults(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("X-Auth-Token"); got != "secret" {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -170,6 +171,23 @@ func TestOAuthDeviceRequestDistinguishesOmittedAndEmpty(t *testing.T) {
 	if err != nil || len(empty) != 0 {
 		t.Fatalf("explicit empty request = %#v, error = %v", empty, err)
 	}
+}
+
+func TestStartBrowserCommandDoesNotWait(t *testing.T) {
+	started := time.Now()
+	if err := startBrowserCommand(os.Args[0], "-test.run=^TestBrowserOpenerHelperProcess$", "--", "browser-opener-helper"); err != nil {
+		t.Fatalf("startBrowserCommand: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("startBrowserCommand waited %s", elapsed)
+	}
+}
+
+func TestBrowserOpenerHelperProcess(t *testing.T) {
+	if os.Args[len(os.Args)-1] != "browser-opener-helper" {
+		return
+	}
+	time.Sleep(3 * time.Second)
 }
 
 func TestAPIKeyLoginUsesManifestDefaults(t *testing.T) {

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -498,7 +498,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	fmt.Fprintf(&b, "4. Execute only after flags, body, auth, HTTP path, and output hints are clear from `commands show`.\n\n")
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
 		b.WriteString("## Auth Login\n\n")
-		fmt.Fprintf(&b, "- Use `%s auth login --device-auth --hostname <host> --provider <provider>` when the user needs browser-based OAuth login.\n", cli)
+		fmt.Fprintf(&b, "- Use `%s auth login --device-auth --hostname <host> --provider <provider>` when the user needs browser-based OAuth login. The browser opens by default in an interactive terminal; use `--no-browser` for manual login.\n", cli)
 		b.WriteString("- The saved host will use `auth_type: bearer`; OAuth is the login method, and the resulting API credential is a bearer token.\n\n")
 	}
 	b.WriteString("## General Commands\n\n")
@@ -579,7 +579,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("## Auth\n\n")
 	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
-		fmt.Fprintf(&b, "For browser-based OAuth login, run `%s auth login --device-auth --hostname <host> --provider <provider>`. `auth_type: bearer` in `hosts.yml` is expected after login because API requests use the issued bearer token.\n", cli)
+		fmt.Fprintf(&b, "For browser-based OAuth login, run `%s auth login --device-auth --hostname <host> --provider <provider>`. The browser opens by default in an interactive terminal; use `--no-browser` for manual login. `auth_type: bearer` in `hosts.yml` is expected after login because API requests use the issued bearer token.\n", cli)
 	}
 	return b.String()
 }

--- a/pkg/config/manifest.go
+++ b/pkg/config/manifest.go
@@ -146,10 +146,23 @@ type WorkflowOutput struct {
 }
 
 type AuthLogin struct {
-	Type        string `yaml:"type"`
-	StartPath   string `yaml:"start_path"`
-	TokenPath   string `yaml:"token_path"`
-	RefreshPath string `yaml:"refresh_path,omitempty"`
+	Type         string                `yaml:"type"`
+	StartPath    string                `yaml:"start_path"`
+	TokenPath    string                `yaml:"token_path"`
+	RefreshPath  string                `yaml:"refresh_path,omitempty"`
+	StartRequest map[string]string     `yaml:"start_request,omitempty"`
+	PollRequest  map[string]string     `yaml:"poll_request,omitempty"`
+	PollResponse AuthLoginPollResponse `yaml:"poll_response,omitempty"`
+}
+
+type AuthLoginPollResponse struct {
+	Status       string `yaml:"status,omitempty"`
+	Error        string `yaml:"error,omitempty"`
+	AccessToken  string `yaml:"access_token,omitempty"`
+	RefreshToken string `yaml:"refresh_token,omitempty"`
+	ExpiresIn    string `yaml:"expires_in,omitempty"`
+	UserEmail    string `yaml:"user_email,omitempty"`
+	UserName     string `yaml:"user_name,omitempty"`
 }
 
 type GitHubUpdate struct {
@@ -180,6 +193,10 @@ const (
 	CommandPathFlat       = "flat"
 	CommandPathNamespaced = "namespaced"
 	AuthLoginOAuthDevice  = "oauth_device"
+	AuthLoginHostname     = "${hostname}"
+	AuthLoginProvider     = "${provider}"
+	AuthLoginDeviceLabel  = "${device_label}"
+	AuthLoginDeviceCode   = "${device_code}"
 )
 
 // Load parses raw cli.yaml bytes into a Manifest. The caller (typically main.go)
@@ -239,6 +256,24 @@ func Load(bytes []byte) (*Manifest, error) {
 		if m.Auth.Login.RefreshPath != "" && !strings.HasPrefix(m.Auth.Login.RefreshPath, "/") {
 			return nil, fmt.Errorf("auth.login.refresh_path must start with /")
 		}
+		if err := validateAuthLoginRequest("start_request", m.Auth.Login.StartRequest, map[string]bool{
+			AuthLoginHostname: true, AuthLoginProvider: true, AuthLoginDeviceLabel: true,
+		}); err != nil {
+			return nil, err
+		}
+		if err := validateAuthLoginRequest("poll_request", m.Auth.Login.PollRequest, map[string]bool{
+			AuthLoginHostname: true, AuthLoginProvider: true, AuthLoginDeviceLabel: true, AuthLoginDeviceCode: true,
+		}); err != nil {
+			return nil, err
+		}
+		fields := &m.Auth.Login.PollResponse
+		fields.Status = strings.TrimSpace(fields.Status)
+		fields.Error = strings.TrimSpace(fields.Error)
+		fields.AccessToken = strings.TrimSpace(fields.AccessToken)
+		fields.RefreshToken = strings.TrimSpace(fields.RefreshToken)
+		fields.ExpiresIn = strings.TrimSpace(fields.ExpiresIn)
+		fields.UserEmail = strings.TrimSpace(fields.UserEmail)
+		fields.UserName = strings.TrimSpace(fields.UserName)
 	} else if m.Auth.DefaultType == "oauth" {
 		return nil, fmt.Errorf("auth.default_type oauth requires an auth.login block")
 	}
@@ -262,6 +297,18 @@ func Load(bytes []byte) (*Manifest, error) {
 		m.CLI.HostEnv = upper + "_HOST"
 	}
 	return &m, nil
+}
+
+func validateAuthLoginRequest(name string, request map[string]string, allowed map[string]bool) error {
+	for field, value := range request {
+		if strings.TrimSpace(field) == "" {
+			return fmt.Errorf("auth.login.%s field names must not be empty", name)
+		}
+		if strings.Contains(value, "${") && !allowed[value] {
+			return fmt.Errorf("auth.login.%s field %q has unsupported placeholder %q", name, field, value)
+		}
+	}
+	return nil
 }
 
 func normalizeWorkflow(workflow *WorkflowInfo) error {

--- a/pkg/config/manifest_test.go
+++ b/pkg/config/manifest_test.go
@@ -19,6 +19,16 @@ auth:
     start_path: /auth/cli/start
     token_path: /auth/cli/token
     refresh_path: /auth/cli/refresh
+    start_request:
+      client_id: demo-cli
+      device_label: ${device_label}
+    poll_request:
+      client_id: demo-cli
+      device_code: ${device_code}
+    poll_response:
+      access_token: token
+      status: state
+      error: failure.code
   validate:
     method: POST
     path: /whoami
@@ -47,6 +57,15 @@ auth:
 	}
 	if m.Auth.Login.Type != AuthLoginOAuthDevice || m.Auth.Login.StartPath != "/auth/cli/start" || m.Auth.Login.TokenPath != "/auth/cli/token" || m.Auth.Login.RefreshPath != "/auth/cli/refresh" {
 		t.Errorf("unexpected AuthLogin: %+v", m.Auth.Login)
+	}
+	if m.Auth.Login.StartRequest["client_id"] != "demo-cli" || m.Auth.Login.StartRequest["device_label"] != "${device_label}" {
+		t.Errorf("unexpected start request: %+v", m.Auth.Login.StartRequest)
+	}
+	if m.Auth.Login.PollRequest["client_id"] != "demo-cli" || m.Auth.Login.PollRequest["device_code"] != "${device_code}" {
+		t.Errorf("unexpected poll request: %+v", m.Auth.Login.PollRequest)
+	}
+	if m.Auth.Login.PollResponse.AccessToken != "token" || m.Auth.Login.PollResponse.Status != "state" || m.Auth.Login.PollResponse.Error != "failure.code" {
+		t.Errorf("unexpected poll response: %+v", m.Auth.Login.PollResponse)
 	}
 	if m.Auth.Validate.Method != "POST" || m.Auth.Validate.Path != "/whoami" {
 		t.Errorf("unexpected AuthValidate: %+v", m.Auth.Validate)
@@ -290,6 +309,20 @@ auth:
   validate:
     path: /whoami
     assert: {}
+`,
+		},
+		{
+			name: "unsupported request placeholder",
+			yaml: `
+cli:
+  name: demo
+auth:
+  login:
+    type: oauth_device
+    start_path: /start
+    token_path: /token
+    start_request:
+      client_id: ${unknown}
 `,
 		},
 	}


### PR DESCRIPTION
## Summary

- add manifest-driven OAuth device start and poll request bodies with closed runtime placeholders
- map OAuth poll response fields without changing existing defaults
- open safe verification URLs in interactive terminals by default with a `--no-browser` opt-out
- document the generated CLI auth contract and update generated Skill guidance

## Verification

- `go test ./internal/auth ./pkg/config -run 'TestOAuthDeviceLogin(SavesBearerHost|UsesManifestWireMapping)|TestLoad_(FullSpec|AuthLoginValidation)' -count=100`
- `make check`
- `go test -race ./...`

## Compatibility

The new manifest fields are optional. Existing manifests keep the current `{hostname[,provider]}` start body, `{device_code}` poll body, and standard OAuth response field names. Catalog schema and generated command shapes are unchanged. Interactive OAuth login now opens the verification URL by default; `--no-browser` preserves a manual flow.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.