### PR TITLE
fix(runtime): provide stable machine-readable errors

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -55,9 +55,20 @@ file; when this page and the code disagree, trust the code and fix this page.
 ## Structured errors and exit codes
 
 - Defined in `pkg/runtime/errors.go`.
-- Error codes: `general`, `usage`, `api_error`, `not_authenticated`.
+- `-o json` and `-o yaml` errors use an `error` envelope with required `code`,
+  `message`, and `hint` fields. An optional `http` object contains only a
+  numeric `status`; URLs, headers, and response bodies are deliberately
+  excluded.
+- Error codes: `general`, `usage`, `api_error`, `not_authenticated`,
+  `canceled`.
 - Exit codes: `0` OK, `1` general, `2` usage, `3` API error,
-  `4` not authenticated.
+  `4` not authenticated, `130` canceled.
+- A configured stream pause is a successful terminal outcome, not an error. It
+  exits `0`; stream collection policy should map the pause event into the
+  returned document when callers need an explicit paused status.
+- Debug output contains request method, HTTP status, retry timing, and elapsed
+  time only. It never prints request or response URLs, headers, bodies, or raw
+  transport errors.
 - Consumers: agents and scripts that branch on failure classes instead of
   parsing prose.
 

--- a/docs/workflow-conditional.md
+++ b/docs/workflow-conditional.md
@@ -324,7 +324,7 @@ design.
 ```
 
 A boolean `continue_on_error: true` is rejected. `ClassifyError`
-(`pkg/runtime/errors.go:52`) sorts errors into four classes and a boolean
+(`pkg/runtime/errors.go:52`) sorts errors into stable classes and a boolean
 swallows all of them, including `CodeGeneral` — which covers reference and
 body-construction failures, i.e. builder bugs in the DSL that must surface
 immediately.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -25,6 +25,10 @@ func NewCommand(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: fmt.Sprintf("Authenticate %s with a host", m.CLI.Name),
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(newLogin(m), newStatus(), newLogout())
 	return cmd
@@ -338,6 +342,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with a host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := rootString(cmd, "hostname")
 			insecure := rootBool(cmd, "insecure")
@@ -350,13 +355,13 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				hostname = strings.TrimSpace(line)
 			}
 			if hostname == "" {
-				return errors.New("hostname is required (use --hostname)")
+				return runtime.UsageError(cmd, errors.New("hostname is required (use --hostname)"))
 			}
 			hostname = config.NormalizeHostname(hostname)
 			authType = strings.ToLower(strings.TrimSpace(authType))
 			if deviceAuth {
 				if cmd.Flags().Changed("auth-type") && authType != "oauth" {
-					return fmt.Errorf("--device-auth cannot be used with --auth-type %s", authType)
+					return runtime.UsageError(cmd, fmt.Errorf("--device-auth cannot be used with --auth-type %s", authType))
 				}
 				authType = "oauth"
 			}
@@ -369,7 +374,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					return err
 				}
 				if token == "" {
-					return errors.New("empty token")
+					return runtime.UsageError(cmd, errors.New("empty token"))
 				}
 				entry.OAuthToken = token
 			case "apikey":
@@ -378,7 +383,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					return err
 				}
 				if key == "" {
-					return errors.New("empty API key")
+					return runtime.UsageError(cmd, errors.New("empty API key"))
 				}
 				entry.APIKey = key
 				entry.APIKeyHeader = m.Auth.APIKeyHeader
@@ -404,7 +409,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 				entry.BasicUser = strings.TrimSpace(uline)
 				if entry.BasicUser == "" {
-					return errors.New("empty username")
+					return runtime.UsageError(cmd, errors.New("empty username"))
 				}
 				pass, err := readSecret("Password", false)
 				if err != nil {
@@ -413,7 +418,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				entry.BasicPassword = pass
 			case "oauth":
 				if withToken {
-					return errors.New("--with-token cannot be used with --auth-type oauth")
+					return runtime.UsageError(cmd, errors.New("--with-token cannot be used with --auth-type oauth"))
 				}
 				var err error
 				entry, err = oauthDeviceLogin(cmd, m, hostname, provider, insecure, noBrowser)
@@ -421,7 +426,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					return err
 				}
 			default:
-				return fmt.Errorf("unknown auth type: %q (use bearer, apikey, basic, or oauth)", authType)
+				return runtime.UsageError(cmd, fmt.Errorf("unknown auth type: %q (use bearer, apikey, basic, or oauth)", authType))
 			}
 
 			if !skipValidate {
@@ -473,6 +478,7 @@ func newStatus() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "View authentication status",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := rootString(cmd, "hostname")
 			hosts, err := config.LoadHosts()
@@ -486,7 +492,7 @@ func newStatus() *cobra.Command {
 			if hostname != "" {
 				e, ok := hosts.Get(hostname)
 				if !ok {
-					return fmt.Errorf("not logged in to %s", hostname)
+					return runtime.NewNotAuthenticatedError()
 				}
 				printStatus(hostname, e)
 				return nil
@@ -504,6 +510,7 @@ func newLogout() *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",
 		Short: "Remove authentication for a host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := rootString(cmd, "hostname")
 			hosts, err := config.LoadHosts()
@@ -512,7 +519,7 @@ func newLogout() *cobra.Command {
 			}
 			names := hosts.Names()
 			if len(names) == 0 {
-				return errors.New("not logged in to any host")
+				return runtime.NewNotAuthenticatedError()
 			}
 			if hostname == "" {
 				if len(names) == 1 {
@@ -522,7 +529,7 @@ func newLogout() *cobra.Command {
 				}
 			}
 			if !hosts.Delete(hostname) {
-				return fmt.Errorf("not logged in to %s", hostname)
+				return runtime.NewNotAuthenticatedError()
 			}
 			if err := hosts.Save(); err != nil {
 				return err

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -522,6 +522,8 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- Do not guess flags or request body shape from command names.\n")
 	b.WriteString("- Do not execute directly from search results; confirm with `commands show` first.\n")
 	b.WriteString("- Prefer `-o json` for machine-readable command output unless the user asks for human-readable output.\n")
+	b.WriteString("- With `-o json` or `-o yaml`, branch on `error.code` and process exit status; `error.message` and `error.hint` are safe human guidance, and `error.http.status` is the only optional HTTP context.\n")
+	b.WriteString("- A configured stream pause is successful (`exit 0`); inspect the collected output field mapped from the pause event instead of treating it as an error.\n")
 	b.WriteString("- For collected streams, choose one mode: `-o json` for one stable document, `--stream` in the default output mode when catalog `output.streaming.policy.live` is present, or `-o raw` for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
@@ -576,6 +578,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
 	b.WriteString("## Output\n\n")
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
+	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
 	b.WriteString("## Auth\n\n")
 	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -95,6 +95,8 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"auth.required=true",
 		"references/modules/users.md",
 		"flags[].input_modes",
+		"error.code",
+		"exit 0",
 	} {
 		if !strings.Contains(skill, want) {
 			t.Errorf("SKILL.md missing %q", want)
@@ -115,7 +117,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 
 	catalog := readFile(t, dir, "skills/acmectl/references/catalog.md")
-	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json"} {
+	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero"} {
 		if !strings.Contains(catalog, want) {
 			t.Errorf("catalog.md missing %q", want)
 		}

--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -17,6 +17,7 @@ func commandsCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "commands",
 		Short: "List generated commands",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			catalog := runtime.BuildCatalog(cmd.Root(), catalogOptions(m, includeHidden))
 			if jsonOut {
@@ -43,7 +44,7 @@ func commandsShowCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show <path...>",
 		Short: "Show one generated command",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  runtime.UsageArgs(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entry, ok := runtime.FindCatalogCommand(cmd.Root(), args, catalogOptions(m, includeHidden))
 			if !ok {
@@ -81,6 +82,7 @@ func commandsSchemaCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schema",
 		Short: "Print command catalog schema version",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			data := map[string]int{"catalog_schema_version": runtime.CatalogSchemaVersion}
 			if jsonOut {
@@ -100,7 +102,7 @@ func searchCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Search generated commands",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  runtime.UsageArgs(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query := strings.Join(args, " ")
 			results := runtime.SearchCatalog(cmd.Root(), query, runtime.SearchOptions{

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -2,6 +2,7 @@ package lathe
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -25,12 +26,26 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	config.Bind(m)
 
 	cmd := &cobra.Command{
-		Use:          m.CLI.Name,
-		Short:        m.CLI.Short,
-		Long:         agentHint(m.CLI.Name, m.CLI.Short),
-		Version:      versionInfo(),
+		Use:     m.CLI.Name,
+		Short:   m.CLI.Short,
+		Long:    agentHint(m.CLI.Name, m.CLI.Short),
+		Version: versionInfo(),
+		Args:    runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if !slices.Contains(runtime.FormatterNames(), format) {
+				return runtime.UsageError(cmd, fmt.Errorf("unsupported output format"))
+			}
+			return nil
+		},
 		SilenceUsage: true,
 	}
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return runtime.UsageError(cmd, err)
+	})
 	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate("{{.Use}} {{.Version}}\n")
 	cmd.PersistentFlags().String("hostname", "", fmt.Sprintf("Server hostname (overrides $%s)", m.CLI.HostEnv))
@@ -63,6 +78,10 @@ func metaCmd(m *config.Manifest) *cobra.Command {
 		Use:    metaCommandName,
 		Short:  "Lathe control commands",
 		Hidden: true,
+		Args:   runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
 	}
 	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(verifyCmd(m))

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -2,6 +2,7 @@ package lathe
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/runtime"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRootHelpExposesAgentHint(t *testing.T) {
@@ -102,8 +104,8 @@ func TestRunReportsInvalidManifest(t *testing.T) {
 	if code != runtime.ExitGeneral {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
 	}
-	if !strings.Contains(stderr.String(), "cli.name is required") {
-		t.Fatalf("stderr missing manifest error: %q", stderr.String())
+	if got := stderr.String(); got != "Error: invalid CLI configuration\nHint: fix cli.yaml and retry\n" {
+		t.Fatalf("stderr = %q", got)
 	}
 }
 
@@ -118,8 +120,8 @@ func TestRunReportsMountError(t *testing.T) {
 	if code != runtime.ExitGeneral {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
 	}
-	if !strings.Contains(stderr.String(), "mount failed") {
-		t.Fatalf("stderr missing mount error: %q", stderr.String())
+	if got := stderr.String(); got != "Error: generated CLI failed to start\nHint: re-run code generation and rebuild the CLI\n" {
+		t.Fatalf("stderr = %q", got)
 	}
 }
 
@@ -139,5 +141,81 @@ func TestRunUsesRuntimeExecuteErrors(t *testing.T) {
 	}, []string{"needs-auth"}, &stdout, &stderr)
 	if code != runtime.ExitNotAuthenticated {
 		t.Fatalf("exit = %d, want %d", code, runtime.ExitNotAuthenticated)
+	}
+}
+
+func TestRunMachineErrorContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		cause    error
+		wantCode string
+		wantExit int
+		status   int
+	}{
+		{name: "cobra usage", args: []string{"unknown-secret-command"}, wantCode: runtime.CodeUsage, wantExit: runtime.ExitUsage},
+		{name: "nested cobra usage", args: []string{"__lathe", "unknown-secret-command"}, wantCode: runtime.CodeUsage, wantExit: runtime.ExitUsage},
+		{name: "extra cobra argument", args: []string{"__lathe", "version", "unknown-secret-command"}, wantCode: runtime.CodeUsage, wantExit: runtime.ExitUsage},
+		{name: "auth", args: []string{"fail"}, cause: runtime.ErrNotAuthenticated, wantCode: runtime.CodeNotAuthenticated, wantExit: runtime.ExitNotAuthenticated},
+		{name: "api", args: []string{"fail"}, cause: &runtime.HTTPError{Method: "GET", URL: "/private", Status: 429, Body: []byte("upstream-secret")}, wantCode: runtime.CodeAPIError, wantExit: runtime.ExitAPIError, status: 429},
+		{name: "canceled", args: []string{"fail"}, cause: context.Canceled, wantCode: runtime.CodeCanceled, wantExit: runtime.ExitCanceled},
+	}
+	for _, format := range []string{"json", "yaml"} {
+		for _, tc := range tests {
+			t.Run(format+"/"+tc.name, func(t *testing.T) {
+				var stdout, stderr bytes.Buffer
+				args := append([]string{"--output", format}, tc.args...)
+				code := run(RunOptions{
+					Manifest: []byte("cli:\n  name: myctl\n"),
+					Mount: func(root *cobra.Command) error {
+						if tc.cause != nil {
+							root.AddCommand(&cobra.Command{Use: "fail", RunE: func(*cobra.Command, []string) error { return tc.cause }})
+						}
+						return nil
+					},
+				}, args, &stdout, &stderr)
+				if code != tc.wantExit {
+					t.Fatalf("exit = %d, want %d; stderr = %s", code, tc.wantExit, stderr.String())
+				}
+				var env struct {
+					Error runtime.LatheError `yaml:"error"`
+				}
+				if err := yaml.Unmarshal(stderr.Bytes(), &env); err != nil {
+					t.Fatalf("decode %s: %v\n%s", format, err, stderr.String())
+				}
+				if env.Error.Code != tc.wantCode || env.Error.Message == "" || env.Error.Hint == "" {
+					t.Fatalf("error = %#v", env.Error)
+				}
+				if tc.status != 0 && (env.Error.HTTP == nil || env.Error.HTTP.Status != tc.status) {
+					t.Fatalf("http context = %#v, want status %d", env.Error.HTTP, tc.status)
+				}
+				for _, secret := range []string{"unknown-secret-command", "upstream-secret", "/private"} {
+					if strings.Contains(stderr.String(), secret) {
+						t.Fatalf("machine error leaked %q: %s", secret, stderr.String())
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRunFormatsStartupErrorAsMachineOutput(t *testing.T) {
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(RunOptions{Manifest: []byte("cli: {}\n")}, []string{"-o=" + format}, &stdout, &stderr)
+			if code != runtime.ExitGeneral {
+				t.Fatalf("exit = %d, want %d", code, runtime.ExitGeneral)
+			}
+			var env struct {
+				Error runtime.LatheError `yaml:"error"`
+			}
+			if err := yaml.Unmarshal(stderr.Bytes(), &env); err != nil {
+				t.Fatalf("decode %s: %v\n%s", format, err, stderr.String())
+			}
+			if env.Error.Code != runtime.CodeGeneral || env.Error.Hint == "" {
+				t.Fatalf("startup error = %#v", env.Error)
+			}
+		})
 	}
 }

--- a/pkg/lathe/run.go
+++ b/pkg/lathe/run.go
@@ -1,8 +1,11 @@
 package lathe
 
 import (
+	"context"
 	"io"
 	"os"
+	"os/signal"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -30,9 +33,16 @@ func Run(opts RunOptions) int {
 }
 
 func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
+	format := errorOutputFormat(args)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 	m, err := config.Load(opts.Manifest)
 	if err != nil {
-		return runtime.FormatError(err, "table", stderr)
+		if ctx.Err() != nil {
+			return runtime.FormatError(ctx.Err(), format, stderr)
+		}
+		err = runtime.NewError(runtime.CodeGeneral, runtime.ExitGeneral, "invalid CLI configuration", "fix cli.yaml and retry", err)
+		return runtime.FormatError(err, format, stderr)
 	}
 
 	setVersionInfo(opts)
@@ -41,14 +51,53 @@ func run(opts RunOptions, args []string, stdout, stderr io.Writer) int {
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
+	if format == "json" || format == "yaml" {
+		_ = root.PersistentFlags().Set("output", format)
+	}
+	root.SetContext(ctx)
 
 	if opts.Mount != nil {
 		if err := opts.Mount(root); err != nil {
-			return runtime.FormatError(err, "table", stderr)
+			if ctx.Err() != nil {
+				return runtime.FormatError(ctx.Err(), format, stderr)
+			}
+			err = runtime.NewError(runtime.CodeGeneral, runtime.ExitGeneral, "generated CLI failed to start", "re-run code generation and rebuild the CLI", err)
+			return runtime.FormatError(err, format, stderr)
 		}
 	}
 
 	return runtime.Execute(root)
+}
+
+func errorOutputFormat(args []string) string {
+	format := "table"
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			break
+		}
+		var value string
+		switch {
+		case arg == "--output" || arg == "-o":
+			if i+1 < len(args) {
+				value = args[i+1]
+				i++
+			}
+		case strings.HasPrefix(arg, "--output="):
+			value = strings.TrimPrefix(arg, "--output=")
+		case strings.HasPrefix(arg, "-o="):
+			value = strings.TrimPrefix(arg, "-o=")
+		case strings.HasPrefix(arg, "-o") && len(arg) > 2:
+			value = arg[2:]
+		}
+		if value != "" {
+			format = "table"
+			if value == "json" || value == "yaml" {
+				format = value
+			}
+		}
+	}
+	return format
 }
 
 func setVersionInfo(opts RunOptions) {

--- a/pkg/lathe/update.go
+++ b/pkg/lathe/update.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
 var (
@@ -49,6 +50,7 @@ func updateCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update this CLI from GitHub Releases",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runGitHubUpdate(cmd, m, yes)
 		},

--- a/pkg/lathe/verify.go
+++ b/pkg/lathe/verify.go
@@ -45,6 +45,7 @@ func verifyCmd(m *config.Manifest) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",
 		Short: "Verify generated CLI contract",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			report := verifyGenerated(cmd.Root(), m)
 			if err := writeJSON(cmd, report); err != nil {

--- a/pkg/lathe/version.go
+++ b/pkg/lathe/version.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/runtime"
 )
 
 var (
@@ -73,6 +75,7 @@ func versionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
 		Run: func(cmd *cobra.Command, _ []string) {
 			cmd.Printf("%s %s\n", cmd.Root().Use, versionInfo())
 		},

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -38,7 +38,8 @@ func Build(root *cobra.Command, service string, specs []CommandSpec) error {
 	if err != nil {
 		return err
 	}
-	svc := &cobra.Command{Use: service, Short: service + " API", GroupID: ModuleGroupID}
+	svc := helpCommand(service, service+" API")
+	svc.GroupID = ModuleGroupID
 	for _, group := range groups {
 		svc.AddCommand(group)
 	}
@@ -81,7 +82,7 @@ func buildGroups(service string, specs []CommandSpec) ([]*cobra.Command, error) 
 		s := specs[i]
 		g, ok := groups[s.Group]
 		if !ok {
-			g = &cobra.Command{Use: strings.ToLower(s.Group), Short: s.Group + " operations"}
+			g = helpCommand(strings.ToLower(s.Group), s.Group+" operations")
 			groups[s.Group] = g
 			ordered = append(ordered, g)
 		}
@@ -97,6 +98,17 @@ func buildGroups(service string, specs []CommandSpec) ([]*cobra.Command, error) 
 		g.AddCommand(c)
 	}
 	return ordered, nil
+}
+
+func helpCommand(use, short string) *cobra.Command {
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
 }
 
 func buildCmd(s CommandSpec) *cobra.Command {
@@ -118,28 +130,58 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		Short:   s.Short,
 		Long:    s.Long,
 		Example: s.Example,
+		Args:    UsageArgs(cobra.NoArgs),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return UsageError(cmd, err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if _, ok := formatters[format]; !ok {
+				return UsageError(cmd, fmt.Errorf("unsupported output format"))
+			}
 			if liveStream && format != "table" {
-				return fmt.Errorf("live stream output does not support -o %s", format)
+				return UsageError(cmd, fmt.Errorf("live stream output does not support -o %s", format))
 			}
 			if liveStream && waitPoll {
-				return fmt.Errorf("live stream output does not support wait polling")
+				return UsageError(cmd, fmt.Errorf("live stream output does not support wait polling"))
 			}
 			changed := operationChangedFlags(cmd, s.Params)
 			if err := bindPositionalArgs(cmd, args, positionals, changed); err != nil {
-				return err
+				return UsageError(cmd, err)
 			}
 			if err := resolveSafeInputFlags(cmd, s.Params, vals); err != nil {
-				return err
+				return UsageError(cmd, err)
 			}
 			if err := validateRequiredParams(s.Params, s.RequestBody != nil, changed); err != nil {
-				return err
+				return UsageError(cmd, err)
+			}
+
+			hasFile := bodyFileFlag != "" && cmd.Flags().Changed(bodyFileFlag)
+			var fileBody []byte
+			var err error
+			if hasFile {
+				fileBody, err = ReadBody(bodyFile)
+				if err != nil {
+					return UsageError(cmd, err)
+				}
+			}
+			input := OperationInput{
+				Values:         vals,
+				Changed:        changed,
+				FileBody:       fileBody,
+				HasFile:        hasFile,
+				BodySets:       bodySets,
+				BodyStringSets: bodyStringSets,
+			}
+			if err := validateOperationInput(s, input); err != nil {
+				return UsageError(cmd, err)
 			}
 
 			var hostname string
 			var clientOpts ClientOptions
-			var err error
 			refreshAuth := !dryRun
 			if dryRun || (s.Security != nil && s.Security.Public) {
 				hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
@@ -148,15 +190,6 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			}
 			if err != nil {
 				return err
-			}
-
-			hasFile := bodyFileFlag != "" && cmd.Flags().Changed(bodyFileFlag)
-			var fileBody []byte
-			if hasFile {
-				fileBody, err = ReadBody(bodyFile)
-				if err != nil {
-					return err
-				}
 			}
 
 			if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
@@ -170,14 +203,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			} else if liveStream && format == "table" {
 				output.live = cmd.OutOrStdout()
 			}
-			result, err := invokeOperation(cmd.Context(), s, OperationInput{
-				Values:         vals,
-				Changed:        changed,
-				FileBody:       fileBody,
-				HasFile:        hasFile,
-				BodySets:       bodySets,
-				BodyStringSets: bodyStringSets,
-			}, OperationOptions{
+			result, err := invokeOperation(cmd.Context(), s, input, OperationOptions{
 				Hostname:    hostname,
 				Client:      clientOpts,
 				DryRun:      dryRun,
@@ -201,7 +227,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		for _, p := range positionals {
 			cmd.Use += " [" + p.Argument + "]"
 		}
-		cmd.Args = cobra.MaximumNArgs(len(positionals))
+		cmd.Args = UsageArgs(cobra.MaximumNArgs(len(positionals)))
 	}
 	configureParamFlagAliases(cmd, s.Params)
 

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -116,6 +116,21 @@ func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 	}
 }
 
+func TestBuild_UnknownNestedCommandIsUsage(t *testing.T) {
+	for _, args := range [][]string{{"demo", "unknown"}, {"demo", "users", "unknown"}, {"demo", "users", "get-user", "unknown"}} {
+		root := newRootWithModuleGroup()
+		root.SetOut(io.Discard)
+		root.SetErr(io.Discard)
+		mustBuild(t, root, "demo", []CommandSpec{{Group: "Users", Use: "get-user"}})
+		root.SetArgs(args)
+
+		err := root.Execute()
+		if err == nil || ClassifyError(err).Code != CodeUsage {
+			t.Fatalf("Execute(%v) error = %v, want usage", args, err)
+		}
+	}
+}
+
 func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 	bindTestManifest(t, "myctl", "MYCTL_HOST")
 	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
@@ -627,6 +642,28 @@ func TestBuild_MultipartSendsFileAndFields(t *testing.T) {
 	}
 }
 
+func TestBuild_MultipartFileErrorPrecedesAuth(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	root := newRootWithModuleGroup()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group: "Uploads", Use: "create", Method: http.MethodPost, PathTpl: "/uploads",
+		Params:      []ParamSpec{{Name: "file", Flag: "file", In: InFormData, GoType: "string", Required: true, Format: "binary"}},
+		RequestBody: &RequestBody{Required: true, MediaType: "multipart/form-data"},
+	}})
+	root.SetArgs([]string{"--hostname", "https://example.invalid", "demo", "uploads", "create", "--file", t.TempDir() + "/missing"})
+
+	err := root.Execute()
+	if err == nil || ClassifyError(err).Code != CodeUsage || !strings.Contains(err.Error(), "read multipart file") {
+		t.Fatalf("error = %v, want local multipart usage error before auth", err)
+	}
+}
+
 func TestBuild_NonJSONRequestBodyRequiresFile(t *testing.T) {
 	for _, args := range [][]string{
 		{"--set", "id=1"},
@@ -644,13 +681,15 @@ func TestBuild_NonJSONRequestBodyRequiresFile(t *testing.T) {
 			Method:      "POST",
 			PathTpl:     "/exports",
 			RequestBody: &RequestBody{Required: true, MediaType: "text/plain"},
-			Security:    &SecurityHint{Public: true},
 		}})
 		root.SetArgs(append([]string{"--hostname", "http://127.0.0.1:1", "demo", "exports", "create-export"}, args...))
 
 		err := root.Execute()
 		if err == nil || !strings.Contains(err.Error(), "requires --file") {
 			t.Fatalf("Execute error = %v, want requires --file", err)
+		}
+		if got := ClassifyError(err).Code; got != CodeUsage {
+			t.Fatalf("error code = %q, want %q", got, CodeUsage)
 		}
 	}
 }
@@ -1088,6 +1127,36 @@ func TestBuild_RequiredQueryParamBlocksBeforeRequest(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "required flag") || !strings.Contains(err.Error(), "type") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server hits = %d, want 0", hits)
+	}
+}
+
+func TestBuild_InvalidOutputBlocksBeforeRequest(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	root := newRootWithModuleGroup()
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group: "Items", Use: "get-item", Method: "GET", PathTpl: "/items/1", Security: &SecurityHint{Public: true},
+	}})
+	root.SetArgs([]string{"--hostname", srv.URL, "--output", "not-a-format", "demo", "items", "get-item"})
+
+	err := root.Execute()
+	if err == nil || ClassifyError(err).Code != CodeUsage {
+		t.Fatalf("error = %v, want usage", err)
 	}
 	if hits != 0 {
 		t.Fatalf("server hits = %d, want 0", hits)

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -267,21 +267,24 @@ func newRequest(ctx context.Context, method, u string, body []byte, contentType 
 
 func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsumer) (*RawResult, error) {
 	method := req.Method
-	u := redactDebugURL(req.URL, opts.sensitiveQueryParams)
 	resp, err := httpClient(opts, consume != nil).Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", method, u, redactClientError(err, opts.sensitiveQueryParams))
+		cause := redactClientError(err, opts.sensitiveQueryParams)
+		if errors.Is(cause, context.Canceled) {
+			return nil, cause
+		}
+		return nil, newAPIError(cause, 0)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("read response: %w", err)
+			return nil, newAPIError(fmt.Errorf("read response: %w", err), resp.StatusCode)
 		}
 		return nil, &HTTPError{
 			Method: method,
-			URL:    u,
+			URL:    redactDebugURL(req.URL, opts.sensitiveQueryParams),
 			Status: resp.StatusCode,
 			Body:   data,
 		}
@@ -296,7 +299,7 @@ func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsum
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
+		return nil, newAPIError(fmt.Errorf("read response: %w", err), resp.StatusCode)
 	}
 	return &RawResult{Body: data, StatusCode: resp.StatusCode, Header: resp.Header}, nil
 }
@@ -334,9 +337,5 @@ type HTTPError struct {
 }
 
 func (e *HTTPError) Error() string {
-	snippet := string(e.Body)
-	if len(snippet) > 200 {
-		snippet = snippet[:200] + "…"
-	}
-	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, e.URL, e.Status, strings.TrimSpace(snippet))
+	return fmt.Sprintf("%s request failed with HTTP %d", e.Method, e.Status)
 }

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -151,7 +151,6 @@ func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, 
 	return hostname, opts, nil
 }
 
-func notAuthenticatedToHost(hostname string) error {
-	name := config.Active().CLI.Name
-	return fmt.Errorf("not authenticated to %s (run: %s auth login --hostname %s)", hostname, name, hostname)
+func notAuthenticatedToHost(string) error {
+	return fmt.Errorf("authentication required for selected host: %w", ErrNotAuthenticated)
 }

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -1,21 +1,14 @@
 package runtime
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"mime"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
-)
-
-const (
-	maxDebugReqBody  = 1024
-	maxDebugRespBody = 4096
 )
 
 type debugTransport struct {
@@ -25,35 +18,18 @@ type debugTransport struct {
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s %s\n", req.Method, redactDebugURL(req.URL, d.sensitiveQueryParams))
-	for k, vs := range req.Header {
-		fmt.Fprintf(os.Stderr, "> %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
-	}
-	if req.Body != nil && isTextContent(req.Header.Get("Content-Type")) {
-		body, restored := peekBody(req.Body, maxDebugReqBody)
-		req.Body = restored
-		dumpBody(os.Stderr, ">", redactDebugBody(req.Header.Get("Content-Type"), body), maxDebugReqBody)
-	}
-	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
 
 	start := time.Now()
 	resp, err := d.inner.RoundTrip(req)
 	elapsed := time.Since(start)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "< error: %v (%s)\n\n", err, elapsed)
+		fmt.Fprintf(os.Stderr, "< request failed (%s)\n\n", elapsed)
 		return nil, err
 	}
 
-	fmt.Fprintf(os.Stderr, "< %s (%s)\n", resp.Status, elapsed)
-	for k, vs := range resp.Header {
-		fmt.Fprintf(os.Stderr, "< %s: %s\n", k, redactDebugHeader(k, strings.Join(vs, ", "), d.sensitiveQueryParams))
-	}
-	if isTextContent(resp.Header.Get("Content-Type")) && (!d.streaming || resp.StatusCode < 200 || resp.StatusCode >= 300) {
-		body, restored := peekBody(resp.Body, maxDebugRespBody)
-		resp.Body = restored
-		dumpBody(os.Stderr, "<", redactDebugBody(resp.Header.Get("Content-Type"), body), maxDebugRespBody)
-	}
+	fmt.Fprintf(os.Stderr, "< HTTP %d (%s)\n", resp.StatusCode, elapsed)
 	fmt.Fprintln(os.Stderr)
 
 	return resp, nil
@@ -111,25 +87,6 @@ func redactDebugURLString(raw string, sensitive map[string]bool) string {
 		return "<invalid URL>"
 	}
 	return redactDebugURL(parsed, sensitive)
-}
-
-type bodyReader struct {
-	io.Reader
-	io.Closer
-}
-
-func isTextContent(ct string) bool {
-	if ct == "" {
-		return false
-	}
-	mt, _, _ := mime.ParseMediaType(ct)
-	switch {
-	case strings.HasPrefix(mt, "text/"):
-		return true
-	case mt == "application/json", mt == "application/xml", mt == "application/x-www-form-urlencoded":
-		return true
-	}
-	return false
 }
 
 func redactDebugHeader(name, value string, sensitive map[string]bool) string {
@@ -242,26 +199,4 @@ func redactDebugText(s string) string {
 		s = strings.ReplaceAll(s, field, name+"=***")
 	}
 	return s
-}
-
-func peekBody(body io.ReadCloser, max int) ([]byte, io.ReadCloser) {
-	peeked, err := io.ReadAll(io.LimitReader(body, int64(max)+1))
-	restored := bodyReader{Reader: io.MultiReader(bytes.NewReader(peeked), body), Closer: body}
-	if err != nil {
-		return nil, restored
-	}
-	return peeked, restored
-}
-
-func dumpBody(w io.Writer, prefix string, body []byte, max int) {
-	if len(body) == 0 {
-		return
-	}
-	if len(body) > max {
-		fmt.Fprintf(w, "%s [body at least %d bytes, showing first %d]\n", prefix, len(body), max)
-		fmt.Fprintln(w, string(body[:max]))
-	} else {
-		fmt.Fprintf(w, "%s [body %d bytes]\n", prefix, len(body))
-		fmt.Fprintln(w, string(body))
-	}
 }

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -36,19 +36,19 @@ func readStderr(t *testing.T, r *os.File) string {
 	return buf.String()
 }
 
-func TestDebugTransport_LogsJSONBody(t *testing.T) {
+func TestDebugTransport_LogsOnlySafeMetadata(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"result":"ok"}`))
+		w.Header().Set("X-Upstream-Secret", "response-header-secret")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"message":"response-body-secret"}`))
 	}))
 	defer srv.Close()
 
 	r := captureStderr(t)
 
 	dt := &debugTransport{inner: http.DefaultTransport}
-	body := strings.NewReader(`{"name":"test"}`)
-	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
-	req.Header.Set("Content-Type", "application/json")
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/private-path?token=query-secret", strings.NewReader(`{"value":"request-body-secret"}`))
+	req.Header.Set("Authorization", "Bearer request-header-secret")
 	resp, err := dt.RoundTrip(req)
 	if err != nil {
 		t.Fatalf("RoundTrip: %v", err)
@@ -56,155 +56,13 @@ func TestDebugTransport_LogsJSONBody(t *testing.T) {
 	resp.Body.Close()
 
 	out := readStderr(t, r)
-	if !strings.Contains(out, `{"name":"test"}`) {
-		t.Errorf("stderr missing request body:\n%s", out)
+	if !strings.Contains(out, "> POST request") || !strings.Contains(out, "< HTTP 400") {
+		t.Fatalf("debug output missing safe metadata:\n%s", out)
 	}
-	if !strings.Contains(out, `{"result":"ok"}`) {
-		t.Errorf("stderr missing response body:\n%s", out)
-	}
-	if !strings.Contains(out, "[body") {
-		t.Errorf("stderr missing body size label:\n%s", out)
-	}
-}
-
-func TestDebugTransport_RedactsSensitiveHeaders(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Set-Cookie", "session=response-secret")
-		w.Header().Set("X-Api-Key", "response-key")
-		w.Write([]byte(`ok`))
-	}))
-	defer srv.Close()
-
-	r := captureStderr(t)
-
-	dt := &debugTransport{inner: http.DefaultTransport}
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
-	req.Header.Set("Authorization", "Bearer request-token")
-	req.Header.Set("Cookie", "session=request-secret")
-	req.Header.Set("X-API-Key", "request-key")
-	req.Header.Set("X-Trace-Token", "trace-secret")
-	resp, err := dt.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	resp.Body.Close()
-
-	out := readStderr(t, r)
-	for _, leaked := range []string{"request-token", "request-secret", "request-key", "trace-secret", "response-secret", "response-key"} {
+	for _, leaked := range []string{"private-path", "query-secret", "request-header-secret", "request-body-secret", "response-header-secret", "response-body-secret"} {
 		if strings.Contains(out, leaked) {
 			t.Fatalf("debug output leaked %q:\n%s", leaked, out)
 		}
-	}
-	if strings.Count(out, "***") < 6 {
-		t.Fatalf("debug output did not redact expected headers:\n%s", out)
-	}
-}
-
-func TestDebugTransport_RedactsQueryCredentials(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Location", "/jobs?opaque=response-query-secret")
-		w.Header().Set("Content-Location", "https://user:response-userinfo-secret%zz@example.com/jobs?sig=response-malformed-secret")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	r := captureStderr(t)
-	dt := &debugTransport{inner: http.DefaultTransport, sensitiveQueryParams: map[string]bool{"opaque": true}}
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/api?key=debug-key-secret&authorization=debug-authorization-secret&X-Amz-Signature=debug-signature-secret&name=alice", nil)
-	resp, err := dt.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	resp.Body.Close()
-
-	out := readStderr(t, r)
-	for _, leaked := range []string{"debug-key-secret", "debug-authorization-secret", "debug-signature-secret", "response-query-secret", "response-malformed-secret", "response-userinfo-secret"} {
-		if strings.Contains(out, leaked) {
-			t.Fatalf("debug output leaked %q:\n%s", leaked, out)
-		}
-	}
-	if !strings.Contains(out, "name=alice") {
-		t.Fatalf("debug output lost non-sensitive query:\n%s", out)
-	}
-}
-
-func TestDebugTransport_RedactsSensitiveJSONBodies(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"result":"ok","token":"response-token","nested":{"apiKey":"response-key"}}`))
-	}))
-	defer srv.Close()
-
-	r := captureStderr(t)
-
-	dt := &debugTransport{inner: http.DefaultTransport}
-	body := strings.NewReader(`{"name":"test","secret":"request-secret","nested":{"password":"request-password"}}`)
-	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL+"/api", body)
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := dt.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	resp.Body.Close()
-
-	out := readStderr(t, r)
-	for _, leaked := range []string{"request-secret", "request-password", "response-token", "response-key"} {
-		if strings.Contains(out, leaked) {
-			t.Fatalf("debug body leaked %q:\n%s", leaked, out)
-		}
-	}
-	if !strings.Contains(out, `"name":"test"`) || !strings.Contains(out, `"result":"ok"`) {
-		t.Fatalf("debug output lost non-sensitive fields:\n%s", out)
-	}
-	if strings.Count(out, "***") < 4 {
-		t.Fatalf("debug output did not redact expected body fields:\n%s", out)
-	}
-}
-
-func TestDebugTransport_TruncatesLargeBody(t *testing.T) {
-	large := strings.Repeat("x", 5000)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.Write([]byte(large))
-	}))
-	defer srv.Close()
-
-	r := captureStderr(t)
-
-	dt := &debugTransport{inner: http.DefaultTransport}
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
-	resp, err := dt.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	resp.Body.Close()
-
-	out := readStderr(t, r)
-	if !strings.Contains(out, "showing first 4096") {
-		t.Errorf("stderr missing truncation label:\n%s", out)
-	}
-}
-
-func TestDebugTransport_SkipsBinaryBody(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "image/png")
-		w.Write([]byte{0x89, 0x50, 0x4e, 0x47})
-	}))
-	defer srv.Close()
-
-	r := captureStderr(t)
-
-	dt := &debugTransport{inner: http.DefaultTransport}
-	req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
-	resp, err := dt.RoundTrip(req)
-	if err != nil {
-		t.Fatalf("RoundTrip: %v", err)
-	}
-	resp.Body.Close()
-
-	out := readStderr(t, r)
-	if strings.Contains(out, "[body") {
-		t.Errorf("stderr should not contain body dump for binary content:\n%s", out)
 	}
 }
 
