### PR TITLE
feat(codegen): normalize command inputs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,7 +217,8 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | IR field | Spec source | Overlay | Priority |
 |---|---|---|---|
 | `Name` | spec | locked | spec-only |
-| `Flag` | kebab-derived | rename | overlay > spec |
+| `Flag` | kebab-derived; old snake spelling remains an accepted alias | rename | overlay > spec |
+| `Argument` | — | `param.argument`; ordered by the source parameter list | overlay-only |
 | `In` | spec | locked | spec-only |
 | `GoType` | `type` / `format` | narrowing only (post-v0.1) | overlay > spec |
 | `Help` | description / comment | override | overlay > spec |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -304,6 +304,24 @@ also removed from generated `SKILL.md`. `SKILL.md` may be appended or replaced,
 but not omitted. `.lathe-skill`, dotfiles, path traversal, and symlinks are
 rejected.
 
+OpenAPI parameter names are rendered as kebab-case flags. Generated commands
+continue accepting the previous snake-case spelling when it differs. An overlay
+can expose selected parameters as ordered positional alternatives without
+removing their flags:
+
+```yaml
+commands:
+  get-user:
+    params:
+      user_id:
+        argument: id
+```
+
+This renders `get-user [id]`; both `get-user 123` and
+`get-user --user-id 123` map to the source parameter `user_id`. Command catalog
+entries retain `name`, `flag`, accepted `aliases`, `argument`, and `position` so
+agents do not infer the mapping from help text.
+
 Generated outputs:
 
 ```text

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -28,8 +28,8 @@ file; when this page and the code disagree, trust the code and fix this page.
   `search "<intent>" --json`, and `commands schema --json`.
 - This is the agent-facing discovery contract and the source of truth for
   generated operation details: HTTP method and path template, auth
-  requirements, flags, body schema, output, pagination, and stream collection
-  hints.
+  requirements, source parameter names, CLI flags and positional alternatives,
+  body schema, output, pagination, and stream collection hints.
 - `catalog.cli.capabilities` lists compiled first-party capabilities such as
   `skill.bundle`. Capability commands are not catalog operations.
 - Only generated API operation commands carry catalog entries. Framework

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -57,6 +57,7 @@ commands: {}
 #         required: true
 #       workspace:
 #         flag: ws
+#         argument: workspace
 #         help: "Target workspace name"
 #         default: "default"
 #   internal-debug:

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -65,6 +65,7 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 			disambiguateMultipartParamFlags(spec.Params, bodyParams)
 			spec.Params = append(spec.Params, bodyParams...)
 		}
+		normalizeParamFlags(spec.Params)
 		lp, itemRef := deriveList(op, mod.Schemas)
 		spec.Output.ListPath = lp
 		if itemRef != "" {
@@ -419,6 +420,22 @@ func variableParam(p rawir.RawParameter) runtime.ParamSpec {
 
 func variableFlagName(name string) string {
 	return strings.ReplaceAll(camelToKebab(name), ".", "-")
+}
+
+func normalizeParamFlags(params []runtime.ParamSpec) {
+	desired := make([]string, len(params))
+	desiredCount := make(map[string]int, len(params))
+	for i, param := range params {
+		desired[i] = strings.Trim(collapseDashes(strings.ReplaceAll(param.Flag, "_", "-")), "-")
+		desiredCount[desired[i]]++
+	}
+	for i := range params {
+		if desired[i] == "" || desired[i] == params[i].Flag || desiredCount[desired[i]] > 1 {
+			continue
+		}
+		params[i].Aliases = []string{params[i].Flag}
+		params[i].Flag = desired[i]
+	}
 }
 
 func headerParam(p rawir.RawParameter) runtime.ParamSpec {

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -43,6 +43,36 @@ func TestNormalize_Golden(t *testing.T) {
 	}
 }
 
+func TestNormalize_ParameterFlagsUseKebabCase(t *testing.T) {
+	specs := Normalize(&rawir.RawModule{Name: "demo", Operations: []rawir.RawOperation{{
+		Group:       "Apps",
+		OperationID: "Apps_Get",
+		Method:      "GET",
+		Path:        "/apps/{app_id}",
+		Parameters: []rawir.RawParameter{
+			{Name: "app_id", In: "path", Type: "string", Required: true},
+			{Name: "page_size", In: "query", Type: "integer"},
+			{Name: "external_id", In: "query", Type: "string"},
+			{Name: "external-id", In: "header", Type: "string"},
+		},
+	}}})
+
+	want := map[string]struct {
+		flag    string
+		aliases []string
+	}{
+		"app_id":      {flag: "app-id", aliases: []string{"app_id"}},
+		"page_size":   {flag: "page-size", aliases: []string{"page_size"}},
+		"external_id": {flag: "external_id"},
+		"external-id": {flag: "external-id"},
+	}
+	for _, param := range specs[0].Params {
+		if got := want[param.Name]; param.Flag != got.flag || !reflect.DeepEqual(param.Aliases, got.aliases) {
+			t.Errorf("param %q = flag %q aliases %#v, want %q %#v", param.Name, param.Flag, param.Aliases, got.flag, got.aliases)
+		}
+	}
+}
+
 func TestNormalize_SuccessResponseHints(t *testing.T) {
 	listSchema := func(listPath string) *rawir.RawSchema {
 		return &rawir.RawSchema{

--- a/internal/codegen/normalize/testdata/pagination-cursor.golden.json
+++ b/internal/codegen/normalize/testdata/pagination-cursor.golden.json
@@ -14,7 +14,10 @@
     "Params": [
       {
         "Name": "page_token",
-        "Flag": "page_token",
+        "Flag": "page-token",
+        "Aliases": [
+          "page_token"
+        ],
         "In": "query",
         "GoType": "string",
         "Help": "Pagination token. (query)",

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -282,14 +282,61 @@ func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runti
 func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) error {
 	for _, spec := range specs {
 		override, ok := mod.Commands[spec.Use]
-		if !ok || !overrideMatches(spec, override) || override.Output == nil || override.Output.Streaming == nil {
+		if !ok || !overrideMatches(spec, override) {
 			continue
 		}
-		if err := validateStreamingOverride(spec, *override.Output.Streaming); err != nil {
-			return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
+		if err := validateArguments(spec, override.Params); err != nil {
+			return fmt.Errorf("command %q: %w", spec.Use, err)
+		}
+		if override.Output != nil && override.Output.Streaming != nil {
+			if err := validateStreamingOverride(spec, *override.Output.Streaming); err != nil {
+				return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
+			}
 		}
 	}
 	return nil
+}
+
+func validateArguments(spec runtime.CommandSpec, overrides map[string]overlay.ParamOverride) error {
+	seenNames := map[string]bool{}
+	for paramName, override := range overrides {
+		if override.Argument == "" {
+			continue
+		}
+		matches := 0
+		for _, param := range spec.Params {
+			if param.Name == paramName {
+				matches++
+			}
+		}
+		if matches == 0 {
+			return fmt.Errorf("argument parameter %q does not exist", paramName)
+		}
+		if matches > 1 {
+			return fmt.Errorf("argument parameter %q is ambiguous", paramName)
+		}
+		if !validArgumentName(override.Argument) {
+			return fmt.Errorf("argument name %q must contain only letters, digits, dots, underscores, or hyphens", override.Argument)
+		}
+		if seenNames[override.Argument] {
+			return fmt.Errorf("argument name %q is mapped more than once", override.Argument)
+		}
+		seenNames[override.Argument] = true
+	}
+	return nil
+}
+
+func validArgumentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func validateStreamingOverride(spec runtime.CommandSpec, stream overlay.StreamingOverride) error {
@@ -370,6 +417,7 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	cloned.KnownErrors = append([]runtime.KnownError(nil), spec.KnownErrors...)
 	cloned.Params = append([]runtime.ParamSpec(nil), spec.Params...)
 	for i := range cloned.Params {
+		cloned.Params[i].Aliases = append([]string(nil), spec.Params[i].Aliases...)
 		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
 	}
 	if spec.Output.Streaming != nil {
@@ -460,6 +508,9 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 			}
 			if po.Flag != "" {
 				spec.Params[j].Flag = po.Flag
+			}
+			if po.Argument != "" {
+				spec.Params[j].Argument = po.Argument
 			}
 			if po.Help != "" {
 				spec.Params[j].Help = po.Help
@@ -858,6 +909,8 @@ func paramSpecsLiteral(params []runtime.ParamSpec) string {
 		b.WriteString("runtime.ParamSpec{")
 		writeStringField(&b, "Name", param.Name)
 		writeStringField(&b, "Flag", param.Flag)
+		writeStringSliceField(&b, "Aliases", param.Aliases)
+		writeStringField(&b, "Argument", param.Argument)
 		writeStringField(&b, "In", param.In)
 		writeStringField(&b, "GoType", param.GoType)
 		writeStringField(&b, "Help", param.Help)
@@ -1227,7 +1280,7 @@ var Specs = []runtime.CommandSpec{
 		{{- if $op.Params}}
 		Params: []runtime.ParamSpec{
 			{{- range $op.Params}}
-			{Name: {{printf "%q" .Name}}, Flag: {{printf "%q" .Flag}}, In: {{printf "%q" .In}}, GoType: {{printf "%q" .GoType}}, Help: {{printf "%q" .Help}}, Required: {{.Required}}{{- if .Default}}, Default: {{printf "%q" .Default}}{{end}}{{- if .Enum}}, Enum: []string{ {{- range .Enum}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{- if .Deprecated}}, Deprecated: true{{end}}},
+			{Name: {{printf "%q" .Name}}, Flag: {{printf "%q" .Flag}}{{- if .Aliases}}, Aliases: []string{ {{- range .Aliases}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Argument}}, Argument: {{printf "%q" .Argument}}{{end}}, In: {{printf "%q" .In}}, GoType: {{printf "%q" .GoType}}, Help: {{printf "%q" .Help}}, Required: {{.Required}}{{- if .Default}}, Default: {{printf "%q" .Default}}{{end}}{{- if .Enum}}, Enum: []string{ {{- range .Enum}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{- if .Deprecated}}, Deprecated: true{{end}}},
 			{{- end}}
 		},
 		{{- end}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -279,10 +279,14 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 	overrides := map[string]overlay.Override{
 		"list-users": {
 			Params: map[string]overlay.ParamOverride{
-				"status": {Flag: "user-status", Help: "override help", Default: "active", Deprecated: true},
+				"status": {Flag: "user-status", Argument: "state", Help: "override help", Default: "active", Deprecated: true},
 				"legacy": {DeprecatedAlias: true},
 			},
 		},
+	}
+	merged := MergeOverlay(specs, overrides)
+	if merged[0].Params[0].Argument != "state" {
+		t.Fatalf("merged positional mapping = %#v", merged[0].Params[0])
 	}
 	if err := RenderModule("demo", "", specs, overrides); err != nil {
 		t.Fatalf("RenderModule: %v", err)
@@ -302,6 +306,23 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 	}
 	if strings.Count(got, `Deprecated: true`) != 2 {
 		t.Errorf("deprecated and legacy hidden alias should both mark params deprecated; output:\n%s", got)
+	}
+	if !strings.Contains(got, `Argument: "state"`) {
+		t.Errorf("positional mapping should be generated; output:\n%s", got)
+	}
+}
+
+func TestValidateOverlayModule_RejectsUnknownArgumentParameter(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group: "Users", Use: "get-user", Params: []runtime.ParamSpec{{Name: "id", Flag: "id"}},
+	}}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"get-user": {Params: map[string]overlay.ParamOverride{"missing": {Argument: "id"}}},
+	}}
+
+	err := ValidateOverlayModule(specs, mod)
+	if err == nil || !strings.Contains(err.Error(), `argument parameter "missing" does not exist`) {
+		t.Fatalf("validation error = %v", err)
 	}
 }
 

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -627,6 +627,7 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule, flat bool
 				b.WriteString("- Flags: none\n")
 			} else {
 				b.WriteString("- Flags:\n")
+				position := 0
 				for _, p := range spec.Params {
 					req := ""
 					if p.Required {
@@ -648,7 +649,12 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule, flat bool
 					if p.Deprecated {
 						deprecated = ", deprecated"
 					}
-					fmt.Fprintf(&b, "  - `--%s` (%s%s%s%s%s%s): %s\n", p.Flag, p.In, req, def, format, enum, deprecated, oneLine(stripHelpMeta(p.Help)))
+					input := fmt.Sprintf("`--%s`", p.Flag)
+					if p.Argument != "" {
+						position++
+						input = fmt.Sprintf("argument %d `[%s]` or `--%s`", position, p.Argument, p.Flag)
+					}
+					fmt.Fprintf(&b, "  - %s (%s%s%s%s%s%s): %s\n", input, p.In, req, def, format, enum, deprecated, oneLine(stripHelpMeta(p.Help)))
 				}
 
 			}

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -73,6 +73,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 			Notes:         []string{"clusterFilter expects a cluster UUID."},
 			Prerequisites: []string{"Find the cluster UUID first."},
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing start/end"}},
+			Params:        map[string]overlay.ParamOverride{"type": {Argument: "receiver"}},
 		},
 	})
 
@@ -129,7 +130,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Summary: Create a user",
 		"Auth: required; scopes: `users:write`",
 		"Body: required; media type `application/json`",
-		"`--type` (query, required): Receiver type",
+		"argument 1 `[receiver]` or `--type` (query, required): Receiver type",
 		"pagination `cursor`",
 		"streaming `sse`",
 		"Notes:",

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -85,6 +85,7 @@ type Shortcut struct {
 
 type ParamOverride struct {
 	Flag            string `yaml:"flag"`
+	Argument        string `yaml:"argument"`
 	Help            string `yaml:"help"`
 	Required        bool   `yaml:"required"`
 	Default         string `yaml:"default"`

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -112,6 +112,7 @@ commands:
     params:
       status:
         flag: user-status
+        argument: state
         help: "Account status"
         required: true
         default: "active"
@@ -159,6 +160,9 @@ commands:
 	sp := cu.Params["status"]
 	if sp.Flag != "user-status" {
 		t.Errorf("param flag = %q, want user-status", sp.Flag)
+	}
+	if sp.Argument != "state" {
+		t.Errorf("param argument = %q, want state", sp.Argument)
 	}
 	if sp.Help != "Account status" {
 		t.Errorf("param help = %q, want Account status", sp.Help)

--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -61,7 +61,11 @@ func commandsShowCmd(m *config.Manifest) *cobra.Command {
 					if flag.Required {
 						required = " required"
 					}
-					fmt.Fprintf(cmd.OutOrStdout(), "  --%s %s%s  %s\n", flag.Flag, flag.Type, required, flag.Help)
+					syntax := "--" + flag.Flag
+					if flag.Position > 0 {
+						syntax = fmt.Sprintf("[%s] | %s", flag.Argument, syntax)
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s %s%s  %s\n", syntax, flag.Type, required, flag.Help)
 				}
 			}
 			return nil

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // ModuleGroupID is the cobra group ID every generated service command tree
@@ -110,13 +111,14 @@ func buildCmd(s CommandSpec) *cobra.Command {
 	var dryRun bool
 	var liveStream bool
 
+	positionals := positionalParams(s.Params)
 	cmd := &cobra.Command{
 		Use:     s.Use,
 		Aliases: s.Aliases,
 		Short:   s.Short,
 		Long:    s.Long,
 		Example: s.Example,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if liveStream && format != "table" {
 				return fmt.Errorf("live stream output does not support -o %s", format)
@@ -124,10 +126,14 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			if liveStream && waitPoll {
 				return fmt.Errorf("live stream output does not support wait polling")
 			}
+			changed := operationChangedFlags(cmd, s.Params)
+			if err := bindPositionalArgs(cmd, args, positionals, vals, changed); err != nil {
+				return err
+			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
 				return err
 			}
-			if err := validateRequiredSafeParams(cmd, s.Params, s.RequestBody != nil); err != nil {
+			if err := validateRequiredParams(s.Params, s.RequestBody != nil, changed); err != nil {
 				return err
 			}
 
@@ -166,7 +172,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			}
 			result, err := invokeOperation(cmd.Context(), s, OperationInput{
 				Values:         vals,
-				Changed:        operationChangedFlags(cmd, s.Params),
+				Changed:        changed,
 				FileBody:       fileBody,
 				HasFile:        hasFile,
 				BodySets:       bodySets,
@@ -191,6 +197,13 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			return FormatOutput(result.Data, format, cmd.OutOrStdout(), s.Output)
 		},
 	}
+	if len(positionals) > 0 {
+		for _, p := range positionals {
+			cmd.Use += " [" + p.Argument + "]"
+		}
+		cmd.Args = cobra.MaximumNArgs(len(positionals))
+	}
+	configureParamFlagAliases(cmd, s.Params)
 
 	for i := range s.Params {
 		bindParamFlag(cmd, vals, s.Params[i], s.RequestBody != nil)
@@ -258,7 +271,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 		vals[key] = v
 		cmd.Flags().StringVar(v, p.Flag, p.Default, p.Help)
 		addSafeInputFlags(cmd, p)
-		if p.Default == "" && !isSensitiveStringParam(p) {
+		if p.Default == "" && p.Argument == "" && !isSensitiveStringParam(p) {
 			_ = cmd.MarkFlagRequired(p.Flag)
 		}
 		if p.Deprecated {
@@ -310,7 +323,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 		cmd.Flags().StringVar(v, p.Flag, p.Default, p.Help)
 		addSafeInputFlags(cmd, p)
 	}
-	if p.Required && p.Default == "" && (p.In != InVariable || !hasRequestBody) && !isSensitiveStringParam(p) {
+	if p.Required && p.Default == "" && p.Argument == "" && (p.In != InVariable || !hasRequestBody) && !isSensitiveStringParam(p) {
 		_ = cmd.MarkFlagRequired(p.Flag)
 	}
 	if p.Deprecated {
@@ -418,19 +431,78 @@ func resolveSafeInputFlags(cmd *cobra.Command, params []ParamSpec, vals map[stri
 	return nil
 }
 
-func validateRequiredSafeParams(cmd *cobra.Command, params []ParamSpec, hasRequestBody bool) error {
+func validateRequiredParams(params []ParamSpec, hasRequestBody bool, changed map[string]bool) error {
 	for _, p := range params {
-		if !p.Required || p.Default != "" || !isSensitiveStringParam(p) {
+		if !p.Required || p.Default != "" {
 			continue
 		}
 		if p.In == InVariable && hasRequestBody {
 			continue
 		}
-		if !flagChangedOrDefault(cmd, p) {
+		if !changed[boundParamKey(p)] {
 			return fmt.Errorf("required flag(s) \"%s\" not set", p.Flag)
 		}
 	}
 	return nil
+}
+
+func positionalParams(params []ParamSpec) []ParamSpec {
+	out := make([]ParamSpec, 0)
+	for _, p := range params {
+		if p.Argument != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func configureParamFlagAliases(cmd *cobra.Command, params []ParamSpec) {
+	aliases := map[string]string{}
+	for _, p := range params {
+		for _, alias := range p.Aliases {
+			if alias == "" || alias == p.Flag {
+				continue
+			}
+			aliases[alias] = p.Flag
+			if isSensitiveStringParam(p) {
+				for _, suffix := range []string{"-env", "-file", "-stdin"} {
+					aliases[alias+suffix] = p.Flag + suffix
+				}
+			}
+		}
+	}
+	if len(aliases) == 0 {
+		return
+	}
+	cmd.Flags().SetNormalizeFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+		if normalized := aliases[name]; normalized != "" {
+			return pflag.NormalizedName(normalized)
+		}
+		return pflag.NormalizedName(name)
+	})
+}
+
+func bindPositionalArgs(cmd *cobra.Command, args []string, params []ParamSpec, vals map[string]any, changed map[string]bool) error {
+	for i, value := range args {
+		p := params[i]
+		if flagChanged(cmd, p) {
+			return fmt.Errorf("parameter %q cannot use both argument %d and --%s", p.Name, i+1, p.Flag)
+		}
+		key := boundParamKey(p)
+		vals[key] = value
+		changed[key] = true
+	}
+	return nil
+}
+
+func flagChanged(cmd *cobra.Command, p ParamSpec) bool {
+	if cmd.Flags().Changed(p.Flag) {
+		return true
+	}
+	if !isSensitiveStringParam(p) {
+		return false
+	}
+	return cmd.Flags().Changed(p.Flag+"-env") || cmd.Flags().Changed(p.Flag+"-file") || cmd.Flags().Changed(p.Flag+"-stdin")
 }
 
 func mountShortcuts(root *cobra.Command, specs []CommandSpec) error {
@@ -594,13 +666,7 @@ func validateShortcutParamValue(p ParamSpec, value string) error {
 }
 
 func flagChangedOrDefault(cmd *cobra.Command, p ParamSpec) bool {
-	if cmd.Flags().Changed(p.Flag) || p.Default != "" {
-		return true
-	}
-	if !isSensitiveStringParam(p) {
-		return false
-	}
-	return cmd.Flags().Changed(p.Flag+"-env") || cmd.Flags().Changed(p.Flag+"-file") || cmd.Flags().Changed(p.Flag+"-stdin")
+	return p.Default != "" || flagChanged(cmd, p)
 }
 
 func operationChangedFlags(cmd *cobra.Command, params []ParamSpec) map[string]bool {

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -127,7 +127,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return fmt.Errorf("live stream output does not support wait polling")
 			}
 			changed := operationChangedFlags(cmd, s.Params)
-			if err := bindPositionalArgs(cmd, args, positionals, vals, changed); err != nil {
+			if err := bindPositionalArgs(cmd, args, positionals, changed); err != nil {
 				return err
 			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
@@ -482,14 +482,16 @@ func configureParamFlagAliases(cmd *cobra.Command, params []ParamSpec) {
 	})
 }
 
-func bindPositionalArgs(cmd *cobra.Command, args []string, params []ParamSpec, vals map[string]any, changed map[string]bool) error {
+func bindPositionalArgs(cmd *cobra.Command, args []string, params []ParamSpec, changed map[string]bool) error {
 	for i, value := range args {
 		p := params[i]
 		if flagChanged(cmd, p) {
 			return fmt.Errorf("parameter %q cannot use both argument %d and --%s", p.Name, i+1, p.Flag)
 		}
+		if err := cmd.Flags().Set(p.Flag, value); err != nil {
+			return fmt.Errorf("parse argument %d for parameter %q: %w", i+1, p.Name, err)
+		}
 		key := boundParamKey(p)
-		vals[key] = value
 		changed[key] = true
 	}
 	return nil

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -116,6 +116,76 @@ func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 	}
 }
 
+func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	tests := []struct {
+		name    string
+		input   []string
+		wantErr string
+	}{
+		{name: "primary flag", input: []string{"--app-id", "a-1", "--workspace-id", "w-1"}},
+		{name: "legacy flag", input: []string{"--app_id", "a-1", "--workspace_id", "w-1"}},
+		{name: "positional", input: []string{"a-1", "--workspace-id", "w-1"}},
+		{name: "conflicting inputs", input: []string{"a-1", "--app-id", "a-2", "--workspace-id", "w-1"}, wantErr: "both argument 1 and --app-id"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestURL string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestURL = r.URL.String()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			root := newRootWithModuleGroup()
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "raw", "")
+			mustBuild(t, root, "demo", []CommandSpec{{
+				Group: "Apps", Use: "describe", Method: "GET", PathTpl: "/apps/{app_id}",
+				Params: []ParamSpec{{
+					Name: "app_id", Flag: "app-id", Aliases: []string{"app_id"}, In: InPath,
+					GoType: "string", Required: true, Argument: "id",
+				}, {
+					Name: "workspace_id", Flag: "workspace-id", Aliases: []string{"workspace_id"}, In: InQuery,
+					GoType: "string", Required: true,
+				}},
+				Security: &SecurityHint{Public: true},
+			}})
+			describe := findChildCommand(mustFindChild(t, mustFindChild(t, root, "demo"), "apps"), "describe")
+			if describe == nil {
+				t.Fatal("describe command was not mounted")
+			}
+			if describe.Use != "describe [id]" {
+				t.Fatalf("use = %q, want describe [id]", describe.Use)
+			}
+			args := []string{"--hostname", srv.URL, "demo", "apps", "describe"}
+			root.SetArgs(append(args, tc.input...))
+
+			err := root.Execute()
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Execute error = %v, want %q", err, tc.wantErr)
+				}
+				if requestURL != "" {
+					t.Fatalf("request sent to %q", requestURL)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if requestURL != "/apps/a-1?workspace_id=w-1" {
+				t.Fatalf("URL = %q, want /apps/a-1?workspace_id=w-1", requestURL)
+			}
+		})
+	}
+}
+
 func TestAssertSchema_Match(t *testing.T) {
 	if err := AssertSchema(SchemaVersion); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -732,7 +802,7 @@ func TestBuild_SensitiveVariableSafeInputModes(t *testing.T) {
 		}
 	}
 
-	root.SetArgs([]string{"--hostname", url, "demo", "credentials", "create-credential", "--input-api-key-env", "OPENAI_API_KEY"})
+	root.SetArgs([]string{"--hostname", url, "demo", "credentials", "create-credential", "--input_api_key-env", "OPENAI_API_KEY"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -829,7 +899,7 @@ func createCredentialSpec() CommandSpec {
 		Method:  "POST",
 		PathTpl: "/graphql",
 		Params: []ParamSpec{
-			{Name: "input.apiKey", Flag: "input-api-key", In: InVariable, GoType: "string", Required: true, Help: "API key"},
+			{Name: "input.apiKey", Flag: "input-api-key", Aliases: []string{"input_api_key"}, In: InVariable, GoType: "string", Required: true, Help: "API key"},
 		},
 		RequestBody: &RequestBody{
 			Required:  true,

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -123,11 +123,13 @@ func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   []string
+		wantURL string
 		wantErr string
 	}{
-		{name: "primary flag", input: []string{"--app-id", "a-1", "--workspace-id", "w-1"}},
-		{name: "legacy flag", input: []string{"--app_id", "a-1", "--workspace_id", "w-1"}},
-		{name: "positional", input: []string{"a-1", "--workspace-id", "w-1"}},
+		{name: "primary flag", input: []string{"--app-id", "a-1", "--workspace-id", "w-1"}, wantURL: "/apps/a-1?workspace_id=w-1"},
+		{name: "legacy flag", input: []string{"--app_id", "a-1", "--workspace_id", "w-1"}, wantURL: "/apps/a-1?workspace_id=w-1"},
+		{name: "positional", input: []string{"a-1", "--workspace-id", "w-1"}, wantURL: "/apps/a-1?workspace_id=w-1"},
+		{name: "positional slice", input: []string{"a-1", "one,two", "--workspace-id", "w-1"}, wantURL: "/apps/a-1?tags=one&tags=two&workspace_id=w-1"},
 		{name: "conflicting inputs", input: []string{"a-1", "--app-id", "a-2", "--workspace-id", "w-1"}, wantErr: "both argument 1 and --app-id"},
 	}
 	for _, tc := range tests {
@@ -153,6 +155,8 @@ func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 				}, {
 					Name: "workspace_id", Flag: "workspace-id", Aliases: []string{"workspace_id"}, In: InQuery,
 					GoType: "string", Required: true,
+				}, {
+					Name: "tags", Flag: "tags", In: InQuery, GoType: "[]string", Argument: "tags",
 				}},
 				Security: &SecurityHint{Public: true},
 			}})
@@ -160,8 +164,8 @@ func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 			if describe == nil {
 				t.Fatal("describe command was not mounted")
 			}
-			if describe.Use != "describe [id]" {
-				t.Fatalf("use = %q, want describe [id]", describe.Use)
+			if describe.Use != "describe [id] [tags]" {
+				t.Fatalf("use = %q, want describe [id] [tags]", describe.Use)
 			}
 			args := []string{"--hostname", srv.URL, "demo", "apps", "describe"}
 			root.SetArgs(append(args, tc.input...))
@@ -179,8 +183,8 @@ func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Execute: %v", err)
 			}
-			if requestURL != "/apps/a-1?workspace_id=w-1" {
-				t.Fatalf("URL = %q, want /apps/a-1?workspace_id=w-1", requestURL)
+			if requestURL != tc.wantURL {
+				t.Fatalf("URL = %q, want %q", requestURL, tc.wantURL)
 			}
 		})
 	}

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 14
+const CatalogSchemaVersion = 15
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -115,6 +115,9 @@ type CatalogBody struct {
 type CatalogFlag struct {
 	Name       string   `json:"name"`
 	Flag       string   `json:"flag"`
+	Aliases    []string `json:"aliases,omitempty"`
+	Argument   string   `json:"argument,omitempty"`
+	Position   int      `json:"position,omitempty"`
 	Location   string   `json:"location"`
 	Type       string   `json:"type"`
 	Required   bool     `json:"required"`
@@ -349,26 +352,7 @@ func findChildCommand(parent *cobra.Command, name string) *cobra.Command {
 }
 
 func catalogCommand(service string, spec CommandSpec, path []string) CatalogCommand {
-	flags := make([]CatalogFlag, 0, len(spec.Params))
-	for _, p := range spec.Params {
-		var inputModes []string
-		if isSensitiveStringParam(p) {
-			inputModes = []string{"flag", "env", "file", "stdin"}
-		}
-		flags = append(flags, CatalogFlag{
-			Name:       p.Name,
-			Flag:       p.Flag,
-			Location:   p.In,
-			Type:       p.GoType,
-			Required:   p.Required,
-			Default:    p.Default,
-			Enum:       append([]string(nil), p.Enum...),
-			Format:     p.Format,
-			InputModes: inputModes,
-			Deprecated: p.Deprecated,
-			Help:       p.Help,
-		})
-	}
+	flags := catalogFlags(spec.Params)
 	examples := spec.Examples
 	if len(examples) == 0 && spec.Example != "" {
 		examples = []CommandExample{{Command: spec.Example}}
@@ -430,26 +414,7 @@ func catalogWorkflowConditions(conditions []WorkflowCondition) []CatalogWorkflow
 }
 
 func catalogWorkflowCommand(spec WorkflowSpec, path []string) CatalogCommand {
-	flags := make([]CatalogFlag, 0, len(spec.Params))
-	for _, p := range spec.Params {
-		var inputModes []string
-		if isSensitiveStringParam(p) {
-			inputModes = []string{"flag", "env", "file", "stdin"}
-		}
-		flags = append(flags, CatalogFlag{
-			Name:       p.Name,
-			Flag:       p.Flag,
-			Location:   p.In,
-			Type:       p.GoType,
-			Required:   p.Required,
-			Default:    p.Default,
-			Enum:       append([]string(nil), p.Enum...),
-			Format:     p.Format,
-			InputModes: inputModes,
-			Deprecated: p.Deprecated,
-			Help:       p.Help,
-		})
-	}
+	flags := catalogFlags(spec.Params)
 	steps := make([]CatalogWorkflowStep, 0, len(spec.Steps))
 	auth := CatalogAuth{Required: false}
 	for _, step := range spec.Steps {
@@ -498,6 +463,39 @@ func catalogWorkflowCommand(spec WorkflowSpec, path []string) CatalogCommand {
 		Hidden:     spec.Hidden,
 		Deprecated: spec.Deprecated,
 	}
+}
+
+func catalogFlags(params []ParamSpec) []CatalogFlag {
+	flags := make([]CatalogFlag, 0, len(params))
+	position := 0
+	for _, p := range params {
+		var inputModes []string
+		if isSensitiveStringParam(p) {
+			inputModes = []string{"flag", "env", "file", "stdin"}
+		}
+		argumentPosition := 0
+		if p.Argument != "" {
+			position++
+			argumentPosition = position
+		}
+		flags = append(flags, CatalogFlag{
+			Name:       p.Name,
+			Flag:       p.Flag,
+			Aliases:    append([]string(nil), p.Aliases...),
+			Argument:   p.Argument,
+			Position:   argumentPosition,
+			Location:   p.In,
+			Type:       p.GoType,
+			Required:   p.Required,
+			Default:    p.Default,
+			Enum:       append([]string(nil), p.Enum...),
+			Format:     p.Format,
+			InputModes: inputModes,
+			Deprecated: p.Deprecated,
+			Help:       p.Help,
+		})
+	}
+	return flags
 }
 
 func cloneShortcuts(shortcuts []CommandShortcut) []CommandShortcut {

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -29,7 +29,7 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 			PathTpl:         "/users/{id}",
 			DefaultHostname: "api.example.com",
 			Params: []ParamSpec{
-				{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true, Help: "User id"},
+				{Name: "user_id", Flag: "user-id", Aliases: []string{"user_id"}, Argument: "id", In: InPath, GoType: "string", Required: true, Help: "User id"},
 				{Name: "workspace", Flag: "workspace", In: InQuery, GoType: "string", Default: "default", Enum: []string{"default", "prod"}, Format: "slug", Help: "Target workspace"},
 			},
 			RequestBody: &RequestBody{Required: true, MediaType: "application/json", Schema: &SchemaSpec{Type: "object", Properties: map[string]*SchemaSpec{"name": {Type: "string"}}}},
@@ -101,6 +101,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if cmd.Flags[0].Location != InPath || !cmd.Flags[0].Required {
 		t.Fatalf("path flag = %+v", cmd.Flags[0])
+	}
+	if cmd.Flags[0].Name != "user_id" || cmd.Flags[0].Flag != "user-id" || !reflect.DeepEqual(cmd.Flags[0].Aliases, []string{"user_id"}) || cmd.Flags[0].Argument != "id" || cmd.Flags[0].Position != 1 {
+		t.Fatalf("path input syntax = %+v", cmd.Flags[0])
 	}
 	if cmd.Flags[1].Default != "default" || !reflect.DeepEqual(cmd.Flags[1].Enum, []string{"default", "prod"}) {
 		t.Fatalf("query flag = %+v", cmd.Flags[1])
@@ -472,8 +475,8 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 
 	catalog := BuildCatalog(root, CatalogOptions{})
-	if catalog.CatalogSchemaVersion != 14 {
-		t.Fatalf("schema version = %d, want 14", catalog.CatalogSchemaVersion)
+	if catalog.CatalogSchemaVersion != 15 {
+		t.Fatalf("schema version = %d, want 15", catalog.CatalogSchemaVersion)
 	}
 	var step *CatalogWorkflowStep
 	for i, entry := range catalog.Commands {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 10
+const SchemaVersion = 11
 
 type CommandSpec struct {
 	Group           string
@@ -53,6 +53,8 @@ type CommandShortcut struct {
 type ParamSpec struct {
 	Name       string
 	Flag       string
+	Aliases    []string `json:",omitempty"`
+	Argument   string   `json:",omitempty"`
 	In         string
 	GoType     string
 	Help       string

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -72,12 +72,13 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 			if err := resolveSafeInputFlags(cmd, spec.Params, vals); err != nil {
 				return err
 			}
-			if err := validateRequiredSafeParams(cmd, spec.Params, false); err != nil {
+			changed := operationChangedFlags(cmd, spec.Params)
+			if err := validateRequiredParams(spec.Params, false, changed); err != nil {
 				return err
 			}
 			if err := validateOperationEnums(CommandSpec{Params: spec.Params}, OperationInput{
 				Values:  vals,
-				Changed: operationChangedFlags(cmd, spec.Params),
+				Changed: changed,
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

- generate kebab-case parameter flags while retaining legacy spellings as accepted aliases
- let overlays expose ordered positional alternatives without removing the corresponding flags
- publish source-to-CLI input mappings in the runtime catalog and generated Skill guidance

## Verification

- `make check`
- `go test -race ./...`
- generated downstream CLI: `__lathe verify --json` passed 31/31 checks
- positional, kebab-case, and legacy snake-case dry runs produced the same request URL