### PR TITLE
feat(runtime): stabilize machine error handling

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -322,6 +322,20 @@ This renders `get-user [id]`; both `get-user 123` and
 entries retain `name`, `flag`, accepted `aliases`, `argument`, and `position` so
 agents do not infer the mapping from help text.
 
+## Handle Errors and Pending Outcomes
+
+Use `-o json` or `-o yaml` when a script or agent must handle failures. The CLI
+writes a stable `error` envelope to stderr with required `code` and `message`
+fields. `hint`, `http_status`, `method`, `url`, and a redacted bounded
+`server_body` appear when relevant. Branch on `code`; message text is for
+people.
+
+Exit codes are `1` for `general`, `2` for `usage`, `3` for `api_error`, `4` for
+`not_authenticated`, and `130` for `canceled`. A collected stream pause exits
+`0` and returns the overlay-defined pending payload. Inspect the command's
+`output.streaming.policy.collect.pause_events` and field mappings rather than
+treating a pause as failure.
+
 Generated outputs:
 
 ```text

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -55,9 +55,17 @@ file; when this page and the code disagree, trust the code and fix this page.
 ## Structured errors and exit codes
 
 - Defined in `pkg/runtime/errors.go`.
-- Error codes: `general`, `usage`, `api_error`, `not_authenticated`.
+- JSON and YAML failures are written to stderr as
+  `{"error":{"code":...,"message":...}}`. Optional fields are `hint`,
+  `http_status`, `method`, `url`, and `server_body`. The server body is emitted
+  only when it is valid JSON, after sensitive fields are redacted and the
+  result is bounded.
+- Error codes: `general`, `usage`, `api_error`, `not_authenticated`,
+  `canceled`.
 - Exit codes: `0` OK, `1` general, `2` usage, `3` API error,
-  `4` not authenticated.
+  `4` not authenticated, `130` canceled. A collected stream pause remains a
+  successful exit `0`; its pending data is the overlay-defined collected
+  payload, not an error envelope.
 - Consumers: agents and scripts that branch on failure classes instead of
   parsing prose.
 

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -525,6 +525,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- For collected streams, choose one mode: `-o json` for one stable document, `--stream` in the default output mode when catalog `output.streaming.policy.live` is present, or `-o raw` for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
+	b.WriteString("- On a non-zero exit with `-o json` or `-o yaml`, parse the stderr `error` envelope and branch on `error.code`, not `error.message`. A collected stream pause is success with exit 0; inspect the collected payload and stream policy.\n")
 	return b.String()
 }
 
@@ -576,6 +577,9 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
 	b.WriteString("## Output\n\n")
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
+	b.WriteString("## Errors and Pending Outcomes\n\n")
+	b.WriteString("With `-o json` or `-o yaml`, failures are written to stderr as an `error` envelope. `code` and `message` are always present; `hint`, `http_status`, `method`, `url`, and a redacted bounded `server_body` are optional. Branch on `code`, never on message text.\n\n")
+	b.WriteString("Exit codes are 1 `general`, 2 `usage`, 3 `api_error`, 4 `not_authenticated`, and 130 `canceled`. A collected stream pause is not an error: it exits 0 and returns the overlay-defined pending payload; inspect `output.streaming.policy.collect.pause_events` and its field mappings before continuing.\n\n")
 	b.WriteString("## Auth\n\n")
 	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -95,6 +95,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"auth.required=true",
 		"references/modules/users.md",
 		"flags[].input_modes",
+		"error.code",
 	} {
 		if !strings.Contains(skill, want) {
 			t.Errorf("SKILL.md missing %q", want)
@@ -115,7 +116,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 
 	catalog := readFile(t, dir, "skills/acmectl/references/catalog.md")
-	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json"} {
+	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "## Errors and Pending Outcomes", "input_modes", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "`canceled`", "stream pause"} {
 		if !strings.Contains(catalog, want) {
 			t.Errorf("catalog.md missing %q", want)
 		}

--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -43,7 +43,7 @@ func commandsShowCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show <path...>",
 		Short: "Show one generated command",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  requireCatalogArgument,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entry, ok := runtime.FindCatalogCommand(cmd.Root(), args, catalogOptions(m, includeHidden))
 			if !ok {
@@ -100,7 +100,7 @@ func searchCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search generated commands",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  requireCatalogArgument,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query := strings.Join(args, " ")
 			results := runtime.SearchCatalog(cmd.Root(), query, runtime.SearchOptions{
@@ -122,6 +122,15 @@ func searchCmd(m *config.Manifest) *cobra.Command {
 	addJSONFlag(cmd, &jsonOut, "Emit search results JSON")
 	cmd.Flags().IntVar(&limit, "limit", runtime.DefaultSearchLimit, "Maximum number of results")
 	return cmd
+}
+
+func requireCatalogArgument(cmd *cobra.Command, args []string) error {
+	if err := cobra.MinimumNArgs(1)(cmd, args); err != nil {
+		usage := runtime.NewLatheError(runtime.CodeUsage, runtime.ExitUsage, err)
+		usage.Hint = fmt.Sprintf("run '%s --help'", cmd.CommandPath())
+		return usage
+	}
+	return nil
 }
 
 func catalogOptions(m *config.Manifest, includeHidden bool) runtime.CatalogOptions {

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -99,12 +99,15 @@ func restoreVersionInfo(t *testing.T) {
 
 func TestRunReportsInvalidManifest(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run(RunOptions{Manifest: []byte("cli: {}\n")}, []string{"--help"}, &stdout, &stderr)
+	code := run(RunOptions{Manifest: []byte("cli: {}\n")}, []string{"--help", "-o", "json"}, &stdout, &stderr)
 	if code != runtime.ExitGeneral {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
 	}
-	if !strings.Contains(stderr.String(), "cli.name is required") {
-		t.Fatalf("stderr missing manifest error: %q", stderr.String())
+	var envelope struct {
+		Error runtime.LatheError `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil || !strings.Contains(envelope.Error.Message, "cli.name is required") {
+		t.Fatalf("manifest error = %+v, decode = %v, stderr = %q", envelope.Error, err, stderr.String())
 	}
 }
 
@@ -115,12 +118,15 @@ func TestRunReportsMountError(t *testing.T) {
 		Mount: func(*cobra.Command) error {
 			return errors.New("mount failed")
 		},
-	}, []string{"--help"}, &stdout, &stderr)
+	}, []string{"--help", "-o", "json"}, &stdout, &stderr)
 	if code != runtime.ExitGeneral {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
 	}
-	if !strings.Contains(stderr.String(), "mount failed") {
-		t.Fatalf("stderr missing mount error: %q", stderr.String())
+	var envelope struct {
+		Error runtime.LatheError `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil || envelope.Error.Message != "mount failed" {
+		t.Fatalf("mount error = %+v, decode = %v, stderr = %q", envelope.Error, err, stderr.String())
 	}
 }
 

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -164,3 +164,28 @@ func TestRunClassifiesCatalogArgumentErrors(t *testing.T) {
 		}
 	}
 }
+
+func TestRunHonorsOutputAfterFlagError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run(RunOptions{
+		Manifest: []byte("cli:\n  name: myctl\n"),
+		Mount: func(root *cobra.Command) error {
+			cmd := &cobra.Command{Use: "demo"}
+			cmd.Flags().Int("count", 0, "")
+			root.AddCommand(cmd)
+			return nil
+		},
+	}, []string{"demo", "--count", "nope", "-o", "json"}, &stdout, &stderr)
+	if code != runtime.ExitUsage {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	var envelope struct {
+		Error runtime.LatheError `json:"error"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+		t.Fatalf("invalid JSON error: %v\n%s", err, stderr.String())
+	}
+	if envelope.Error.Code != runtime.CodeUsage {
+		t.Fatalf("error = %+v", envelope.Error)
+	}
+}

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -2,6 +2,7 @@ package lathe
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -139,5 +140,27 @@ func TestRunUsesRuntimeExecuteErrors(t *testing.T) {
 	}, []string{"needs-auth"}, &stdout, &stderr)
 	if code != runtime.ExitNotAuthenticated {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitNotAuthenticated)