@@ -291,27 +149,5 @@ func TestDebugTransport_DoesNotPeekStreamingResponse(t *testing.T) {
 	}
 	if strings.Contains(out, "[body") {
 		t.Fatalf("debug output unexpectedly dumped streaming body:\n%s", out)
-	}
-}
-
-func TestIsTextContent(t *testing.T) {
-	tests := []struct {
-		ct   string
-		want bool
-	}{
-		{"application/json", true},
-		{"application/xml", true},
-		{"text/plain", true},
-		{"text/html", true},
-		{"application/x-www-form-urlencoded", true},
-		{"image/png", false},
-		{"application/octet-stream", false},
-		{"", false},
-		{"application/json; charset=utf-8", true},
-	}
-	for _, tc := range tests {
-		if got := isTextContent(tc.ct); got != tc.want {
-			t.Errorf("isTextContent(%q) = %v, want %v", tc.ct, got, tc.want)
-		}
 	}
 }

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -1,13 +1,14 @@
 package runtime
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 	ExitUsage            = 2
 	ExitAPIError         = 3
 	ExitNotAuthenticated = 4
+	ExitCanceled         = 130
 )
 
 const (
@@ -23,16 +25,26 @@ const (
 	CodeUsage            = "usage"
 	CodeAPIError         = "api_error"
 	CodeNotAuthenticated = "not_authenticated"
+	CodeCanceled         = "canceled"
 )
 
+type ErrorHTTPContext struct {
+	Status int `json:"status" yaml:"status"`
+}
+
 type LatheError struct {
-	Code     string `json:"code"`
-	Message  string `json:"message"`
-	ExitCode int    `json:"-"`
+	Code     string            `json:"code" yaml:"code"`
+	Message  string            `json:"message" yaml:"message"`
+	Hint     string            `json:"hint" yaml:"hint"`
+	HTTP     *ErrorHTTPContext `json:"http,omitempty" yaml:"http,omitempty"`
+	ExitCode int               `json:"-" yaml:"-"`
 	cause    error
 }
 
 func (e *LatheError) Error() string {
+	if e.cause != nil {
+		return e.cause.Error()
+	}
 	return e.Message
 }
 
@@ -41,34 +53,95 @@ func (e *LatheError) Unwrap() error {
 }
 
 func NewLatheError(code string, exitCode int, cause error) *LatheError {
+	return NewError(code, exitCode, cause.Error(), defaultErrorHint(code), cause)
+}
+
+func NewError(code string, exitCode int, message, hint string, cause error) *LatheError {
 	return &LatheError{
 		Code:     code,
-		Message:  cause.Error(),
+		Message:  message,
+		Hint:     hint,
 		ExitCode: exitCode,
 		cause:    cause,
 	}
+}
+
+func UsageError(cmd *cobra.Command, cause error) *LatheError {
+	hint := "run the command with --help and correct the arguments"
+	if cmd != nil && cmd.CommandPath() != "" {
+		hint = fmt.Sprintf("run `%s --help` and correct the arguments", cmd.CommandPath())
+	}
+	return NewError(CodeUsage, ExitUsage, "invalid command usage", hint, cause)
+}
+
+func UsageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := validate(cmd, args); err != nil {
+			return UsageError(cmd, err)
+		}
+		return nil
+	}
+}
+
+func newAPIError(cause error, status int) *LatheError {
+	hint := "check the hostname, network connectivity, and TLS settings"
+	if status != 0 {
+		hint = "check the request and API documentation"
+		switch {
+		case status == 401 || status == 403:
+			hint = "check authentication and authorization"
+		case status == 429 || status >= 500:
+			hint = "retry later or contact the API operator"
+		}
+	}
+	err := NewError(CodeAPIError, ExitAPIError, "API request failed", hint, cause)
+	if status != 0 {
+		err.HTTP = &ErrorHTTPContext{Status: status}
+	}
+	return err
 }
 
 func ClassifyError(err error) *LatheError {
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, context.Canceled) {
+		return NewError(CodeCanceled, ExitCanceled, "command canceled", "retry the command when ready", err)
+	}
 	var le *LatheError
 	if errors.As(err, &le) {
+		if le.Hint == "" {
+			le.Hint = defaultErrorHint(le.Code)
+		}
 		return le
 	}
 	if errors.Is(err, ErrNotAuthenticated) {
-		return NewLatheError(CodeNotAuthenticated, ExitNotAuthenticated, err)
+		return NewError(CodeNotAuthenticated, ExitNotAuthenticated, "authentication required", "run `auth login` for the selected hostname", err)
 	}
 	var he *HTTPError
 	if errors.As(err, &he) {
-		return NewLatheError(CodeAPIError, ExitAPIError, err)
+		return newAPIError(err, he.Status)
 	}
