### PR TITLE
feat(codegen): preserve OpenAPI 3.1 schemas

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -412,6 +412,9 @@ Rules:
 - Prefer `-o json` for agent-readable output.
 - Use `--file`, `--set`, or `--set-str` according to the command detail body
   contract.
+- Body schemas preserve nullable values, `anyOf`/`oneOf`/`allOf`, and
+  `additionalProperties` for discovery; request execution does not validate
+  JSON Schema.
 - If a command detail flag exposes `input_modes`, prefer `--<flag>-env NAME`,
   `--<flag>-file path`, or `--<flag>-stdin` over passing secrets directly in
   shell arguments.

--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -519,13 +519,6 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 			return out
 		}
 	}
-	if len(s.AnyOf) == 0 && len(s.AllOf) == 0 {
-		if option, ok := nullableAlternative(s, s.OneOf); ok {
-			out := convertSchema(option)
-			out.Nullable = true
-			return out
-		}
-	}
 	out := &rawir.RawSchema{
 		Type:     s.Type.Value,
 		Format:   s.Format,

--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -1,6 +1,7 @@
 package openapi3
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -82,22 +83,36 @@ type response struct {
 }
 
 type schemaNode struct {
-	Ref        string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	Type       schemaType             `json:"type,omitempty" yaml:"type,omitempty"`
-	Format     string                 `json:"format,omitempty" yaml:"format,omitempty"`
-	Default    any                    `json:"default,omitempty" yaml:"default,omitempty"`
-	Enum       []any                  `json:"enum,omitempty" yaml:"enum,omitempty"`
-	Properties map[string]*schemaNode `json:"properties,omitempty" yaml:"properties,omitempty"`
-	Required   []string               `json:"required,omitempty" yaml:"required,omitempty"`
-	Items      *schemaNode            `json:"items,omitempty" yaml:"items,omitempty"`
+	Ref                  string                      `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Type                 schemaType                  `json:"type,omitempty" yaml:"type,omitempty"`
+	Format               string                      `json:"format,omitempty" yaml:"format,omitempty"`
+	Default              any                         `json:"default,omitempty" yaml:"default,omitempty"`
+	Enum                 []any                       `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Nullable             bool                        `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Properties           map[string]*schemaNode      `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Required             []string                    `json:"required,omitempty" yaml:"required,omitempty"`
+	Items                *schemaNode                 `json:"items,omitempty" yaml:"items,omitempty"`
+	AnyOf                []*schemaNode               `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	OneOf                []*schemaNode               `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	AllOf                []*schemaNode               `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	AdditionalProperties *schemaAdditionalProperties `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
 }
 
-type schemaType string
+type schemaType struct {
+	Value    string
+	Nullable bool
+}
+
+type schemaAdditionalProperties struct {
+	Allowed bool
+	Schema  *schemaNode
+}
 
 func (t *schemaType) UnmarshalJSON(data []byte) error {
 	var single string
 	if err := json.Unmarshal(data, &single); err == nil {
-		*t = schemaType(single)
+		t.Value = single
+		t.Nullable = false
 		return nil
 	}
 
@@ -109,19 +124,21 @@ func (t *schemaType) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*t = schemaType(primary)
+	t.Value = primary
+	t.Nullable = primary != "null" && containsType(many, "null")
 	return nil
 }
 
 func (t *schemaType) UnmarshalYAML(value *yaml.Node) error {
 	if value == nil || value.Tag == "!!null" {
-		*t = ""
+		*t = schemaType{}
 		return nil
 	}
 
 	var single string
 	if err := value.Decode(&single); err == nil {
-		*t = schemaType(single)
+		t.Value = single
+		t.Nullable = false
 		return nil
 	}
 
@@ -133,8 +150,55 @@ func (t *schemaType) UnmarshalYAML(value *yaml.Node) error {
 	if err != nil {
 		return err
 	}
-	*t = schemaType(primary)
+	t.Value = primary
+	t.Nullable = primary != "null" && containsType(many, "null")
 	return nil
+}
+
+func (p *schemaAdditionalProperties) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("true")) || bytes.Equal(data, []byte("false")) {
+		p.Schema = nil
+		return json.Unmarshal(data, &p.Allowed)
+	}
+	if len(data) == 0 || data[0] != '{' {
+		return fmt.Errorf("additionalProperties must be a boolean or schema")
+	}
+	var schema schemaNode
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return err
+	}
+	p.Allowed = false
+	p.Schema = &schema
+	return nil
+}
+
+func (p *schemaAdditionalProperties) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Tag == "!!null" {
+		return fmt.Errorf("additionalProperties must be a boolean or schema")
+	}
+	var allowed bool
+	if err := value.Decode(&allowed); err == nil {
+		p.Allowed = allowed
+		p.Schema = nil
+		return nil
+	}
+	var schema schemaNode
+	if err := value.Decode(&schema); err != nil {
+		return fmt.Errorf("additionalProperties must be a boolean or schema: %w", err)
+	}
+	p.Allowed = false
+	p.Schema = &schema
+	return nil
+}
+
+func containsType(types []string, want string) bool {
+	for _, typ := range types {
+		if typ == want {
+			return true
+		}
+	}
+	return false
 }
 
 func primarySchemaType(types []string) (string, error) {
@@ -406,8 +470,8 @@ func convertParam(p parameter) rawir.RawParameter {
 	var format, def string
 	var enum []string
 	if p.Schema != nil {
-		if p.Schema.Type != "" {
-			typ = string(p.Schema.Type)
+		if p.Schema.Type.Value != "" {
+			typ = p.Schema.Type.Value
 		}
 		format = p.Schema.Format
 		def = anyToString(p.Schema.Default)
@@ -448,9 +512,24 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 	if s == nil {
 		return nil
 	}
+	if len(s.OneOf) == 0 && len(s.AllOf) == 0 {
+		if option, ok := nullableAlternative(s, s.AnyOf); ok {
+			out := convertSchema(option)
+			out.Nullable = true
+			return out
+		}
+	}
+	if len(s.AnyOf) == 0 && len(s.AllOf) == 0 {
+		if option, ok := nullableAlternative(s, s.OneOf); ok {
+			out := convertSchema(option)
+			out.Nullable = true
+			return out
+		}
+	}
 	out := &rawir.RawSchema{
-		Type:   string(s.Type),
-		Format: s.Format,
+		Type:     s.Type.Value,
+		Format:   s.Format,
+		Nullable: s.Nullable || s.Type.Nullable,
 	}
 	if s.Ref != "" {
 		if strings.HasPrefix(s.Ref, oas3RefPrefix) {
@@ -470,6 +549,43 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 	}
 	if s.Items != nil {
 		out.Items = convertSchema(s.Items)
+	}
+	out.AnyOf = convertSchemas(s.AnyOf)
+	out.OneOf = convertSchemas(s.OneOf)
+	out.AllOf = convertSchemas(s.AllOf)
+	if s.AdditionalProperties != nil {
+		out.AdditionalProperties = &rawir.RawAdditionalProperties{
+			Allowed: s.AdditionalProperties.Allowed,
+			Schema:  convertSchema(s.AdditionalProperties.Schema),
+		}
+	}
+	return out
+}
+
+func nullableAlternative(schema *schemaNode, options []*schemaNode) (*schemaNode, bool) {
+	if len(options) != 2 || schema.Ref != "" || schema.Type.Value != "" || schema.Format != "" || len(schema.Properties) > 0 || len(schema.Required) > 0 || schema.Items != nil || schema.AdditionalProperties != nil {
+		return nil, false
+	}
+	if isNullSchema(options[0]) {
+		return options[1], options[1] != nil && !isNullSchema(options[1])
+	}
+	if isNullSchema(options[1]) {
+		return options[0], options[0] != nil && !isNullSchema(options[0])
+	}
+	return nil, false
+}
+
+func isNullSchema(schema *schemaNode) bool {
+	return schema != nil && schema.Type.Value == "null"
+}
+
+func convertSchemas(schemas []*schemaNode) []*rawir.RawSchema {
+	if len(schemas) == 0 {
+		return nil
+	}
+	out := make([]*rawir.RawSchema, len(schemas))
+	for i, schema := range schemas {
+		out[i] = convertSchema(schema)
 	}
 	return out
 }

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -76,6 +76,72 @@ func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
 	if got := mod.Operations[0].Responses["200"].Schema.Properties["name"].Type; got != "string" {
 		t.Fatalf("property type = %q, want string", got)
 	}
+	if !mod.Operations[0].Responses["200"].Schema.Properties["name"].Nullable {
+		t.Fatal("nullable type array lost nullability")
+	}
+}
+
+func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
+	input := `{
+  "openapi": "3.1.0",
+  "paths": {
+    "/widgets": {
+      "post": {
+        "operationId": "Widget_Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "nickname": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                  "choice": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+                  "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
+                  "freeform": {"type": "object", "additionalProperties": true},
+                  "closed": {"type": "object", "additionalProperties": false},
+                  "related": {"anyOf": [{"$ref": "#/components/schemas/Base"}, {"type": "null"}]},
+                  "composed": {"allOf": [
+                    {"type": "object", "properties": {"id": {"type": "string"}}},
+                    {"type": "object", "properties": {"name": {"type": "string"}}}
+                  ]}
+                }
+              }
+            }
+          }
+        },
+        "responses": {"201": {}}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Base": {"type": "object", "properties": {"id": {"type": "string"}}}
+    }
+  }
+}`
+	schema := parseNormalized(t, input)[0].RequestBody.Schema
+	if nickname := schema.Properties["nickname"]; nickname.Type != "string" || !nickname.Nullable {
+		t.Fatalf("nickname = %#v, want nullable string", nickname)
+	}
+	if choice := schema.Properties["choice"]; len(choice.OneOf) != 2 || choice.OneOf[0].Type != "string" || choice.OneOf[1].Type != "integer" {
+		t.Fatalf("choice = %#v, want string/integer oneOf", choice)
+	}
+	metadata := schema.Properties["metadata"].AdditionalProperties
+	if metadata == nil || metadata.Schema == nil || metadata.Schema.Type != "string" {
+		t.Fatalf("metadata additionalProperties = %#v, want string schema", metadata)
+	}
+	if freeform := schema.Properties["freeform"].AdditionalProperties; freeform == nil || !freeform.Allowed || freeform.Schema != nil {
+		t.Fatalf("freeform additionalProperties = %#v, want true", freeform)
+	}
+	if closed := schema.Properties["closed"].AdditionalProperties; closed == nil || closed.Allowed || closed.Schema != nil {
+		t.Fatalf("closed additionalProperties = %#v, want false", closed)
+	}
+	if related := schema.Properties["related"]; !related.Nullable || related.Properties["id"] == nil || related.Properties["id"].Type != "string" {
+		t.Fatalf("related = %#v, want expanded nullable Base", related)
+	}
+	if composed := schema.Properties["composed"]; len(composed.AllOf) != 2 || composed.AllOf[0].Properties["id"].Type != "string" || composed.AllOf[1].Properties["name"].Type != "string" {
+		t.Fatalf("composed = %#v, want both allOf branches", composed)
+	}
 }
 
 func TestParse_MultipartBodyFields(t *testing.T) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -100,6 +100,10 @@ func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
                   "freeform": {"type": "object", "additionalProperties": true},
                   "closed": {"type": "object", "additionalProperties": false},
                   "related": {"anyOf": [{"$ref": "#/components/schemas/Base"}, {"type": "null"}]},
+                  "extended": {
+                    "$ref": "#/components/schemas/Base",
+                    "properties": {"id": {"type": "string", "nullable": true}}
+                  },
                   "composed": {"allOf": [
                     {"type": "object", "properties": {"id": {"type": "string"}}},
                     {"type": "object", "properties": {"name": {"type": "string"}}}
@@ -138,6 +142,10 @@ func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
 	}
 	if related := schema.Properties["related"]; !related.Nullable || related.Properties["id"] == nil || related.Properties["id"].Type != "string" {
 		t.Fatalf("related = %#v, want expanded nullable Base", related)
+	}
+	extended := schema.Properties["extended"]
+	if extended == nil || len(extended.AllOf) != 2 || extended.AllOf[0] == nil || extended.AllOf[1] == nil || extended.AllOf[0].Properties["id"] == nil || extended.AllOf[0].Properties["id"].Nullable || extended.AllOf[1].Properties["id"] == nil || !extended.AllOf[1].Properties["id"].Nullable {
+		t.Fatalf("extended = %#v, want referenced and sibling constraints", extended)
 	}
 	if composed := schema.Properties["composed"]; len(composed.AllOf) != 2 || composed.AllOf[0].Properties["id"].Type != "string" || composed.AllOf[1].Properties["name"].Type != "string" {
 		t.Fatalf("composed = %#v, want both allOf branches", composed)

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -96,6 +96,7 @@ func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
                 "properties": {
                   "nickname": {"anyOf": [{"type": "string"}, {"type": "null"}]},
                   "choice": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+                  "exclusive_null": {"oneOf": [{"type": ["string", "null"]}, {"type": "null"}]},
                   "metadata": {"type": "object", "additionalProperties": {"type": "string"}},
                   "freeform": {"type": "object", "additionalProperties": true},
                   "closed": {"type": "object", "additionalProperties": false},
@@ -129,6 +130,9 @@ func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
 	}
 	if choice := schema.Properties["choice"]; len(choice.OneOf) != 2 || choice.OneOf[0].Type != "string" || choice.OneOf[1].Type != "integer" {
 		t.Fatalf("choice = %#v, want string/integer oneOf", choice)
+	}
+	if exclusive := schema.Properties["exclusive_null"]; len(exclusive.OneOf) != 2 || !exclusive.OneOf[0].Nullable || exclusive.OneOf[1].Type != "null" {
+		t.Fatalf("exclusive_null = %#v, want both oneOf branches", exclusive)
 	}
 	metadata := schema.Properties["metadata"].AdditionalProperties
 	if metadata == nil || metadata.Schema == nil || metadata.Schema.Type != "string" {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -707,32 +707,74 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 	if s == nil {
 		return nil
 	}
+	var out *runtime.SchemaSpec
 	if s.Ref != "" {
 		if visited[s.Ref] {
-			return &runtime.SchemaSpec{Ref: s.Ref}
-		}
-		resolved := rawir.Resolve(s, defs)
-		if resolved != nil {
+			out = &runtime.SchemaSpec{Ref: s.Ref}
+		} else if resolved := rawir.Resolve(s, defs); resolved != nil {
 			next := copyVisited(visited)
 			next[s.Ref] = true
-			return runtimeSchema(resolved, defs, next)
+			out = runtimeSchema(resolved, defs, next)
 		}
 	}
-	out := &runtime.SchemaSpec{Type: s.Type}
-	if s.Ref != "" {
+	if out == nil {
+		out = &runtime.SchemaSpec{}
+	}
+	if s.Ref != "" && rawir.Resolve(s, defs) == nil {
 		out.Ref = s.Ref
 	}
+	if s.Type != "" {
+		out.Type = s.Type
+	}
+	out.Nullable = out.Nullable || s.Nullable
 	if len(s.Properties) > 0 {
-		out.Properties = make(map[string]*runtime.SchemaSpec, len(s.Properties))
+		if out.Properties == nil {
+			out.Properties = make(map[string]*runtime.SchemaSpec, len(s.Properties))
+		}
 		for k, v := range s.Properties {
 			out.Properties[k] = runtimeSchema(v, defs, visited)
 		}
 	}
 	if len(s.Required) > 0 {
-		out.Required = append([]string(nil), s.Required...)
+		seen := make(map[string]bool, len(out.Required)+len(s.Required))
+		for _, name := range out.Required {
+			seen[name] = true
+		}
+		for _, name := range s.Required {
+			if !seen[name] {
+				out.Required = append(out.Required, name)
+				seen[name] = true
+			}
+		}
 	}
 	if s.Items != nil {
 		out.Items = runtimeSchema(s.Items, defs, visited)
+	}
+	if len(s.AnyOf) > 0 {
+		out.AnyOf = runtimeSchemas(s.AnyOf, defs, visited)
+	}
+	if len(s.OneOf) > 0 {
+		out.OneOf = runtimeSchemas(s.OneOf, defs, visited)
+	}
+	if len(s.AllOf) > 0 {
+		out.AllOf = runtimeSchemas(s.AllOf, defs, visited)
+	}
+	if s.AdditionalProperties != nil {
+		out.AdditionalProperties = &runtime.AdditionalPropertiesSpec{
+			Allowed: s.AdditionalProperties.Allowed,
+			Schema:  runtimeSchema(s.AdditionalProperties.Schema, defs, visited),
+		}
+	}
+	return out
+}
+
+func runtimeSchemas(schemas []*rawir.RawSchema, defs map[string]*rawir.RawSchema, visited map[string]bool) []*runtime.SchemaSpec {
+	if len(schemas) == 0 {
+		return nil
+	}
+	out := make([]*runtime.SchemaSpec, len(schemas))
+	for i, schema := range schemas {
+		out[i] = runtimeSchema(schema, defs, visited)
 	}
 	return out
 }

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -707,45 +707,29 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 	if s == nil {
 		return nil
 	}
-	var out *runtime.SchemaSpec
-	if s.Ref != "" {
-		if visited[s.Ref] {
-			out = &runtime.SchemaSpec{Ref: s.Ref}
-		} else if resolved := rawir.Resolve(s, defs); resolved != nil {
+	if s.Ref != "" && !visited[s.Ref] {
+		if resolved := rawir.Resolve(s, defs); resolved != nil {
 			next := copyVisited(visited)
 			next[s.Ref] = true
-			out = runtimeSchema(resolved, defs, next)
+			base := runtimeSchema(resolved, defs, next)
+			if rawSchemaHasRefSiblings(s) {
+				sibling := *s
+				sibling.Ref = ""
+				return &runtime.SchemaSpec{AllOf: []*runtime.SchemaSpec{base, runtimeSchema(&sibling, defs, visited)}}
+			}
+			base.Nullable = base.Nullable || s.Nullable
+			return base
 		}
 	}
-	if out == nil {
-		out = &runtime.SchemaSpec{}
-	}
-	if s.Ref != "" && rawir.Resolve(s, defs) == nil {
-		out.Ref = s.Ref
-	}
-	if s.Type != "" {
-		out.Type = s.Type
-	}
-	out.Nullable = out.Nullable || s.Nullable
+	out := &runtime.SchemaSpec{Ref: s.Ref, Type: s.Type, Nullable: s.Nullable}
 	if len(s.Properties) > 0 {
-		if out.Properties == nil {
-			out.Properties = make(map[string]*runtime.SchemaSpec, len(s.Properties))
-		}
+		out.Properties = make(map[string]*runtime.SchemaSpec, len(s.Properties))
 		for k, v := range s.Properties {
 			out.Properties[k] = runtimeSchema(v, defs, visited)
 		}
 	}
 	if len(s.Required) > 0 {
-		seen := make(map[string]bool)
-		for _, name := range out.Required {
-			seen[name] = true
-		}
-		for _, name := range s.Required {
-			if !seen[name] {
-				out.Required = append(out.Required, name)
-				seen[name] = true
-			}
-		}
+		out.Required = append([]string(nil), s.Required...)
 	}
 	if s.Items != nil {
 		out.Items = runtimeSchema(s.Items, defs, visited)
@@ -766,6 +750,10 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 		}
 	}
 	return out
+}
+
+func rawSchemaHasRefSiblings(s *rawir.RawSchema) bool {
+	return s.Type != "" || len(s.Properties) > 0 || len(s.Required) > 0 || s.Items != nil || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || len(s.AllOf) > 0 || s.AdditionalProperties != nil
 }
 
 func runtimeSchemas(schemas []*rawir.RawSchema, defs map[string]*rawir.RawSchema, visited map[string]bool) []*runtime.SchemaSpec {

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -736,7 +736,7 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 		}
 	}
 	if len(s.Required) > 0 {
-		seen := make(map[string]bool, len(out.Required)+len(s.Required))
+		seen := make(map[string]bool)
 		for _, name := range out.Required {
 			seen[name] = true
 		}

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -67,12 +67,22 @@ type RawPaginationHint struct {
 }
 
 type RawSchema struct {
-	Ref        string
-	Type       string
-	Format     string `json:",omitempty"`
-	Properties map[string]*RawSchema
-	Required   []string `json:",omitempty"`
-	Items      *RawSchema
+	Ref                  string
+	Type                 string
+	Format               string `json:",omitempty"`
+	Nullable             bool   `json:",omitempty"`
+	Properties           map[string]*RawSchema
+	Required             []string `json:",omitempty"`
+	Items                *RawSchema
+	AnyOf                []*RawSchema             `json:",omitempty"`
+	OneOf                []*RawSchema             `json:",omitempty"`
+	AllOf                []*RawSchema             `json:",omitempty"`
+	AdditionalProperties *RawAdditionalProperties `json:",omitempty"`
+}
+
+type RawAdditionalProperties struct {
+	Allowed bool
+	Schema  *RawSchema
 }
 
 const RefPrefix = "#/definitions/"

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -1068,6 +1068,7 @@ func writeSchemaLiteral(b *strings.Builder, s *runtime.SchemaSpec) {
 	if s.Type != "" {
 		fmt.Fprintf(b, "Type: %q,", s.Type)
 	}
+	writeBoolField(b, "Nullable", s.Nullable)
 	if len(s.Properties) > 0 {
 		b.WriteString("Properties: map[string]*runtime.SchemaSpec{")
 		keys := make([]string, 0, len(s.Properties))
@@ -1094,7 +1095,32 @@ func writeSchemaLiteral(b *strings.Builder, s *runtime.SchemaSpec) {
 		writeSchemaLiteral(b, s.Items)
 		b.WriteByte(',')
 	}
+	writeSchemaSliceLiteral(b, "AnyOf", s.AnyOf)
+	writeSchemaSliceLiteral(b, "OneOf", s.OneOf)
+	writeSchemaSliceLiteral(b, "AllOf", s.AllOf)
+	if s.AdditionalProperties != nil {
+		b.WriteString("AdditionalProperties: &runtime.AdditionalPropertiesSpec{")
+		writeBoolField(b, "Allowed", s.AdditionalProperties.Allowed)
+		if s.AdditionalProperties.Schema != nil {
+			b.WriteString("Schema: ")
+			writeSchemaLiteral(b, s.AdditionalProperties.Schema)
+			b.WriteByte(',')
+		}
+		b.WriteString("},")
+	}
 	b.WriteByte('}')
+}
+
+func writeSchemaSliceLiteral(b *strings.Builder, name string, schemas []*runtime.SchemaSpec) {
+	if len(schemas) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "%s: []*runtime.SchemaSpec{", name)
+	for _, schema := range schemas {
+		writeSchemaLiteral(b, schema)
+		b.WriteByte(',')
+	}
+	b.WriteString("},")
 }
 
 var moduleTmpl = template.Must(template.New("gen").Funcs(template.FuncMap{

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 13
+const CatalogSchemaVersion = 14
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -244,9 +244,12 @@ func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
 			Required:  true,
 			MediaType: "application/json",
 			Schema: &SchemaSpec{
-				Type:       "object",
-				Properties: map[string]*SchemaSpec{"name": {Type: "string"}},
-				Required:   []string{"name"},
+				Type: "object",
+				Properties: map[string]*SchemaSpec{
+					"name":   {Type: "string", Nullable: true},
+					"labels": {Type: "object", AdditionalProperties: &AdditionalPropertiesSpec{Schema: &SchemaSpec{Type: "string"}}},
+				},
+				Required: []string{"name"},
 			},
 			Template:  tmpl,
 			MergePath: "variables",
@@ -266,7 +269,7 @@ func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`"template":`, `"merge_path":"variables"`, `"required":["name"]`, `createApp(name:$name)`} {
+	for _, want := range []string{`"template":`, `"merge_path":"variables"`, `"required":["name"]`, `"nullable":true`, `"additionalProperties":{"type":"string"}`, `createApp(name:$name)`} {
 		if !strings.Contains(string(raw), want) {
 			t.Fatalf("catalog JSON missing %q:\n%s", want, raw)
 		}
@@ -279,8 +282,12 @@ func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
 	if rt == nil || rt.Template != tmpl || rt.MergePath != "variables" {
 		t.Fatalf("round-trip body envelope = %+v", rt)
 	}
-	if rt.Schema == nil || !reflect.DeepEqual(rt.Schema.Required, []string{"name"}) {
+	if rt.Schema == nil || !reflect.DeepEqual(rt.Schema.Required, []string{"name"}) || rt.Schema.Properties["name"] == nil || !rt.Schema.Properties["name"].Nullable {
 		t.Fatalf("round-trip body schema = %+v", rt.Schema)
+	}
+	labels := rt.Schema.Properties["labels"]
+	if labels == nil || labels.AdditionalProperties == nil || labels.AdditionalProperties.Schema == nil || labels.AdditionalProperties.Schema.Type != "string" {
+		t.Fatalf("round-trip labels schema = %+v", labels)
 	}
 }
 
@@ -465,8 +472,8 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 
 	catalog := BuildCatalog(root, CatalogOptions{})
-	if catalog.CatalogSchemaVersion != 13 {
-		t.Fatalf("schema version = %d, want 13", catalog.CatalogSchemaVersion)
+	if catalog.CatalogSchemaVersion != 14 {
+		t.Fatalf("schema version = %d, want 14", catalog.CatalogSchemaVersion)
 	}
 	var step *CatalogWorkflowStep
 	for i, entry := range catalog.Commands {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
 
 const SchemaVersion = 9
 
@@ -78,11 +82,46 @@ type RequestBody struct {
 }
 
 type SchemaSpec struct {
-	Ref        string                 `json:"ref,omitempty"`
-	Type       string                 `json:"type,omitempty"`
-	Properties map[string]*SchemaSpec `json:"properties,omitempty"`
-	Required   []string               `json:"required,omitempty"`
-	Items      *SchemaSpec            `json:"items,omitempty"`
+	Ref                  string                    `json:"ref,omitempty"`
+	Type                 string                    `json:"type,omitempty"`
+	Nullable             bool                      `json:"nullable,omitempty"`
+	Properties           map[string]*SchemaSpec    `json:"properties,omitempty"`
+	Required             []string                  `json:"required,omitempty"`
+	Items                *SchemaSpec               `json:"items,omitempty"`
+	AnyOf                []*SchemaSpec             `json:"anyOf,omitempty"`
+	OneOf                []*SchemaSpec             `json:"oneOf,omitempty"`
+	AllOf                []*SchemaSpec             `json:"allOf,omitempty"`
+	AdditionalProperties *AdditionalPropertiesSpec `json:"additionalProperties,omitempty"`
+}
+
+type AdditionalPropertiesSpec struct {
+	Allowed bool
+	Schema  *SchemaSpec
+}
+
+func (s AdditionalPropertiesSpec) MarshalJSON() ([]byte, error) {
+	if s.Schema != nil {
+		return json.Marshal(s.Schema)
+	}
+	return json.Marshal(s.Allowed)
+}
+
+func (s *AdditionalPropertiesSpec) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("true")) || bytes.Equal(data, []byte("false")) {
+		s.Schema = nil
+		return json.Unmarshal(data, &s.Allowed)
+	}
+	if len(data) == 0 || data[0] != '{' {
+		return fmt.Errorf("additionalProperties must be a boolean or schema")
+	}
+	var schema SchemaSpec
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return err
+	}
+	s.Allowed = false
+	s.Schema = &schema
+	return nil
 }
 
 type OutputHints struct {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 9
+const SchemaVersion = 10
 
 type CommandSpec struct {
 	Group           string


### PR DESCRIPTION
## Summary

- preserve nullable OpenAPI 3.0/3.1 schemas instead of reducing common nullable unions to empty objects
- carry `anyOf`, `oneOf`, `allOf`, and boolean/schema `additionalProperties` through raw IR, generated runtime specs, and catalog JSON
- keep unsupported multi-type arrays fail-closed and document that schema metadata is for discovery rather than runtime validation

## Verification

- `make check`
- `go test -race ./...`
- `go test ./internal/codegen/backends/openapi3 ./internal/codegen/normalize ./internal/codegen/render ./pkg/runtime -run 'Test(Parse_OpenAPI31|BuildCatalog_RequestBodyEnvelope|Render)' -count=50`
- generated OpenAPI 3.1 downstream CLI compiled successfully and `__lathe verify --json` passed 31/31 checks
- downstream loopback probes kept SSE, multipart, and OAuth behavior passing

## Compatibility

The schema fields are additive and existing generated command names, flags, and request execution are unchanged. Catalog schema version advances from 13 to 14. Generating new schema literals requires the matching Lathe runtime from the same release.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