+	}
+}
+
+func TestRunClassifiesCatalogArgumentErrors(t *testing.T) {
+	for _, args := range [][]string{
+		{"commands", "show", "-o", "json"},
+		{"search", "-o", "json"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := run(RunOptions{Manifest: []byte("cli:\n  name: myctl\n")}, args, &stdout, &stderr)
+		if code != runtime.ExitUsage {
+			t.Fatalf("args %v: exit = %d, stderr = %q", args, code, stderr.String())
+		}
+		var envelope struct {
+			Error runtime.LatheError `json:"error"`
+		}
+		if err := json.Unmarshal(stderr.Bytes(), &envelope); err != nil {
+			t.Fatalf("args %v: invalid JSON error: %v\n%s", args, err, stderr.String())
+		}
+		if envelope.Error.Code != runtime.CodeUsage || envelope.Error.Hint == "" {
+			t.Fatalf("args %v: error = %+v", args, envelope.Error)
+		}
 	}
 }

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -34,6 +34,11 @@ func Run(opts RunOptions) int {
 func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+	go func() {
+		<-ctx.Done()
+		// Restore the default so a second interrupt can terminate context-unaware reads.
+		stop()
+	}()
 
 	m, err := config.Load(opts.Manifest)
 	if err != nil {

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/runtime"
@@ -49,6 +50,7 @@ func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 
 	root := NewApp(m)
 	root.SetContext(ctx)
+	seedOutputFormat(root, args)
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
@@ -60,6 +62,15 @@ func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 	}
 
 	return runtime.Execute(root)
+}
+
+func seedOutputFormat(root *cobra.Command, args []string) {
+	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
+	flags.ParseErrorsAllowlist.UnknownFlags = true
+	format := flags.StringP("output", "o", "", "")
+	if err := flags.Parse(args); err == nil && flags.Changed("output") {
+		_ = root.PersistentFlags().Set("output", *format)
+	}
 }
 
 func setVersionInfo(opts RunOptions) {

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -1,8 +1,10 @@
 package lathe
 
 import (
+	"context"
 	"io"
 	"os"
+	"os/signal"
 
 	"github.com/spf13/cobra"
 
@@ -30,6 +32,9 @@ func Run(opts RunOptions) int {
 }
 
 func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
 	m, err := config.Load(opts.Manifest)
 	if err != nil {
 		return runtime.FormatError(err, "table", stderr)
@@ -38,6 +43,7 @@ func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 	setVersionInfo(opts)
 
 	root := NewApp(m)
+	root.SetContext(ctx)
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -40,37 +40,40 @@ func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 		// Restore the default so a second interrupt can terminate context-unaware reads.
 		stop()
 	}()
+	format := requestedOutputFormat(args)
 
 	m, err := config.Load(opts.Manifest)
 	if err != nil {
-		return runtime.FormatError(err, "table", stderr)
+		return runtime.FormatError(err, format, stderr)
 	}
 
 	setVersionInfo(opts)
 
 	root := NewApp(m)
 	root.SetContext(ctx)
-	seedOutputFormat(root, args)
+	_ = root.PersistentFlags().Set("output", format)
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
 
 	if opts.Mount != nil {
 		if err := opts.Mount(root); err != nil {
-			return runtime.FormatError(err, "table", stderr)
+			return runtime.FormatError(err, format, stderr)
 		}
 	}
 
 	return runtime.Execute(root)
 }
 
-func seedOutputFormat(root *cobra.Command, args []string) {
+func requestedOutputFormat(args []string) string {
 	flags := pflag.NewFlagSet("output", pflag.ContinueOnError)
 	flags.ParseErrorsAllowlist.UnknownFlags = true
+	flags.BoolP("help", "h", false, "")
 	format := flags.StringP("output", "o", "", "")
 	if err := flags.Parse(args); err == nil && flags.Changed("output") {
-		_ = root.PersistentFlags().Set("output", *format)
+		return *format
 	}
+	return "table"
 }
 
 func setVersionInfo(opts RunOptions) {

--- a/pkg/runtime/body.go
+++ b/pkg/runtime/body.go
@@ -56,12 +56,12 @@ func buildEnvelopeBody(template, mergePath string, vars map[string]any, sets, st
 	}
 	if hasFile {
 		if mergePath == "" {
-			return nil, fmt.Errorf("--file is not supported for this command's body template")
+			return nil, NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("--file is not supported for this command's body template"))
 		}
 		var v any
 		if len(strings.TrimSpace(string(fileData))) > 0 {
 			if err := json.Unmarshal(fileData, &v); err != nil {
-				return nil, fmt.Errorf("invalid --file JSON: %w", err)
+				return nil, NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("invalid --file JSON: %w", err))
 			}
 		}
 		if err := setNestedPath(envelope, mergePath, v); err != nil {
@@ -76,19 +76,19 @@ func buildEnvelopeBody(template, mergePath string, vars map[string]any, sets, st
 	for _, kv := range sets {
 		path, value, err := parseSet(kv, "--set")
 		if err != nil {
-			return nil, err
+			return nil, NewLatheError(CodeUsage, ExitUsage, err)
 		}
 		if err := setNestedPath(envelope, joinBodyPath(mergePath, path), inferValue(value)); err != nil {
-			return nil, err
+			return nil, NewLatheError(CodeUsage, ExitUsage, err)
 		}
 	}
 	for _, kv := range stringSets {
 		path, value, err := parseSet(kv, "--set-str")
 		if err != nil {
-			return nil, err
+			return nil, NewLatheError(CodeUsage, ExitUsage, err)
 		}
 		if err := setNestedPath(envelope, joinBodyPath(mergePath, path), value); err != nil {
-			return nil, err
+			return nil, NewLatheError(CodeUsage, ExitUsage, err)
 		}
 	}
 	return json.Marshal(envelope)

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -354,7 +354,7 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 func redactedDryRunHeaders(headers map[string][]string) map[string]string {
 	out := make(map[string]string, len(headers))
 	for k, vs := range headers {
-		out[k] = redactDebugHeader(k, strings.Join(vs, ", "), nil)
+		out[k] = redactDebugHeader(k, strings.Join(vs, ", "), nil, false)
 	}
 	return out
 }

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -127,6 +127,9 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if err := validateOutputFormat(format); err != nil {
+				return newUsageError(cmd, err)
+			}
 			if liveStream && format != "table" {
 				return newUsageError(cmd, fmt.Errorf("live stream output does not support -o %s", format))
 			}

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -625,7 +625,7 @@ func validateRequiredVariableParams(s CommandSpec, body any) error {
 	}
 	raw, ok := body.([]byte)
 	if !ok || len(raw) == 0 {
-		return fmt.Errorf("required body field missing: %s", required[0].Name)
+		return NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("required body field missing: %s", required[0].Name))
 	}
 	var doc any
 	if err := json.Unmarshal(raw, &doc); err != nil {
@@ -634,7 +634,7 @@ func validateRequiredVariableParams(s CommandSpec, body any) error {
 	for _, p := range required {
 		v, ok := getNestedPath(doc, joinBodyPath(s.RequestBody.MergePath, p.Name))
 		if !ok || v == nil {
-			return fmt.Errorf("required body field missing: %s", p.Name)
+			return NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("required body field missing: %s", p.Name))
 		}
 	}
 	return nil

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -118,23 +118,29 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		Short:   s.Short,
 		Long:    s.Long,
 		Example: s.Example,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return newUsageError(cmd, err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if liveStream && format != "table" {
-				return fmt.Errorf("live stream output does not support -o %s", format)
+				return newUsageError(cmd, fmt.Errorf("live stream output does not support -o %s", format))
 			}
 			if liveStream && waitPoll {
-				return fmt.Errorf("live stream output does not support wait polling")
+				return newUsageError(cmd, fmt.Errorf("live stream output does not support wait polling"))
 			}
 			changed := operationChangedFlags(cmd, s.Params)
 			if err := bindPositionalArgs(cmd, args, positionals, changed); err != nil {
 				return err
 			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
-				return err
+				return newUsageError(cmd, err)
 			}
 			if err := validateRequiredParams(s.Params, s.RequestBody != nil, changed); err != nil {
-				return err
+				return newUsageError(cmd, err)
 			}
 
 			var hostname string
@@ -201,7 +207,13 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		for _, p := range positionals {
 			cmd.Use += " [" + p.Argument + "]"
 		}
-		cmd.Args = cobra.MaximumNArgs(len(positionals))
+		validateArgs := cobra.MaximumNArgs(len(positionals))
+		cmd.Args = func(cmd *cobra.Command, args []string) error {
+			if err := validateArgs(cmd, args); err != nil {
+				return newUsageError(cmd, err)
+			}
+			return nil
+		}
 	}
 	configureParamFlagAliases(cmd, s.Params)
 
@@ -486,10 +498,10 @@ func bindPositionalArgs(cmd *cobra.Command, args []string, params []ParamSpec, c
 	for i, value := range args {
 		p := params[i]
 		if flagChanged(cmd, p) {
-			return fmt.Errorf("parameter %q cannot use both argument %d and --%s", p.Name, i+1, p.Flag)
+			return newUsageError(cmd, fmt.Errorf("parameter %q cannot use both argument %d and --%s", p.Name, i+1, p.Flag))
 		}
 		if err := cmd.Flags().Set(p.Flag, value); err != nil {
-			return fmt.Errorf("parse argument %d for parameter %q: %w", i+1, p.Name, err)
+			return newUsageError(cmd, fmt.Errorf("parse argument %d for parameter %q: %w", i+1, p.Name, err))
 		}
 		key := boundParamKey(p)
 		changed[key] = true

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -161,7 +162,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			if hasFile {
 				fileBody, err = ReadBody(bodyFile)
 				if err != nil {
-					return err
+					return newUsageError(cmd, err)
 				}
 			}
 
@@ -192,6 +193,10 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				Wait:        waitPoll,
 			}, output)
 			if err != nil {
+				var usage *LatheError
+				if errors.As(err, &usage) && usage.Code == CodeUsage {
+					return newUsageError(cmd, err)
+				}
 				return err
 			}
 			if result.DryRun != nil {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1120,6 +1120,41 @@ func TestBuild_RequiredQueryParamBlocksBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestBuild_InvalidOutputBlocksBeforeRequest(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	root := newRootWithModuleGroup()
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group: "Items", Use: "create-item", Method: "POST", PathTpl: "/items",
+		Security: &SecurityHint{Public: true},
+	}})
+	root.SetArgs([]string{"--hostname", srv.URL, "-o", "csv", "demo", "items", "create-item"})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected output format error")
+	}
+	if classified := ClassifyError(err); classified.Code != CodeUsage || classified.ExitCode != ExitUsage {
+		t.Fatalf("classified error = %+v", classified)
+	}
+	if hits != 0 {
+		t.Fatalf("server hits = %d, want 0", hits)
+	}
+}
+
 func TestBuild_PaginationFlagsAttached(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:   "Items",

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1086,6 +1086,9 @@ func TestBuild_RequiredQueryParamBlocksBeforeRequest(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected required flag error")
 	}
+	if classified := ClassifyError(err); classified.Code != CodeUsage || classified.ExitCode != ExitUsage {
+		t.Fatalf("classified error = %+v", classified)
+	}
 	if !strings.Contains(err.Error(), "required flag") || !strings.Contains(err.Error(), "type") {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -627,10 +627,16 @@ func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
 	}
 }
 
-func TestBuild_NonJSONRequestBodyRequiresFile(t *testing.T) {
-	for _, args := range [][]string{
-		{"--set", "id=1"},
-		nil,
+func TestBuild_RequestBodyInputErrorsAreUsage(t *testing.T) {
+	for _, tc := range []struct {
+		media string
+		args  []string
+		want  string
+	}{
+		{media: "text/plain", args: []string{"--set", "id=1"}, want: "requires --file"},
+		{media: "text/plain", want: "requires --file"},
+		{media: "application/json", want: "request body required"},
+		{media: "application/json", args: []string{"--set", "missing-equals"}, want: "expected key=value"},
 	} {
 		bindTestManifest(t, "myctl", "MYCTL_HOST")
 		t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
@@ -643,14 +649,17 @@ func TestBuild_NonJSONRequestBodyRequiresFile(t *testing.T) {
 			Use:         "create-export",
 			Method:      "POST",
 			PathTpl:     "/exports",
-			RequestBody: &RequestBody{Required: true, MediaType: "text/plain"},
+			RequestBody: &RequestBody{Required: true, MediaType: tc.media},
 			Security:    &SecurityHint{Public: true},
 		}})
-		root.SetArgs(append([]string{"--hostname", "http://127.0.0.1:1", "demo", "exports", "create-export"}, args...))
+		root.SetArgs(append([]string{"--hostname", "http://127.0.0.1:1", "demo", "exports", "create-export"}, tc.args...))
 
 		err := root.Execute()
-		if err == nil || !strings.Contains(err.Error(), "requires --file") {
-			t.Fatalf("Execute error = %v, want requires --file", err)
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Fatalf("Execute error = %v, want %q", err, tc.want)
+		}
+		if classified := ClassifyError(err); classified.Code != CodeUsage || classified.ExitCode != ExitUsage {
+			t.Fatalf("classified error = %+v", classified)
 		}
 	}
 }

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -857,6 +857,17 @@ func TestBuild_RequiredVariableCanComeFromBodyInput(t *testing.T) {
 			name:    "missing",
 			wantErr: true,
 		},
+		{
+			name:    "invalid set",
+			args:    []string{"--set", "missing-equals"},
+			wantErr: true,
+		},
+		{
+			name:     "invalid file JSON",
+			args:     []string{"--file", "BODY_FILE"},
+			fileBody: `{`,
+			wantErr:  true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -878,6 +889,9 @@ func TestBuild_RequiredVariableCanComeFromBodyInput(t *testing.T) {
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("expected error")
+				}
+				if classified := ClassifyError(err); classified.Code != CodeUsage || classified.ExitCode != ExitUsage {
+					t.Fatalf("classified error = %+v", classified)
 				}
 				_, called := recorded()
 				if called {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -32,6 +32,7 @@ type ClientOptions struct {
 	Accept      string
 
 	sensitiveQueryParams map[string]bool
+	sensitivePath        bool
 	checkRedirect        func(*http.Request, []*http.Request) error
 }
 
@@ -76,7 +77,7 @@ func httpClient(opts ClientOptions, streaming bool) *http.Client {
 		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug, safeMethodsOnly: safeMethodsOnly}
 	}
 	if opts.Debug {
-		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming}
+		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, sensitivePath: opts.sensitivePath, streaming: streaming}
 	}
 	return &http.Client{
 		Timeout:       timeout,
@@ -267,10 +268,10 @@ func newRequest(ctx context.Context, method, u string, body []byte, contentType 
 
 func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsumer) (*RawResult, error) {
 	method := req.Method
-	u := redactDebugURL(req.URL, opts.sensitiveQueryParams)
+	u := redactDebugURL(req.URL, opts.sensitiveQueryParams, opts.sensitivePath)
 	resp, err := httpClient(opts, consume != nil).Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", method, u, redactClientError(err, opts.sensitiveQueryParams))
+		return nil, fmt.Errorf("%s %s: %w", method, u, redactClientError(err, opts.sensitiveQueryParams, opts.sensitivePath))
 	}
 	defer resp.Body.Close()
 
@@ -301,13 +302,13 @@ func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsum
 	return &RawResult{Body: data, StatusCode: resp.StatusCode, Header: resp.Header}, nil
 }
 
-func redactClientError(err error, sensitive map[string]bool) error {
+func redactClientError(err error, sensitive map[string]bool, sensitivePath bool) error {
 	var urlErr *url.Error
 	if !errors.As(err, &urlErr) {
 		return err
 	}
 	redacted := *urlErr
-	redacted.URL = redactDebugURLString(redacted.URL, sensitive)
+	redacted.URL = redactDebugURLString(redacted.URL, sensitive, sensitivePath)
 	if urlErr.Err != nil && strings.HasPrefix(urlErr.Err.Error(), "failed to parse Location header ") {
 		redacted.Err = errors.New("failed to parse Location header")
 	}

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -334,9 +334,5 @@ type HTTPError struct {
 }
 
 func (e *HTTPError) Error() string {
-	snippet := string(e.Body)
-	if len(snippet) > 200 {
-		snippet = snippet[:200] + "…"
-	}
-	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, e.URL, e.Status, strings.TrimSpace(snippet))
+	return fmt.Sprintf("%s %s: HTTP %d", e.Method, e.URL, e.Status)
 }

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -111,6 +111,33 @@ func TestInvokeOperation_RedactsQueryCredentialFromHTTPError(t *testing.T) {
 	}
 }
 
+func TestInvokeOperation_RedactsPathCredentialFromHTTPError(t *testing.T) {
+	const secret = "path-error-secret"
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := InvokeOperation(context.Background(), CommandSpec{
+		Method: "POST", PathTpl: "/reset/{token}",
+		Params: []ParamSpec{{Name: "token", Flag: "token", In: InPath, GoType: "string"}},
+	}, OperationInput{
+		Values: map[string]any{"token": secret}, Changed: map[string]bool{"token": true},
+	}, OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}})
+	if err == nil {
+		t.Fatal("InvokeOperation returned nil error")
+	}
+	if gotPath != "/reset/"+secret {
+		t.Fatalf("server path = %q", gotPath)
+	}
+	classified := ClassifyError(err)
+	if strings.Contains(err.Error()+classified.URL, secret) || strings.Contains(classified.URL, "/reset/") {
+		t.Fatalf("path credential was not redacted: err=%v url=%q", err, classified.URL)
+	}
+}
+
 func TestInvokeOperation_RedactsQueryCredentialFromTransportError(t *testing.T) {
 	const secret = "transport-error-secret"
 	_, err := InvokeOperation(context.Background(), CommandSpec{

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -20,7 +20,10 @@ var ErrNotAuthenticated = errors.New("not authenticated")
 // the bound manifest and wraps ErrNotAuthenticated so errors.Is still works.
 func NewNotAuthenticatedError() error {
 	name := config.Active().CLI.Name
-	return fmt.Errorf("not logged in to any %s host; run `%s auth login` to authenticate: %w", name, name, ErrNotAuthenticated)
+	return notAuthenticatedError(
+		fmt.Sprintf("not logged in to any %s host", name),
+		fmt.Sprintf("run '%s auth login'", name),
+	)
 }
 
 func ResolveHost(cmd *cobra.Command) (string, error) {
@@ -153,5 +156,15 @@ func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, 
 
 func notAuthenticatedToHost(hostname string) error {
 	name := config.Active().CLI.Name
-	return fmt.Errorf("not authenticated to %s (run: %s auth login --hostname %s)", hostname, name, hostname)
+	return notAuthenticatedError(
+		fmt.Sprintf("not authenticated to %s", hostname),
+		fmt.Sprintf("run '%s auth login --hostname %s'", name, hostname),
+	)
+}
+
+func notAuthenticatedError(message, hint string) *LatheError {
+	return &LatheError{
+		Code: CodeNotAuthenticated, Message: message, Hint: hint,
+		ExitCode: ExitNotAuthenticated, cause: ErrNotAuthenticated,
+	}
 }

--- a/pkg/runtime/ctx_test.go
+++ b/pkg/runtime/ctx_test.go
@@ -27,12 +27,17 @@ func bindTestManifest(t *testing.T, name, hostEnv string) {
 
 func TestNewNotAuthenticatedError_WrapsSentinel(t *testing.T) {
 	bindTestManifest(t, "demo", "DEMO_HOST")
-	err := NewNotAuthenticatedError()
-	if !errors.Is(err, ErrNotAuthenticated) {
-		t.Fatal("expected errors.Is to match ErrNotAuthenticated")
-	}
-	if !strings.Contains(err.Error(), "demo host") || !strings.Contains(err.Error(), "`demo auth login`") {
-		t.Errorf("expected rendered message to use bound name; got %q", err.Error())
+	for _, err := range []error{NewNotAuthenticatedError(), notAuthenticatedToHost("api.example.com")} {
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Fatal("expected errors.Is to match ErrNotAuthenticated")
+		}
+		classified := ClassifyError(err)
+		if classified.Code != CodeNotAuthenticated || classified.ExitCode != ExitNotAuthenticated {
+			t.Errorf("classified error = %+v", classified)
+		}
+		if !strings.Contains(classified.Hint, "demo auth login") {
+			t.Errorf("hint does not use bound CLI name: %+v", classified)
+		}
 	}
 }
 

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -28,13 +28,14 @@ var (
 type debugTransport struct {
 	inner                http.RoundTripper
 	sensitiveQueryParams map[string]bool
+	sensitivePath        bool
 	streaming            bool
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, redactDebugURL(req.URL, d.sensitiveQueryParams))
+	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, redactDebugURL(req.URL, d.sensitiveQueryParams, d.sensitivePath))
 	for k, vs := range req.Header {
-		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
+		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams, d.sensitivePath))
 	}
 	if req.Body != nil && isTextContent(req.Header.Get("Content-Type")) {
 		body, restored := peekBody(req.Body, maxDebugReqBody)
@@ -54,7 +55,7 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	fmt.Fprintf(os.Stderr, "< %s (%s)\n", resp.Status, elapsed)
 	for k, vs := range resp.Header {
-		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
+		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams, d.sensitivePath))
 	}
 	if isTextContent(resp.Header.Get("Content-Type")) && (!d.streaming || resp.StatusCode < 200 || resp.StatusCode >= 300) {
 		body, restored := peekBody(resp.Body, maxDebugRespBody)
@@ -66,11 +67,15 @@ func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func redactDebugURL(u *url.URL, sensitive map[string]bool) string {
+func redactDebugURL(u *url.URL, sensitive map[string]bool, sensitivePath bool) string {
 	if u == nil {
 		return ""
 	}
 	redacted := *u
+	if sensitivePath {
+		redacted.Path = "/***"
+		redacted.RawPath = ""
+	}
 	redacted.RawQuery = redactDebugQuery(redacted.RawQuery, sensitive)
 	return redacted.Redacted()
 }
@@ -112,12 +117,12 @@ func isSensitiveDebugQueryName(name string) bool {
 	return false
 }
 
-func redactDebugURLString(raw string, sensitive map[string]bool) string {
+func redactDebugURLString(raw string, sensitive map[string]bool, sensitivePath bool) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		return "<invalid URL>"
 	}
-	return redactDebugURL(parsed, sensitive)
+	return redactDebugURL(parsed, sensitive, sensitivePath)
 }
 
 type bodyReader struct {
@@ -139,9 +144,9 @@ func isTextContent(ct string) bool {
 	return false
 }
 
-func redactDebugHeader(name, value string, sensitive map[string]bool) string {
+func redactDebugHeader(name, value string, sensitive map[string]bool, sensitivePath bool) string {
 	if strings.EqualFold(name, "location") || strings.EqualFold(name, "content-location") {
-		return redactDebugURLString(value, sensitive)
+		return redactDebugURLString(value, sensitive, sensitivePath)
 	}
 	if isSensitiveDebugName(name) {
 		return "***"
@@ -267,7 +272,7 @@ func isDebugEnvVarContainer(name string) bool {
 func redactDebugText(s string) string {
 	s = redactAuthorization(s)
 	s = debugURLPattern.ReplaceAllStringFunc(s, func(raw string) string {
-		return redactDebugURLString(raw, nil)
+		return redactDebugURLString(raw, nil, false)
 	})
 	matches := debugAssignmentPrefix.FindAllStringIndex(s, -1)
 	for i := len(matches) - 1; i >= 0; i-- {

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -19,7 +19,7 @@ const (
 	maxDebugRespBody = 4096
 )
 
-var bearerPattern = regexp.MustCompile(`(?i)\bBearer[ \t]+[A-Za-z0-9._~+/=-]+`)
+var authorizationPattern = regexp.MustCompile(`(?i)\b(Basic|Bearer)[ \t]+[A-Za-z0-9._~+/=-]+`)
 
 type debugTransport struct {
 	inner                http.RoundTripper
@@ -235,8 +235,8 @@ func redactDebugJSONAt(v any, path []string) bool {
 	}
 }
 
-func redactBearer(s string) string {
-	return bearerPattern.ReplaceAllString(s, "Bearer ***")
+func redactAuthorization(s string) string {
+	return authorizationPattern.ReplaceAllString(s, "$1 ***")
 }
 
 func isDebugEnvVarPair(path []string, v map[string]any) bool {
@@ -254,7 +254,7 @@ func isDebugEnvVarContainer(name string) bool {
 }
 
 func redactDebugText(s string) string {
-	s = redactBearer(s)
+	s = redactAuthorization(s)
 	fields := strings.FieldsFunc(s, func(r rune) bool {
 		return r == '&' || r == ';' || r == '\n' || r == '\r'
 	})

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -247,8 +247,15 @@ func isDebugEnvVarPair(path []string, v map[string]any) bool {
 	if len(path) == 0 || !isDebugEnvVarContainer(path[len(path)-1]) {
 		return false
 	}
-	_, hasKey := v["key"]
-	_, hasValue := v["value"]
+	var hasKey, hasValue bool
+	for name := range v {
+		switch strings.ToLower(name) {
+		case "key", "name":
+			hasKey = true
+		case "value":
+			hasValue = true
+		}
+	}
 	return hasKey && hasValue
 }
 

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -22,6 +22,7 @@ const (
 var (
 	authorizationPattern  = regexp.MustCompile(`(?i)\b(Basic|Bearer)[ \t]+[A-Za-z0-9._~+/=-]+`)
 	debugAssignmentPrefix = regexp.MustCompile(`[[:alnum:]_.-]+[ \t]*[=:][ \t]*`)
+	debugURLPattern       = regexp.MustCompile(`(?i)\b[a-z][a-z0-9+.-]*://[^\s"'<>]+`)
 )
 
 type debugTransport struct {
@@ -258,6 +259,9 @@ func isDebugEnvVarContainer(name string) bool {
 
 func redactDebugText(s string) string {
 	s = redactAuthorization(s)
+	s = debugURLPattern.ReplaceAllStringFunc(s, func(raw string) string {
+		return redactDebugURLString(raw, nil)
+	})
 	matches := debugAssignmentPrefix.FindAllStringIndex(s, -1)
 	for i := len(matches) - 1; i >= 0; i-- {
 		start, valueStart := matches[i][0], matches[i][1]

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -202,7 +202,7 @@ func redactDebugJSONAt(v any, path []string) bool {
 				continue
 			}
 			if text, ok := child.(string); ok {
-				redacted := redactBearer(text)
+				redacted := redactDebugText(text)
 				if redacted != text {
 					tv[k] = redacted
 					changed = true
@@ -218,7 +218,7 @@ func redactDebugJSONAt(v any, path []string) bool {
 		changed := false
 		for i, child := range tv {
 			if text, ok := child.(string); ok {
-				redacted := redactBearer(text)
+				redacted := redactDebugText(text)
 				if redacted != text {
 					tv[i] = redacted
 					changed = true

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -259,11 +259,15 @@ func redactDebugText(s string) string {
 		return r == '&' || r == ';' || r == '\n' || r == '\r'
 	})
 	for _, field := range fields {
-		name, value, ok := strings.Cut(field, "=")
-		if !ok || !isSensitiveDebugName(strings.TrimSpace(name)) || value == "" {
+		separator := strings.IndexAny(field, "=:")
+		if separator < 0 || separator == len(field)-1 {
 			continue
 		}
-		s = strings.ReplaceAll(s, field, name+"=***")
+		name := field[:separator]
+		if !isSensitiveDebugName(strings.TrimSpace(name)) {
+			continue
+		}
+		s = strings.ReplaceAll(s, field, name+field[separator:separator+1]+"***")
 	}
 	return s
 }

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -19,7 +19,10 @@ const (
 	maxDebugRespBody = 4096
 )
 
-var authorizationPattern = regexp.MustCompile(`(?i)\b(Basic|Bearer)[ \t]+[A-Za-z0-9._~+/=-]+`)
+var (
+	authorizationPattern  = regexp.MustCompile(`(?i)\b(Basic|Bearer)[ \t]+[A-Za-z0-9._~+/=-]+`)
+	debugAssignmentPrefix = regexp.MustCompile(`[[:alnum:]_.-]+[ \t]*[=:][ \t]*`)
+)
 
 type debugTransport struct {
 	inner                http.RoundTripper
@@ -255,19 +258,19 @@ func isDebugEnvVarContainer(name string) bool {
 
 func redactDebugText(s string) string {
 	s = redactAuthorization(s)
-	fields := strings.FieldsFunc(s, func(r rune) bool {
-		return r == '&' || r == ';' || r == '\n' || r == '\r'
-	})
-	for _, field := range fields {
-		separator := strings.IndexAny(field, "=:")
-		if separator < 0 || separator == len(field)-1 {
+	matches := debugAssignmentPrefix.FindAllStringIndex(s, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		start, valueStart := matches[i][0], matches[i][1]
+		prefix := s[start:valueStart]
+		separator := strings.IndexAny(prefix, "=:")
+		if separator < 0 || !isSensitiveDebugName(strings.TrimSpace(prefix[:separator])) {
 			continue
 		}
-		name := field[:separator]
-		if !isSensitiveDebugName(strings.TrimSpace(name)) {
-			continue
+		valueEnd := len(s)
+		if boundary := strings.IndexAny(s[valueStart:], "&;\n\r"); boundary >= 0 {
+			valueEnd = valueStart + boundary
 		}
-		s = strings.ReplaceAll(s, field, name+field[separator:separator+1]+"***")
+		s = s[:valueStart] + "***" + s[valueEnd:]
 	}
 	return s
 }

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -17,6 +18,8 @@ const (
 	maxDebugReqBody  = 1024
 	maxDebugRespBody = 4096
 )
+
+var bearerPattern = regexp.MustCompile(`(?i)\bBearer[ \t]+[A-Za-z0-9._~+/=-]+`)
 
 type debugTransport struct {
 	inner                http.RoundTripper
@@ -198,6 +201,14 @@ func redactDebugJSONAt(v any, path []string) bool {
 				changed = true
 				continue
 			}
+			if text, ok := child.(string); ok {
+				redacted := redactBearer(text)
+				if redacted != text {
+					tv[k] = redacted
+					changed = true
+				}
+				continue
+			}
 			if redactDebugJSONAt(child, append(path, k)) {
 				changed = true
 			}
@@ -205,7 +216,15 @@ func redactDebugJSONAt(v any, path []string) bool {
 		return changed
 	case []any:
 		changed := false
-		for _, child := range tv {
+		for i, child := range tv {
+			if text, ok := child.(string); ok {
+				redacted := redactBearer(text)
+				if redacted != text {
+					tv[i] = redacted
+					changed = true
+				}
+				continue
+			}
 			if redactDebugJSONAt(child, path) {
 				changed = true
 			}
@@ -214,6 +233,10 @@ func redactDebugJSONAt(v any, path []string) bool {
 	default:
 		return false
 	}
+}
+
+func redactBearer(s string) string {
+	return bearerPattern.ReplaceAllString(s, "Bearer ***")
 }
 
 func isDebugEnvVarPair(path []string, v map[string]any) bool {
@@ -231,6 +254,7 @@ func isDebugEnvVarContainer(name string) bool {
 }
 
 func redactDebugText(s string) string {
+	s = redactBearer(s)
 	fields := strings.FieldsFunc(s, func(r rune) bool {
 		return r == '&' || r == ';' || r == '\n' || r == '\r'
 	})

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -131,14 +131,14 @@ func TestDebugTransport_RedactsQueryCredentials(t *testing.T) {
 func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"result":"ok","message":"Bearer response-bearer","token":"response-token","nested":{"apiKey":"response-key"}}`))
+		w.Write([]byte(`{"result":"ok","message":"token=response-message-secret; Bearer response-bearer","token":"response-token","nested":{"apiKey":"response-key"}}`))
 	}))
 	defer srv.Close()
 
 	r := captureStderr(t)
 
 	dt := &debugTransport{inner: http.DefaultTransport}
-	body := strings.NewReader(`{"name":"test","message":"bearer request-bearer","secret":"request-secret","nested":{"password":"request-password"}}`)
+	body := strings.NewReader(`{"name":"test","message":"token=request-message-secret; bearer request-bearer","secret":"request-secret","nested":{"password":"request-password"}}`)
 	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := dt.RoundTrip(req)
@@ -148,7 +148,7 @@ func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
 	resp.Body.Close()
 
 	out := readStderr(t, r)
-	for _, leaked := range []string{"request-secret", "request-password", "request-bearer", "response-token", "response-key", "response-bearer"} {
+	for _, leaked := range []string{"request-secret", "request-password", "request-message-secret", "request-bearer", "response-token", "response-key", "response-message-secret", "response-bearer"} {
 		if strings.Contains(out, leaked) {
 			t.Fatalf("debug body leaked %q:\n%s", leaked, out)
 		}

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -131,14 +131,14 @@ func TestDebugTransport_RedactsQueryCredentials(t *testing.T) {
 func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"result":"ok","token":"response-token","nested":{"apiKey":"response-key"}}`))
+		w.Write([]byte(`{"result":"ok","message":"Bearer response-bearer","token":"response-token","nested":{"apiKey":"response-key"}}`))
 	}))
 	defer srv.Close()
 
 	r := captureStderr(t)
 
 	dt := &debugTransport{inner: http.DefaultTransport}
-	body := strings.NewReader(`{"name":"test","secret":"request-secret","nested":{"password":"request-password"}}`)
+	body := strings.NewReader(`{"name":"test","message":"bearer request-bearer","secret":"request-secret","nested":{"password":"request-password"}}`)
 	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := dt.RoundTrip(req)
@@ -148,7 +148,7 @@ func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
 	resp.Body.Close()
 
 	out := readStderr(t, r)
-	for _, leaked := range []string{"request-secret", "request-password", "response-token", "response-key"} {
+	for _, leaked := range []string{"request-secret", "request-password", "request-bearer", "response-token", "response-key", "response-bearer"} {
 		if strings.Contains(out, leaked) {
 			t.Fatalf("debug body leaked %q:\n%s", leaked, out)
 		}

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -1,13 +1,15 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -16,6 +18,7 @@ const (
 	ExitUsage            = 2
 	ExitAPIError         = 3
 	ExitNotAuthenticated = 4
+	ExitCanceled         = 130
 )
 
 const (
@@ -23,13 +26,19 @@ const (
 	CodeUsage            = "usage"
 	CodeAPIError         = "api_error"
 	CodeNotAuthenticated = "not_authenticated"
+	CodeCanceled         = "canceled"
 )
 
 type LatheError struct {
-	Code     string `json:"code"`
-	Message  string `json:"message"`
-	ExitCode int    `json:"-"`
-	cause    error
+	Code       string `json:"code" yaml:"code"`
+	Message    string `json:"message" yaml:"message"`
+	Hint       string `json:"hint,omitempty" yaml:"hint,omitempty"`
+	HTTPStatus int    `json:"http_status,omitempty" yaml:"http_status,omitempty"`
+	Method     string `json:"method,omitempty" yaml:"method,omitempty"`
+	URL        string `json:"url,omitempty" yaml:"url,omitempty"`
+	ServerBody string `json:"server_body,omitempty" yaml:"server_body,omitempty"`
+	ExitCode   int    `json:"-" yaml:"-"`
+	cause      error
 }
 
 func (e *LatheError) Error() string {
@@ -57,18 +66,33 @@ func ClassifyError(err error) *LatheError {
 	if errors.As(err, &le) {
 		return le
 	}
+	if errors.Is(err, context.Canceled) {
+		return &LatheError{
+			Code: CodeCanceled, Message: "operation canceled", ExitCode: ExitCanceled, cause: err,
+		}
+	}
 	if errors.Is(err, ErrNotAuthenticated) {
 		return NewLatheError(CodeNotAuthenticated, ExitNotAuthenticated, err)
 	}
 	var he *HTTPError
 	if errors.As(err, &he) {
-		return NewLatheError(CodeAPIError, ExitAPIError, err)
+		return &LatheError{
+			Code:       CodeAPIError,
+			Message:    fmt.Sprintf("request failed with HTTP %d", he.Status),
+			Hint:       "run again with --debug to inspect a redacted server response",
+			HTTPStatus: he.Status,
+			Method:     he.Method,
+			URL:        he.URL,
+			ServerBody: safeHTTPServerBody(he.Body),
+			ExitCode:   ExitAPIError,
+			cause:      err,
+		}
 	}
 	return NewLatheError(CodeGeneral, ExitGeneral, err)
 }
 
 type jsonErrorEnvelope struct {
-	Error LatheError `json:"error"`
+	Error LatheError `json:"error" yaml:"error"`
 }
 
 type silentExitError interface {
@@ -80,18 +104,35 @@ func FormatError(err error, format string, w io.Writer) int {
 	if le == nil {
 		return ExitOK
 	}
-	if format == "json" {
+	switch format {
+	case "json":
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
 		_ = enc.Encode(jsonErrorEnvelope{Error: *le})
-	} else {
+	case "yaml", "yml":
+		enc := yaml.NewEncoder(w)
+		enc.SetIndent(2)
+		_ = enc.Encode(jsonErrorEnvelope{Error: *le})
+	default:
 		fmt.Fprintln(w, "Error:", le.Message)
+		if le.Hint != "" {
+			fmt.Fprintln(w, "hint:", le.Hint)
+		}
+		if le.Method != "" && le.URL != "" {
+			fmt.Fprintf(w, "request: %s %s\n", le.Method, le.URL)
+		}
+		if le.HTTPStatus != 0 {
+			fmt.Fprintln(w, "http_status:", le.HTTPStatus)
+		}
 	}
 	return le.ExitCode
 }
 
 func Execute(cmd *cobra.Command) int {
 	cmd.SilenceErrors = true
+	cmd.SetFlagErrorFunc(func(active *cobra.Command, err error) error {
+		return newUsageError(active, err)
+	})
 	err := cmd.Execute()
 	if err == nil {
 		return ExitOK
@@ -101,5 +142,27 @@ func Execute(cmd *cobra.Command) int {
 		return silent.SilentExitCode()
 	}
 	format, _ := cmd.PersistentFlags().GetString("output")
-	return FormatError(err, format, os.Stderr)
+	return FormatError(err, format, cmd.ErrOrStderr())
+}
+
+func newUsageError(cmd *cobra.Command, cause error) *LatheError {
+	path := strings.TrimSpace(cmd.CommandPath())
+	if path == "" {
+		path = cmd.Name()
+	}
+	err := NewLatheError(CodeUsage, ExitUsage, cause)
+	err.Hint = fmt.Sprintf("run '%s --help'", path)
+	return err
+}
+
+func safeHTTPServerBody(body []byte) string {
+	if !json.Valid(body) {
+		return ""
+	}
+	const maxRunes = 1024
+	redacted := []rune(strings.TrimSpace(string(redactDebugBody("application/json", body))))
+	if len(redacted) > maxRunes {
+		return string(redacted[:maxRunes]) + "…"
+	}
+	return string(redacted)
 }

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,10 +42,10 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"token=***; Bearer ***; Basic ***","error":"invalid input","token":"***"}` {
+	if le.ServerBody != `{"detail":"token=***; secret:***; Bearer ***; Basic ***","error":"invalid input","token":"***"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "body-bearer") || strings.Contains(le.ServerBody, "Ym9keTpiYXNpYw") {
+	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "colon-secret") || strings.Contains(le.ServerBody, "body-bearer") || strings.Contains(le.ServerBody, "Ym9keTpiYXNpYw") {
 		t.Fatalf("classified error leaked server secret: %+v", le)
 	}
 	if strings.Contains(err.Error(), "server-secret") {

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"Bearer body-secret","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; Bearer body-bearer","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,10 +42,10 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"Bearer ***","error":"invalid input","token":"***"}` {
+	if le.ServerBody != `{"detail":"token=***; Bearer ***","error":"invalid input","token":"***"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") {
+	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "body-bearer") {
 		t.Fatalf("classified error leaked server secret: %+v", le)
 	}
 	if strings.Contains(err.Error(), "server-secret") {

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","prefixed":"request failed: token=prefixed-secret","url":"https://example.test?token=url-secret","userinfo":"request to https://alice:userinfo-secret@example.test failed","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","env":[{"name":"API_TOKEN","value":"env-secret"}],"prefixed":"request failed: token=prefixed-secret","url":"https://example.test?token=url-secret","userinfo":"request to https://alice:userinfo-secret@example.test failed","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,10 +42,10 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"token=***; secret: ***; Bearer ***; Basic ***","error":"invalid input","prefixed":"request failed: token=***","token":"***","url":"https://example.test?token=***","userinfo":"request to https://alice:xxxxx@example.test failed"}` {
+	if le.ServerBody != `{"detail":"token=***; secret: ***; Bearer ***; Basic ***","env":[{"name":"API_TOKEN","value":"***"}],"error":"invalid input","prefixed":"request failed: token=***","token":"***","url":"https://example.test?token=***","userinfo":"request to https://alice:xxxxx@example.test failed"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	for _, secret := range []string{"server-secret", "body-secret", "colon-secret", "body-bearer", "Ym9keTpiYXNpYw", "prefixed-secret", "url-secret", "userinfo-secret"} {
+	for _, secret := range []string{"server-secret", "body-secret", "colon-secret", "body-bearer", "Ym9keTpiYXNpYw", "env-secret", "prefixed-secret", "url-secret", "userinfo-secret"} {
 		if strings.Contains(le.Message+le.ServerBody, secret) {
 			t.Fatalf("classified error leaked %q: %+v", secret, le)
 		}

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","prefixed":"request failed: token=prefixed-secret","url":"https://example.test?token=url-secret","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,11 +42,13 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"token=***; secret:***; Bearer ***; Basic ***","error":"invalid input","token":"***"}` {
+	if le.ServerBody != `{"detail":"token=***; secret: ***; Bearer ***; Basic ***","error":"invalid input","prefixed":"request failed: token=***","token":"***","url":"https://example.test?token=***"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "colon-secret") || strings.Contains(le.ServerBody, "body-bearer") || strings.Contains(le.ServerBody, "Ym9keTpiYXNpYw") {
-		t.Fatalf("classified error leaked server secret: %+v", le)
+	for _, secret := range []string{"server-secret", "body-secret", "colon-secret", "body-bearer", "Ym9keTpiYXNpYw", "prefixed-secret", "url-secret"} {
+		if strings.Contains(le.Message+le.ServerBody, secret) {
+			t.Fatalf("classified error leaked %q: %+v", secret, le)
+		}
 	}
 	if strings.Contains(err.Error(), "server-secret") {
 		t.Fatalf("HTTPError.Error leaked response body: %q", err.Error())

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func TestClassifyError_Nil(t *testing.T) {
@@ -29,13 +31,41 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 500, Body: []byte("fail")}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"Bearer body-secret","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
 	}
 	if le.ExitCode != ExitAPIError {
 		t.Errorf("exit = %d, want %d", le.ExitCode, ExitAPIError)
+	}
+	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
+		t.Errorf("HTTP context = %+v", le)
+	}
+	if le.ServerBody != `{"detail":"Bearer ***","error":"invalid input","token":"***"}` {
+		t.Errorf("server body = %q", le.ServerBody)
+	}
+	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") {
+		t.Fatalf("classified error leaked server secret: %+v", le)
+	}
+	if strings.Contains(err.Error(), "server-secret") {
+		t.Fatalf("HTTPError.Error leaked response body: %q", err.Error())
+	}
+
+	large := ClassifyError(&HTTPError{Status: 500, Body: []byte(`{"message":"` + strings.Repeat("x", 2048) + `"}`)})
+	if len([]rune(large.ServerBody)) > 1025 {
+		t.Fatalf("server body is not bounded: %d runes", len([]rune(large.ServerBody)))
+	}
+	plain := ClassifyError(&HTTPError{Status: 500, Body: []byte("token=server-secret")})
+	if plain.ServerBody != "" {
+		t.Fatalf("non-JSON server body was exposed: %q", plain.ServerBody)
+	}
+}
+
+func TestClassifyError_Canceled(t *testing.T) {
+	le := ClassifyError(fmt.Errorf("request stopped: %w", context.Canceled))
+	if le.Code != CodeCanceled || le.ExitCode != ExitCanceled {
+		t.Fatalf("classified canceled error = %+v", le)
 	}
 }
 
@@ -59,19 +89,39 @@ func TestClassifyError_Generic(t *testing.T) {
 
 func TestFormatError_JSON(t *testing.T) {
 	var buf bytes.Buffer
-	code := FormatError(errors.New("oops"), "json", &buf)
-	if code != ExitGeneral {
-		t.Errorf("exit = %d, want %d", code, ExitGeneral)
+	err := NewLatheError(CodeUsage, ExitUsage, errors.New("missing id"))
+	err.Hint = "run 'demo show --help'"
+	code := FormatError(err, "json", &buf)
+	if code != ExitUsage {
+		t.Errorf("exit = %d, want %d", code, ExitUsage)
 	}
 	var env jsonErrorEnvelope
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
 	}
-	if env.Error.Code != CodeGeneral {
-		t.Errorf("json code = %q, want %q", env.Error.Code, CodeGeneral)
+	if env.Error.Code != CodeUsage {
+		t.Errorf("json code = %q, want %q", env.Error.Code, CodeUsage)
 	}
-	if env.Error.Message != "oops" {
-		t.Errorf("json message = %q, want %q", env.Error.Message, "oops")
+	if env.Error.Message != "missing id" || env.Error.Hint != "run 'demo show --help'" {
+		t.Errorf("json error = %+v", env.Error)
+	}
+}
+
+func TestFormatError_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	err := NewLatheError(CodeNotAuthenticated, ExitNotAuthenticated, errors.New("not authenticated"))
+	err.Hint = "run 'demo auth login'"
+	if code := FormatError(err, "yaml", &buf); code != ExitNotAuthenticated {
+		t.Fatalf("exit = %d, want %d", code, ExitNotAuthenticated)
+	}
+	var env struct {
+		Error LatheError `yaml:"error"`
+	}
+	if err := yaml.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, buf.String())
+	}
+	if env.Error.Code != CodeNotAuthenticated || env.Error.Hint != "run 'demo auth login'" {
+		t.Fatalf("yaml error = %+v", env.Error)
 	}
 }
 
@@ -124,5 +174,25 @@ func TestExecuteSilentExitError(t *testing.T) {
 	}
 	if code := Execute(cmd); code != ExitUsage {
 		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+}
+
+func TestExecuteClassifiesFlagErrors(t *testing.T) {
+	cmd := &cobra.Command{Use: "demo", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.PersistentFlags().StringP("output", "o", "table", "")
+	cmd.Flags().Int("count", 0, "")
+	cmd.SetArgs([]string{"-o", "json", "--count", "nope"})
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	if code := Execute(cmd); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d; stderr = %q", code, ExitUsage, stderr.String())
+	}
+	var env jsonErrorEnvelope
+	if err := json.Unmarshal(stderr.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON error: %v\n%s", err, stderr.String())
+	}
+	if env.Error.Code != CodeUsage || !strings.Contains(env.Error.Hint, "demo --help") {
+		t.Fatalf("error = %+v", env.Error)
 	}
 }

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; Bearer body-bearer","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,10 +42,10 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"token=***; Bearer ***","error":"invalid input","token":"***"}` {
+	if le.ServerBody != `{"detail":"token=***; Bearer ***; Basic ***","error":"invalid input","token":"***"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "body-bearer") {
+	if strings.Contains(le.Message+le.ServerBody, "server-secret") || strings.Contains(le.ServerBody, "body-secret") || strings.Contains(le.ServerBody, "body-bearer") || strings.Contains(le.ServerBody, "Ym9keTpiYXNpYw") {
 		t.Fatalf("classified error leaked server secret: %+v", le)
 	}
 	if strings.Contains(err.Error(), "server-secret") {

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -31,7 +31,7 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","prefixed":"request failed: token=prefixed-secret","url":"https://example.test?token=url-secret","token":"server-secret"}`)}
+	err := &HTTPError{Method: "GET", URL: "/x", Status: 422, Body: []byte(`{"error":"invalid input","detail":"token=body-secret; secret: colon-secret; Bearer body-bearer; Basic Ym9keTpiYXNpYw==","prefixed":"request failed: token=prefixed-secret","url":"https://example.test?token=url-secret","userinfo":"request to https://alice:userinfo-secret@example.test failed","token":"server-secret"}`)}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
@@ -42,10 +42,10 @@ func TestClassifyError_HTTPError(t *testing.T) {
 	if le.HTTPStatus != 422 || le.Method != "GET" || le.URL != "/x" {
 		t.Errorf("HTTP context = %+v", le)
 	}
-	if le.ServerBody != `{"detail":"token=***; secret: ***; Bearer ***; Basic ***","error":"invalid input","prefixed":"request failed: token=***","token":"***","url":"https://example.test?token=***"}` {
+	if le.ServerBody != `{"detail":"token=***; secret: ***; Bearer ***; Basic ***","error":"invalid input","prefixed":"request failed: token=***","token":"***","url":"https://example.test?token=***","userinfo":"request to https://alice:xxxxx@example.test failed"}` {
 		t.Errorf("server body = %q", le.ServerBody)
 	}
-	for _, secret := range []string{"server-secret", "body-secret", "colon-secret", "body-bearer", "Ym9keTpiYXNpYw", "prefixed-secret", "url-secret"} {
+	for _, secret := range []string{"server-secret", "body-secret", "colon-secret", "body-bearer", "Ym9keTpiYXNpYw", "prefixed-secret", "url-secret", "userinfo-secret"} {
 		if strings.Contains(le.Message+le.ServerBody, secret) {
 			t.Fatalf("classified error leaked %q: %+v", secret, le)
 		}

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -240,16 +240,20 @@ func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, 
 	switch {
 	case len(input.BodySets) > 0 || len(input.BodyStringSets) > 0:
 		if !supportsJSONBodyBuilder(s.RequestBody.MediaType) {
-			return nil, fmt.Errorf("request body media type %s requires --file; --set and --set-str only support JSON request bodies", s.RequestBody.MediaType)
+			return nil, NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("request body media type %s requires --file; --set and --set-str only support JSON request bodies", s.RequestBody.MediaType))
 		}
-		return buildBodyFromSet(input.BodySets, input.BodyStringSets)
+		body, err := buildBodyFromSet(input.BodySets, input.BodyStringSets)
+		if err != nil {
+			return nil, NewLatheError(CodeUsage, ExitUsage, err)
+		}
+		return body, nil
 	case input.HasFile:
 		return input.FileBody, nil
 	case s.RequestBody.Required:
 		if !supportsJSONBodyBuilder(s.RequestBody.MediaType) {
-			return nil, fmt.Errorf("request body media type %s requires --file", s.RequestBody.MediaType)
+			return nil, NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("request body media type %s requires --file", s.RequestBody.MediaType))
 		}
-		return nil, fmt.Errorf("request body required: pass --file, --set, or --set-str")
+		return nil, NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("request body required: pass --file, --set, or --set-str"))
 	default:
 		return nil, nil
 	}

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -140,6 +140,9 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 				continue
 			}
 			path = strings.Replace(path, "{"+p.Name+"}", url.PathEscape(operationStringValue(v)), 1)
+			if isSensitiveStringParam(p) {
+				clientOpts.sensitivePath = true
+			}
 			continue
 		case InHeader:
 			if !operationChanged(input, p) {
@@ -282,7 +285,7 @@ func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path strin
 	}
 	return DryRunRequest{
 		Method:  req.Method,
-		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams),
+		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams, opts.sensitivePath),
 		Headers: redactedDryRunHeaders(req.Header),
 		Body:    redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
 		Auth:    dryRunAuthForSpec(s),

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -301,7 +301,7 @@ func validateRequiredOperationParams(s CommandSpec, input OperationInput) error 
 			continue
 		}
 		if !operationChanged(input, p) {
-			return fmt.Errorf("required param %q missing", p.Name)
+			return NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("required param %q missing", p.Name))
 		}
 	}
 	return nil
@@ -314,7 +314,7 @@ func validateOperationEnums(s CommandSpec, input OperationInput) error {
 		}
 		v, _, err := operationValue(input, p)
 		if err != nil {
-			return err
+			return NewLatheError(CodeUsage, ExitUsage, err)
 		}
 		raw := operationStringValue(v)
 		valid := false
@@ -325,7 +325,7 @@ func validateOperationEnums(s CommandSpec, input OperationInput) error {
 			}
 		}
 		if !valid {
-			return fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", "))
+			return NewLatheError(CodeUsage, ExitUsage, fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", ")))
 		}
 	}
 	return nil

--- a/pkg/runtime/output.go
+++ b/pkg/runtime/output.go
@@ -12,11 +12,18 @@ func FormatOutput(data []byte, format string, w io.Writer, hints OutputHints) er
 	if len(data) == 0 {
 		return nil
 	}
-	f, ok := formatters[format]
-	if !ok {
+	if err := validateOutputFormat(format); err != nil {
+		return err
+	}
+	f := formatters[format]
+	return f.Format(w, data, hints)
+}
+
+func validateOutputFormat(format string) error {
+	if _, ok := formatters[format]; !ok {
 		return fmt.Errorf("unknown output format: %s (supported: table|json|yaml|raw)", format)
 	}
-	return f.Format(w, data, hints)
+	return nil
 }
 
 func renderJSON(data []byte, w io.Writer) error {

--- a/pkg/runtime/poll.go
+++ b/pkg/runtime/poll.go
@@ -42,7 +42,7 @@ func PollUntilDone(ctx context.Context, hostname, location string, opts ClientOp
 	}
 	opts.checkRedirect = func(req *http.Request, _ []*http.Request) error {
 		if !strings.EqualFold(req.URL.Scheme, baseURL.Scheme) || !strings.EqualFold(req.URL.Hostname(), baseURL.Hostname()) || port(req.URL) != port(baseURL) {
-			return fmt.Errorf("cross-host polling redirect %q", redactDebugURL(req.URL, opts.sensitiveQueryParams))
+			return fmt.Errorf("cross-host polling redirect %q", redactDebugURL(req.URL, opts.sensitiveQueryParams, opts.sensitivePath))
 		}
 		return nil
 	}
@@ -56,11 +56,11 @@ func PollUntilDone(ctx context.Context, hostname, location string, opts ClientOp
 
 		loc, err := url.Parse(location)
 		if err != nil {
-			return nil, fmt.Errorf("parse polling location: %w", redactClientError(err, opts.sensitiveQueryParams))
+			return nil, fmt.Errorf("parse polling location: %w", redactClientError(err, opts.sensitiveQueryParams, opts.sensitivePath))
 		}
 		resolved := baseURL.ResolveReference(loc)
 		if !strings.EqualFold(resolved.Scheme, baseURL.Scheme) || !strings.EqualFold(resolved.Hostname(), baseURL.Hostname()) || port(resolved) != port(baseURL) {
-			return nil, fmt.Errorf("cross-host polling location %q", redactDebugURLString(location, opts.sensitiveQueryParams))
+			return nil, fmt.Errorf("cross-host polling location %q", redactDebugURLString(location, opts.sensitiveQueryParams, opts.sensitivePath))
 		}
 		location = resolved.RequestURI()
 		r, err := DoRawFull(ctx, hostname, "GET", location, nil, opts)

--- a/pkg/runtime/retry.go
+++ b/pkg/runtime/retry.go
@@ -36,7 +36,13 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			if t.sleepFn != nil {
 				t.sleepFn(wait)
 			} else {
-				time.Sleep(wait)
+				timer := time.NewTimer(wait)
+				select {
+				case <-timer.C:
+				case <-req.Context().Done():
+					timer.Stop()
+					return nil, req.Context().Err()
+				}
 			}
 			if req.GetBody != nil {
 				req.Body, err = req.GetBody()

--- a/pkg/runtime/retry_test.go
+++ b/pkg/runtime/retry_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -208,6 +209,40 @@ func TestRetryTransport_RespectsRetryAfter(t *testing.T) {
 	resp.Body.Close()
 	if slept != 7*time.Second {
 		t.Errorf("slept = %v, want 7s (Retry-After)", slept)
+	}
+}
+
+func TestRetryTransport_CancelInterruptsBackoff(t *testing.T) {
+	started := make(chan struct{})
+	rt := &retryTransport{
+		inner: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			close(started)
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Status:     "429 Too Many Requests",
+				Header:     http.Header{"Retry-After": []string{"300"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+		maxRetries: 1,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+	done := make(chan error, 1)
+	go func() {
+		_, err := rt.RoundTrip(req)
+		done <- err
+	}()
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RoundTrip error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RoundTrip remained blocked in retry backoff")
 	}
 }
 

--- a/pkg/runtime/stream.go
+++ b/pkg/runtime/stream.go
@@ -235,7 +235,7 @@ func streamEventError(event string, payload any) error {
 	for _, path := range []string{"message", "error"} {
 		if value, ok := getNestedPath(payload, path); ok {
 			if text, ok := value.(string); ok && text != "" {
-				return fmt.Errorf("stream event %q: %s", event, text)
+				return fmt.Errorf("stream event %q: %s", event, redactDebugText(text))
 			}
 		}
 	}

--- a/pkg/runtime/stream_test.go
+++ b/pkg/runtime/stream_test.go
@@ -120,8 +120,11 @@ func TestCollectStream_RejectsMissingRequiredStop(t *testing.T) {
 
 	hint.Policy.Collect.RequireStop = false
 	hint.Policy.Collect.ErrorEvents = []string{"failed"}
-	_, err := collectStream(strings.NewReader("{\"kind\":\"failed\",\"message\":\"run failed\"}\n"), hint, nil, &outcome)
+	_, err := collectStream(strings.NewReader("{\"kind\":\"failed\",\"message\":\"run failed; token=stream-secret; Bearer stream-bearer\"}\n"), hint, nil, &outcome)
 	if classified := ClassifyError(err); classified == nil || classified.ExitCode != ExitAPIError {
 		t.Fatalf("error = %v, classified = %#v", err, classified)
+	}
+	if strings.Contains(err.Error(), "stream-secret") || strings.Contains(err.Error(), "stream-bearer") {
+		t.Fatalf("stream error leaked server secret: %v", err)
 	}
 }

--- a/pkg/runtime/stream_test.go
+++ b/pkg/runtime/stream_test.go
@@ -120,11 +120,11 @@ func TestCollectStream_RejectsMissingRequiredStop(t *testing.T) {
 
 	hint.Policy.Collect.RequireStop = false
 	hint.Policy.Collect.ErrorEvents = []string{"failed"}
-	_, err := collectStream(strings.NewReader("{\"kind\":\"failed\",\"message\":\"run failed; token=stream-secret; Bearer stream-bearer\"}\n"), hint, nil, &outcome)
+	_, err := collectStream(strings.NewReader("{\"kind\":\"failed\",\"message\":\"run failed; token=stream-secret; Bearer stream-bearer; Basic c3RyZWFtOmJhc2lj\"}\n"), hint, nil, &outcome)
 	if classified := ClassifyError(err); classified == nil || classified.ExitCode != ExitAPIError {
 		t.Fatalf("error = %v, classified = %#v", err, classified)
 	}
-	if strings.Contains(err.Error(), "stream-secret") || strings.Contains(err.Error(), "stream-bearer") {
+	if strings.Contains(err.Error(), "stream-secret") || strings.Contains(err.Error(), "stream-bearer") || strings.Contains(err.Error(), "c3RyZWFtOmJhc2lj") {
 		t.Fatalf("stream error leaked server secret: %v", err)
 	}
 }

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -75,6 +75,10 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if err := validateOutputFormat(format); err != nil {
+				return newUsageError(cmd, err)
+			}
 			if err := resolveSafeInputFlags(cmd, spec.Params, vals); err != nil {
 				return newUsageError(cmd, err)
 			}
@@ -99,7 +103,6 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 					return marshalErr
 				}
 			}
-			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			return FormatOutput(data, format, cmd.OutOrStdout(), spec.Output)
 		},
 	}

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -68,19 +68,25 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 		Long:    spec.Long,
 		Example: spec.Example,
 		Hidden:  spec.Hidden,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return newUsageError(cmd, err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := resolveSafeInputFlags(cmd, spec.Params, vals); err != nil {
-				return err
+				return newUsageError(cmd, err)
 			}
 			changed := operationChangedFlags(cmd, spec.Params)
 			if err := validateRequiredParams(spec.Params, false, changed); err != nil {
-				return err
+				return newUsageError(cmd, err)
 			}
 			if err := validateOperationEnums(CommandSpec{Params: spec.Params}, OperationInput{
 				Values:  vals,
 				Changed: changed,
 			}); err != nil {
-				return err
+				return newUsageError(cmd, err)
 			}
 			result, data, err := executeWorkflow(cmd, spec, vals)
 			if err != nil {


### PR DESCRIPTION
## Summary

- emit one stable error envelope for JSON and YAML with typed codes, actionable hints, and bounded redacted HTTP context
- classify generated-command usage, authentication, API, and cancellation failures while preserving collected stream pauses as successful outcomes
- reuse the runtime redaction boundary for HTTP and declared stream errors, and teach generated Skills how to branch on the contract

## Verification

- `go test ./pkg/runtime -run 'Test(CollectStream_RejectsMissingRequiredStop|ClassifyError_HTTPError|ClassifyError_Canceled|FormatError_JSON|FormatError_YAML|ExecuteClassifiesFlagErrors|DebugTransport_RedactsSensitiveJSONBodies|Build_RequiredQueryParamBlocksBeforeRequest|NewNotAuthenticatedError_WrapsSentinel)$' -count=50`
- `go test ./internal/codegen/render -run 'TestRenderSkillDirectory_GeneratesSkillStructure$' -count=50`
- `make check`
- `go test -race ./...`
- generated CLI loopback smoke: 31/31 contract checks; usage `2`, API `3`, auth `4`, cancel `130`, pause `0`; JSON/YAML parity; no tested secret leakage; live stream remained unbuffered

## Compatibility

- Generated command shape, catalog schema, auth configuration, request bodies, and successful output are unchanged.
- Existing JSON `code` and `message` fields remain; new context fields are optional. YAML failures now use the same envelope.
- Usage failures now consistently exit `2`, SIGINT cancellation exits `130`, API/auth remain `3`/`4`, and collected pauses remain `0`.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