-	return NewLatheError(CodeGeneral, ExitGeneral, err)
+	return NewError(CodeGeneral, ExitGeneral, "command failed", "check local configuration and retry", err)
 }
 
-type jsonErrorEnvelope struct {
-	Error LatheError `json:"error"`
+func defaultErrorHint(code string) string {
+	switch code {
+	case CodeUsage:
+		return "run the command with --help and correct the arguments"
+	case CodeAPIError:
+		return "check the request and API documentation"
+	case CodeNotAuthenticated:
+		return "run `auth login` for the selected hostname"
+	case CodeCanceled:
+		return "retry the command when ready"
+	default:
+		return "check local configuration and retry"
+	}
+}
+
+type errorEnvelope struct {
+	Error LatheError `json:"error" yaml:"error"`
 }
 
 type silentExitError interface {
@@ -80,12 +153,19 @@ func FormatError(err error, format string, w io.Writer) int {
 	if le == nil {
 		return ExitOK
 	}
-	if format == "json" {
+	switch format {
+	case "json":
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		_ = enc.Encode(jsonErrorEnvelope{Error: *le})
-	} else {
+		_ = enc.Encode(errorEnvelope{Error: *le})
+	case "yaml":
+		enc := yaml.NewEncoder(w)
+		enc.SetIndent(2)
+		_ = enc.Encode(errorEnvelope{Error: *le})
+		_ = enc.Close()
+	default:
 		fmt.Fprintln(w, "Error:", le.Message)
+		fmt.Fprintln(w, "Hint:", le.Hint)
 	}
 	return le.ExitCode
 }
@@ -101,5 +181,5 @@ func Execute(cmd *cobra.Command) int {
 		return silent.SilentExitCode()
 	}
 	format, _ := cmd.PersistentFlags().GetString("output")
-	return FormatError(err, format, os.Stderr)
+	return FormatError(err, format, cmd.ErrOrStderr())
 }

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func TestClassifyError_Nil(t *testing.T) {
@@ -26,16 +28,25 @@ func TestClassifyError_NotAuthenticated(t *testing.T) {
 	if le.ExitCode != ExitNotAuthenticated {
 		t.Errorf("exit = %d, want %d", le.ExitCode, ExitNotAuthenticated)
 	}
+	if le.Hint == "" {
+		t.Fatal("authentication error missing hint")
+	}
 }
 
 func TestClassifyError_HTTPError(t *testing.T) {
-	err := &HTTPError{Method: "GET", URL: "/x", Status: 500, Body: []byte("fail")}
+	err := &HTTPError{Method: "GET", URL: "/private", Status: 500, Body: []byte("upstream-secret")}
 	le := ClassifyError(err)
 	if le.Code != CodeAPIError {
 		t.Errorf("code = %q, want %q", le.Code, CodeAPIError)
 	}
 	if le.ExitCode != ExitAPIError {
 		t.Errorf("exit = %d, want %d", le.ExitCode, ExitAPIError)
+	}
+	if le.HTTP == nil || le.HTTP.Status != 500 {
+		t.Fatalf("http context = %#v, want status 500", le.HTTP)
+	}
+	if strings.Contains(le.Message, "upstream-secret") || strings.Contains(le.Message, "/private") {
+		t.Fatalf("machine message exposed HTTP details: %q", le.Message)
 	}
 }
 
@@ -55,6 +66,9 @@ func TestClassifyError_Generic(t *testing.T) {
 	if le.ExitCode != ExitGeneral {
 		t.Errorf("exit = %d, want %d", le.ExitCode, ExitGeneral)
 	}
+	if le.Message != "command failed" || le.Hint == "" {
+		t.Fatalf("generic machine error = %#v", le)
+	}
 }
 
 func TestFormatError_JSON(t *testing.T) {
@@ -63,15 +77,33 @@ func TestFormatError_JSON(t *testing.T) {
 	if code != ExitGeneral {
 		t.Errorf("exit = %d, want %d", code, ExitGeneral)
 	}
-	var env jsonErrorEnvelope
+	var env errorEnvelope
 	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
 	}
 	if env.Error.Code != CodeGeneral {
 		t.Errorf("json code = %q, want %q", env.Error.Code, CodeGeneral)
 	}
-	if env.Error.Message != "oops" {
-		t.Errorf("json message = %q, want %q", env.Error.Message, "oops")
+	if env.Error.Message != "command failed" || env.Error.Hint == "" {
+		t.Errorf("json error = %#v", env.Error)
+	}
+}
+
+func TestFormatError_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	cause := &HTTPError{Method: "POST", URL: "https://example.invalid/private", Status: 429, Body: []byte("upstream-secret")}
+	if code := FormatError(cause, "yaml", &buf); code != ExitAPIError {
+		t.Fatalf("exit = %d, want %d", code, ExitAPIError)
+	}
+	var env errorEnvelope
+	if err := yaml.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid YAML: %v\n%s", err, buf.String())
+	}
+	if env.Error.Code != CodeAPIError || env.Error.Hint == "" || env.Error.HTTP == nil || env.Error.HTTP.Status != 429 {
+		t.Fatalf("yaml error = %#v", env.Error)
+	}
+	if strings.Contains(buf.String(), "upstream-secret") || strings.Contains(buf.String(), "private") {
+		t.Fatalf("YAML leaked HTTP details: %s", buf.String())
 	}
 }
 
@@ -81,8 +113,8 @@ func TestFormatError_Plain(t *testing.T) {
 	if code != ExitGeneral {
 		t.Errorf("exit = %d, want %d", code, ExitGeneral)
 	}
-	if !strings.Contains(buf.String(), "oops") {
-		t.Errorf("output missing error message: %q", buf.String())
+	if !strings.Contains(buf.String(), "Error: command failed") || !strings.Contains(buf.String(), "Hint:") || strings.Contains(buf.String(), "oops") {
+		t.Errorf("plain error = %q", buf.String())
 	}
 }
 
@@ -102,6 +134,13 @@ func TestLatheError_Unwrap(t *testing.T) {
 	le := NewLatheError(CodeGeneral, ExitGeneral, cause)
 	if !errors.Is(le, cause) {
 		t.Error("expected Unwrap to expose cause")
+	}
+}
+
+func TestClassifyError_Canceled(t *testing.T) {
+	le := ClassifyError(fmt.Errorf("request: %w", context.Canceled))
+	if le.Code != CodeCanceled || le.ExitCode != ExitCanceled || le.Hint == "" {
+		t.Fatalf("canceled error = %#v", le)
 	}
 }
 

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -115,6 +115,15 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 	return OperationResult{Data: data, Outcome: outcome}, nil
 }
 
+func validateOperationInput(s CommandSpec, input OperationInput) error {
+	_, body, _, err := resolveOperationRequest(s, input, ClientOptions{})
+	if err != nil {
+		return err
+	}
+	_, _, err = encodeRequestBody(body)
+	return err
+}
+
 func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts ClientOptions) (string, any, ClientOptions, error) {
 	if err := validateRequiredOperationParams(s, input); err != nil {
 		return "", nil, ClientOptions{}, err

--- a/pkg/runtime/poll.go
+++ b/pkg/runtime/poll.go
@@ -51,16 +51,16 @@ func PollUntilDone(ctx context.Context, hostname, location string, opts ClientOp
 
 	for {
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("polling timed out after %s", timeout)
+			return nil, newAPIError(fmt.Errorf("polling timed out after %s", timeout), 0)
 		}
 
 		loc, err := url.Parse(location)
 		if err != nil {
-			return nil, fmt.Errorf("parse polling location: %w", redactClientError(err, opts.sensitiveQueryParams))
+			return nil, newAPIError(fmt.Errorf("parse polling location: %w", redactClientError(err, opts.sensitiveQueryParams)), 0)
 		}
 		resolved := baseURL.ResolveReference(loc)
 		if !strings.EqualFold(resolved.Scheme, baseURL.Scheme) || !strings.EqualFold(resolved.Hostname(), baseURL.Hostname()) || port(resolved) != port(baseURL) {
-			return nil, fmt.Errorf("cross-host polling location %q", redactDebugURLString(location, opts.sensitiveQueryParams))
+			return nil, newAPIError(fmt.Errorf("cross-host polling location %q", redactDebugURLString(location, opts.sensitiveQueryParams)), 0)
 		}
 		location = resolved.RequestURI()
 		r, err := DoRawFull(ctx, hostname, "GET", location, nil, opts)

--- a/pkg/runtime/poll_test.go
+++ b/pkg/runtime/poll_test.go
@@ -107,6 +107,9 @@ func TestPollUntilDone_RejectsCrossHostAbsoluteLocation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "cross-host polling location") {
 		t.Fatalf("PollUntilDone error = %v, want cross-host polling location", err)
 	}
+	if got := ClassifyError(err).Code; got != CodeAPIError {
+		t.Fatalf("error code = %q, want %q", got, CodeAPIError)
+	}
 	if strings.Contains(err.Error(), querySecret) || strings.Contains(err.Error(), password) {
 		t.Fatalf("PollUntilDone error leaked Location credential: %v", err)
 	}
@@ -180,6 +183,9 @@ func TestPollUntilDone_Timeout(t *testing.T) {
 	_, err := PollUntilDone(context.Background(), srv.URL, "/status", ClientOptions{Timeout: 5 * time.Second}, 2*time.Second)
 	if err == nil {
 		t.Fatal("expected timeout error")
+	}
+	if got := ClassifyError(err).Code; got != CodeAPIError {
+		t.Fatalf("error code = %q, want %q", got, CodeAPIError)
 	}
 }
 

--- a/pkg/runtime/retry.go
+++ b/pkg/runtime/retry.go
@@ -25,18 +25,16 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if attempt > 0 {
 			wait := retryBackoff(attempt, resp)
 			if t.debug {
-				reason := "backoff"
-				if resp != nil {
-					if ra := resp.Header.Get("Retry-After"); ra != "" {
-						reason = "Retry-After=" + ra
-					}
-				}
-				fmt.Fprintf(os.Stderr, "[retry %d/%d] %s - waiting %s (%s)\n", attempt, t.maxRetries, resp.Status, wait, reason)
+				fmt.Fprintf(os.Stderr, "[retry %d/%d] HTTP %d - waiting %s\n", attempt, t.maxRetries, resp.StatusCode, wait)
 			}
 			if t.sleepFn != nil {
 				t.sleepFn(wait)
 			} else {
-				time.Sleep(wait)
+				select {
+				case <-time.After(wait):
+				case <-req.Context().Done():
+					return nil, req.Context().Err()
+				}
 			}
 			if req.GetBody != nil {
 				req.Body, err = req.GetBody()

--- a/pkg/runtime/retry_test.go
+++ b/pkg/runtime/retry_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -208,6 +209,34 @@ func TestRetryTransport_RespectsRetryAfter(t *testing.T) {
 	resp.Body.Close()
 	if slept != 7*time.Second {
 		t.Errorf("slept = %v, want 7s (Retry-After)", slept)
+	}
+}
+
+func TestRetryTransport_CancellationStopsBackoff(t *testing.T) {
+	called := make(chan struct{}, 1)
+	rt := &retryTransport{
+		inner: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			called <- struct{}{}
+			return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader("")), Header: make(http.Header)}, nil
+		}),
+		maxRetries: 1,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.invalid", nil)
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := rt.RoundTrip(req)
+		errCh <- err
+	}()
+	<-called
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context canceled", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("retry backoff ignored cancellation")
 	}
 }
 

--- a/pkg/runtime/stream.go
+++ b/pkg/runtime/stream.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,14 +17,14 @@ var errStreamTerminal = errors.New("stream terminal event")
 func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *string) ([]byte, error) {
 	policy := hint.Policy
 	if policy.DataFormat != "json" {
-		return nil, fmt.Errorf("unsupported stream data format %q", policy.DataFormat)
+		return nil, newAPIError(fmt.Errorf("unsupported stream data format %q", policy.DataFormat), 0)
 	}
 	collected := map[string]any{}
 	stopped := false
 	handle := func(transportEvent string, data []byte) error {
 		var payload any
 		if err := json.Unmarshal(data, &payload); err != nil {
-			return NewLatheError(CodeAPIError, ExitAPIError, fmt.Errorf("decode %s stream event: %w", hint.Strategy, err))
+			return newAPIError(fmt.Errorf("decode %s stream event: %w", hint.Strategy, err), 0)
 		}
 		event := transportEvent
 		if event == "" && policy.EventNamePath != "" {
@@ -38,7 +39,7 @@ func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *st
 			value, ok := streamFieldValue(payload, field)
 			if ok {
 				if err := reduceStreamField(collected, field, value); err != nil {
-					return NewLatheError(CodeAPIError, ExitAPIError, err)
+					return newAPIError(err, 0)
 				}
 			}
 		}
@@ -50,7 +51,7 @@ func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *st
 			}
 		}
 		if slices.Contains(policy.Collect.ErrorEvents, event) {
-			return NewLatheError(CodeAPIError, ExitAPIError, streamEventError(event, payload))
+			return newAPIError(streamEventError(event, payload), 0)
 		}
 		if slices.Contains(policy.Collect.PauseEvents, event) {
 			*outcome = OperationOutcomePaused
@@ -71,13 +72,20 @@ func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *st
 	case "ndjson":
 		err = readNDJSON(r, handle)
 	default:
-		err = fmt.Errorf("unsupported stream strategy %q", hint.Strategy)
+		err = newAPIError(fmt.Errorf("unsupported stream strategy %q", hint.Strategy), 0)
 	}
 	if err != nil && !errors.Is(err, errStreamTerminal) {
-		return nil, err
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		var apiErr *LatheError
+		if errors.As(err, &apiErr) {
+			return nil, err
+		}
+		return nil, newAPIError(err, 0)
 	}
 	if policy.Collect.RequireStop && !stopped {
-		return nil, NewLatheError(CodeAPIError, ExitAPIError, fmt.Errorf("%s stream ended without a terminal event", hint.Strategy))
+		return nil, newAPIError(fmt.Errorf("%s stream ended without a terminal event", hint.Strategy), 0)
 	}
 	return json.Marshal(collected)
 }

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -68,19 +68,30 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 		Long:    spec.Long,
 		Example: spec.Example,
 		Hidden:  spec.Hidden,
+		Args:    UsageArgs(cobra.NoArgs),
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmd.ValidateRequiredFlags(); err != nil {
+				return UsageError(cmd, err)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			format, _ := cmd.Root().PersistentFlags().GetString("output")
+			if _, ok := formatters[format]; !ok {
+				return UsageError(cmd, fmt.Errorf("unsupported output format"))
+			}
 			if err := resolveSafeInputFlags(cmd, spec.Params, vals); err != nil {
-				return err
+				return UsageError(cmd, err)
 			}
 			changed := operationChangedFlags(cmd, spec.Params)
 			if err := validateRequiredParams(spec.Params, false, changed); err != nil {
-				return err
+				return UsageError(cmd, err)
 			}
 			if err := validateOperationEnums(CommandSpec{Params: spec.Params}, OperationInput{
 				Values:  vals,
 				Changed: changed,
 			}); err != nil {
-				return err
+				return UsageError(cmd, err)
 			}
 			result, data, err := executeWorkflow(cmd, spec, vals)
 			if err != nil {
@@ -93,7 +104,6 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 					return marshalErr
 				}
 			}
-			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			return FormatOutput(data, format, cmd.OutOrStdout(), spec.Output)
 		},
 	}
@@ -149,6 +159,9 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 				continue
 			}
 			return fail(err)
+		}
+		if err := validateOperationInput(step.Operation, input); err != nil {
+			return fail(UsageError(cmd, err))
 		}
 
 		var hostname string


### PR DESCRIPTION
## Goal

Give every Lathe-generated CLI a stable, machine-decidable error contract for humans and agents without adding provider-specific behavior or breaking the generated catalog contract.

## What changed

- emit `code`, `message`, and `hint` for JSON and YAML errors, with optional status-only HTTP context
- distinguish usage, authentication, API, and cancellation failures with exits 2, 4, 3, and 130
- keep configured stream pauses successful (`exit 0`) and machine-readable in collected output
- classify Cobra, generated input/body, auth, transport/retry/poll/stream, startup, and signal paths at their owning runtime seams
- validate local output/body/argument errors before auth refreshes or network requests
- limit debug/error output to safe transport metadata instead of URLs, headers, bodies, or raw upstream errors
- document the contract in the generated Agent Skill and runtime contract reference

## Boundary

- This is provider-neutral Lathe runtime behavior; it contains no Dify concepts or Dify-specific branches.
- Overlays remain codegen-time input only. `pkg/runtime` does not learn overlay concepts.
- The command catalog schema and generated operation metadata shape are unchanged.
- HTTP context intentionally exposes only the numeric status. Arbitrary upstream bodies are never treated as safe diagnostic material.

## Verification

```console
go test ./pkg/runtime ./pkg/lathe ./internal/auth ./internal/codegen/render -count=1
make build
(cd examples/petstore && ../../bin/lathe codegen -cache fixtures -overlay overlays && go build -o bin/petstore ./cmd/petstore && ./bin/petstore __lathe verify --json)
make check
go test -race ./...
```

A local `ThreadingHTTPServer` loopback also exercised the generated Petstore and Rich API binaries with these CLI paths:

```console
./bin/petstore -o json pets unknown-secret-command
./bin/petstore -o yaml __lathe version unknown-secret-command
./bin/petstore -o json --hostname http://127.0.0.1:18090 pets get --id ok
./bin/petstore -o yaml --hostname http://127.0.0.1:18090 pets get --id ok
./bin/petstore -o json --hostname http://127.0.0.1:18089 pets get --id private
./bin/petstore -o yaml --hostname http://127.0.0.1:18089 pets get --id private
./bin/petstore --debug -o json --hostname http://127.0.0.1:18089 pets get --id private
./bin/petstore --hostname http://127.0.0.1:18089 -o bogus pets get --id ok
./bin/richapi -o json --hostname http://127.0.0.1:18091 events stream
./bin/richapi -o yaml --hostname http://127.0.0.1:18091 events stream
```

The loopback returned secret-bearing 400 bodies/headers, delayed requests for SIGINT cancellation, and an overlay-configured pause SSE event. JSON/YAML exits were 2 for usage, 4 for missing auth, 3 for API failures, 130 for SIGINT cancellation, and 0 for pause. Invalid output produced zero server hits; error and debug output contained no loopback secret values.
