### PR TITLE
feat(runtime): support runtime body schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,9 +417,10 @@ commands:
           fields: input_schema
 ```
 
-The schema operation must be a visible, non-streaming `GET` in the
-same module, use the same hostname, return JSON, and require no more auth than
-the target. Parameter mappings use source parameter names or flags; values are
+The schema operation must be a visible, non-streaming `GET` in the same module,
+use the same hostname, and require no request body. It must return JSON and
+require no more auth than the target. Parameter mappings use source parameter
+names or flags; values are
 literals or exact `${params.<target-name-or-flag>}` references. Before the
 target request, the runtime executes the schema operation and validates the
 JSON body against `type`, `properties`, `required`, `additionalProperties`,

--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ Relay-style outputs with `list_path: data.<operation>.nodes` or `.edges`,
 
 ### Overlays
 
-Overlays polish generated commands without changing the upstream spec or editing
-generated Go code.
+Overlays polish generated commands and bind bounded runtime behavior that the
+upstream spec cannot express, without editing generated Go code.
 
 `internal/overlay/iam.yaml`:
 
@@ -401,6 +401,31 @@ required when an upstream spec is incomplete; it does not create new flags.
 Command `shortcuts` add root-level commands that execute the same generated
 operation with preset values for existing parameters. Shortcut params may use
 the parameter name or flag name; invocation flags can still override the preset.
+
+When a read-only operation returns the JSON Schema for a later request body, an
+overlay can bind that preflight without hard-coding provider behavior:
+
+```yaml
+commands:
+  run-app:
+    body:
+      runtime_schema:
+        operation_id: describeApp
+        response_path: input_schema
+        params:
+          app_id: ${params.app_id}
+          fields: input_schema
+```
+
+The schema operation must be a visible, non-streaming `GET` or `HEAD` in the
+same module, use the same hostname, return JSON, and require no more auth than
+the target. Parameter mappings use source parameter names or flags; values are
+literals or exact `${params.<target-name-or-flag>}` references. Before the
+target request, the runtime executes the schema operation and validates the
+JSON body against `type`, `properties`, `required`, `additionalProperties`,
+`items`, `enum`, `minLength`, and `maxLength`. Unsupported assertion keywords
+fail the preflight instead of being ignored. `--dry-run` remains network-free,
+so it shows the static request without dynamic validation.
 
 For an SSE or NDJSON operation whose event semantics are not described by the
 API spec, an overlay can collect JSON frames into one stable result:

--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ commands:
           fields: input_schema
 ```
 
-The schema operation must be a visible, non-streaming `GET` or `HEAD` in the
+The schema operation must be a visible, non-streaming `GET` in the
 same module, use the same hostname, return JSON, and require no more auth than
 the target. Parameter mappings use source parameter names or flags; values are
 literals or exact `${params.<target-name-or-flag>}` references. Before the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,7 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `Deprecated` | `deprecated` / proto option | bool + message | overlay > spec |
 | `Security` | `security` / proto option | override (post-v0.1) | overlay > spec |
 | `RequestBody.MediaType` | `consumes[0]` | override | overlay > spec |
+| `RequestBody.RuntimeSchema` | — | read-only schema operation, response path, and parameter mapping | overlay-only |
 | `Output.Streaming.Policy` | streaming media type supplies transport only | JSON event collection and live projection | overlay > spec transport |
 | `Ignore` (command filter) | — | bool | overlay-only |
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -29,7 +29,8 @@ file; when this page and the code disagree, trust the code and fix this page.
 - This is the agent-facing discovery contract and the source of truth for
   generated operation details: HTTP method and path template, auth
   requirements, source parameter names, CLI flags and positional alternatives,
-  body schema, output, pagination, and stream collection hints.
+  body schema (including any runtime schema source), output, pagination, and
+  stream collection hints.
 - `catalog.cli.capabilities` lists compiled first-party capabilities such as
   `skill.bundle`. Capability commands are not catalog operations.
 - Only generated API operation commands carry catalog entries. Framework

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -259,6 +259,7 @@ func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Over
 
 func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
 	var merged []runtime.CommandSpec
+	runtimeSchemas := map[int]*overlay.RuntimeSchemaOverride{}
 	for _, s := range specs {
 		o, ok := mod.Commands[s.Use]
 		if ok && !overrideMatches(s, o) {
@@ -275,8 +276,33 @@ func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runti
 		}
 		applyCommandOverride(&cs, o)
 		merged = append(merged, cs)
+		if o.Body != nil && o.Body.RuntimeSchema != nil {
+			runtimeSchemas[len(merged)-1] = o.Body.RuntimeSchema
+		}
+	}
+	byOperationID := make(map[string]runtime.CommandSpec, len(merged))
+	for _, spec := range merged {
+		byOperationID[spec.OperationID] = spec
+	}
+	for index, configured := range runtimeSchemas {
+		merged[index].RequestBody.RuntimeSchema = &runtime.RuntimeSchemaSource{
+			Operation:    runtimeSchemaOperation(byOperationID[configured.OperationID]),
+			ResponsePath: configured.ResponsePath,
+			Params:       copyStringMap(configured.Params),
+		}
 	}
 	return merged
+}
+
+func runtimeSchemaOperation(source runtime.CommandSpec) runtime.CommandSpec {
+	return runtime.CommandSpec{
+		OperationID:     source.OperationID,
+		Method:          source.Method,
+		PathTpl:         source.PathTpl,
+		DefaultHostname: source.DefaultHostname,
+		Params:          append([]runtime.ParamSpec(nil), source.Params...),
+		Output:          runtime.OutputHints{ResponseMediaType: source.Output.ResponseMediaType},
+	}
 }
 
 func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) error {
@@ -293,8 +319,169 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 				return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
 			}
 		}
+		if override.Body != nil && override.Body.RuntimeSchema != nil {
+			if err := validateRuntimeSchemaOverride(specs, spec, *override.Body.RuntimeSchema, mod); err != nil {
+				return fmt.Errorf("command %q runtime body schema: %w", spec.Use, err)
+			}
+		}
 	}
 	return nil
+}
+
+func validateRuntimeSchemaOverride(specs []runtime.CommandSpec, target runtime.CommandSpec, configured overlay.RuntimeSchemaOverride, mod overlay.Module) error {
+	if target.RequestBody == nil || !jsonMediaType(target.RequestBody.MediaType) {
+		return fmt.Errorf("target must have a JSON request body")
+	}
+	if configured.OperationID == "" || configured.ResponsePath == "" {
+		return fmt.Errorf("operation_id and response_path are required")
+	}
+	source, matches := runtime.CommandSpec{}, 0
+	for _, candidate := range specs {
+		if candidate.OperationID == configured.OperationID {
+			source, matches = candidate, matches+1
+		}
+	}
+	if matches != 1 {
+		return fmt.Errorf("operation_id %q must match exactly one operation", configured.OperationID)
+	}
+	if source.OperationID == target.OperationID {
+		return fmt.Errorf("schema operation must differ from the target operation")
+	}
+	if source.Method != "GET" && source.Method != "HEAD" {
+		return fmt.Errorf("schema operation %q must be read-only (GET or HEAD)", configured.OperationID)
+	}
+	if source.Output.Streaming != nil || !jsonMediaType(source.Output.ResponseMediaType) {
+		return fmt.Errorf("schema operation %q must return non-streaming JSON", configured.OperationID)
+	}
+	if source.DefaultHostname != target.DefaultHostname {
+		return fmt.Errorf("schema operation %q must use the target hostname", configured.OperationID)
+	}
+	sourceParams, targetParams := source.Params, target.Params
+	sourceHidden := source.Hidden
+	if sourceOverride, ok := mod.Commands[source.Use]; ok && overrideMatches(source, sourceOverride) {
+		if sourceOverride.Ignore {
+			return fmt.Errorf("schema operation %q is ignored", configured.OperationID)
+		}
+		if sourceOverride.Body != nil && sourceOverride.Body.RuntimeSchema != nil {
+			return fmt.Errorf("schema operation %q cannot use a runtime body schema", configured.OperationID)
+		}
+		sourceParams = effectiveOverlayParams(source.Params, sourceOverride.Params)
+		if sourceOverride.Hidden != nil {
+			sourceHidden = *sourceOverride.Hidden
+		}
+	}
+	if targetOverride, ok := mod.Commands[target.Use]; ok && overrideMatches(target, targetOverride) {
+		targetParams = effectiveOverlayParams(target.Params, targetOverride.Params)
+	}
+	if sourceHidden {
+		return fmt.Errorf("schema operation %q must be visible", configured.OperationID)
+	}
+	if securityRequired(source.Security) && !securityRequired(target.Security) {
+		return fmt.Errorf("schema operation %q requires authentication but target is public", configured.OperationID)
+	}
+	if !scopesContain(target.Security, source.Security) {
+		return fmt.Errorf("target auth scopes must include schema operation %q scopes", configured.OperationID)
+	}
+
+	mapped := map[string]bool{}
+	for key, value := range configured.Params {
+		param, ok := findParam(sourceParams, key)
+		if !ok {
+			return fmt.Errorf("schema operation parameter %q does not exist", key)
+		}
+		if mapped[param.Name] {
+			return fmt.Errorf("schema operation parameter %q is mapped more than once", param.Name)
+		}
+		mapped[param.Name] = true
+		if strings.HasPrefix(value, "${") {
+			ref, ok := runtimeSchemaParamRef(value)
+			if !ok {
+				return fmt.Errorf("parameter %q has invalid target reference %q", key, value)
+			}
+			targetParam, ok := findParam(targetParams, ref)
+			if !ok {
+				return fmt.Errorf("target parameter %q does not exist", ref)
+			}
+			if targetParam.GoType != param.GoType {
+				return fmt.Errorf("target parameter %q type %q does not match schema operation parameter %q type %q", ref, targetParam.GoType, param.Name, param.GoType)
+			}
+			if param.Required && param.Default == "" && !targetParam.Required && targetParam.Default == "" {
+				return fmt.Errorf("required schema operation parameter %q maps from optional target parameter %q", param.Name, ref)
+			}
+		}
+	}
+	for _, param := range sourceParams {
+		if param.Required && param.Default == "" && !mapped[param.Name] {
+			return fmt.Errorf("required schema operation parameter %q is not mapped", param.Name)
+		}
+	}
+	return nil
+}
+
+func effectiveOverlayParams(params []runtime.ParamSpec, overrides map[string]overlay.ParamOverride) []runtime.ParamSpec {
+	out := append([]runtime.ParamSpec(nil), params...)
+	for index := range out {
+		override, ok := overrides[out[index].Name]
+		if !ok {
+			continue
+		}
+		if override.Flag != "" {
+			out[index].Flag = override.Flag
+		}
+		if override.Required {
+			out[index].Required = true
+		}
+		if override.Default != "" {
+			out[index].Default = override.Default
+		}
+	}
+	return out
+}
+
+func jsonMediaType(mediaType string) bool {
+	mediaType, _, _ = strings.Cut(strings.ToLower(strings.TrimSpace(mediaType)), ";")
+	return mediaType == "" || mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func runtimeSchemaParamRef(value string) (string, bool) {
+	const prefix = "${params."
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, "}") {
+		return "", false
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(value, prefix), "}")
+	return name, name != "" && !strings.ContainsAny(name, "${}")
+}
+
+func findParam(params []runtime.ParamSpec, name string) (runtime.ParamSpec, bool) {
+	for _, param := range params {
+		if param.Name == name || param.Flag == name {
+			return param, true
+		}
+	}
+	return runtime.ParamSpec{}, false
+}
+
+func securityRequired(security *runtime.SecurityHint) bool {
+	return security == nil || !security.Public
+}
+
+func scopesContain(target, source *runtime.SecurityHint) bool {
+	if source == nil || len(source.Scopes) == 0 {
+		return true
+	}
+	if target == nil {
+		return false
+	}
+	wanted := map[string]bool{}
+	for _, scope := range target.Scopes {
+		wanted[scope] = true
+	}
+	for _, scope := range source.Scopes {
+		if !wanted[scope] {
+			return false
+		}
+	}
+	return true
 }
 
 func validateArguments(spec runtime.CommandSpec, overrides map[string]overlay.ParamOverride) error {
@@ -419,6 +606,10 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	for i := range cloned.Params {
 		cloned.Params[i].Aliases = append([]string(nil), spec.Params[i].Aliases...)
 		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
+	}
+	if spec.RequestBody != nil {
+		body := *spec.RequestBody
+		cloned.RequestBody = &body
 	}
 	if spec.Output.Streaming != nil {
 		streaming := *spec.Output.Streaming
@@ -977,8 +1168,23 @@ func requestBodyLiteral(body *runtime.RequestBody) string {
 	if body.Schema != nil {
 		fmt.Fprintf(&b, "Schema: %s,", schemaLiteral(body.Schema))
 	}
+	if body.RuntimeSchema != nil {
+		fmt.Fprintf(&b, "RuntimeSchema: %s,", runtimeSchemaSourceLiteral(body.RuntimeSchema))
+	}
 	writeStringField(&b, "Template", body.Template)
 	writeStringField(&b, "MergePath", body.MergePath)
+	b.WriteByte('}')
+	return b.String()
+}
+
+func runtimeSchemaSourceLiteral(source *runtime.RuntimeSchemaSource) string {
+	var b strings.Builder
+	b.WriteString("&runtime.RuntimeSchemaSource{")
+	fmt.Fprintf(&b, "Operation: %s,", commandSpecLiteral(source.Operation))
+	writeStringField(&b, "ResponsePath", source.ResponsePath)
+	if len(source.Params) > 0 {
+		fmt.Fprintf(&b, "Params: %s,", stringMapLiteral(source.Params))
+	}
 	b.WriteByte('}')
 	return b.String()
 }
@@ -1180,6 +1386,7 @@ var moduleTmpl = template.Must(template.New("gen").Funcs(template.FuncMap{
 	"schemaLiteral":      schemaLiteral,
 	"stringMapLiteral":   stringMapLiteral,
 	"outputHintsLiteral": outputHintsLiteral,
+	"requestBodyLiteral": requestBodyLiteral,
 }).Parse(`// Code generated by lathe codegen. DO NOT EDIT.
 
 package {{.Module}}
@@ -1285,22 +1492,8 @@ var Specs = []runtime.CommandSpec{
 		},
 		{{- end}}
 		{{- if $op.RequestBody}}
-			RequestBody: &runtime.RequestBody{
-				Required: {{$op.RequestBody.Required}},
-				{{- if $op.RequestBody.MediaType}}
-				MediaType: {{printf "%q" $op.RequestBody.MediaType}},
-				{{- end}}
-				{{- if $op.RequestBody.Schema}}
-				Schema: {{schemaLiteral $op.RequestBody.Schema}},
-				{{- end}}
-				{{- if $op.RequestBody.Template}}
-				Template: {{printf "%q" $op.RequestBody.Template}},
-				{{- end}}
-				{{- if $op.RequestBody.MergePath}}
-				MergePath: {{printf "%q" $op.RequestBody.MergePath}},
-				{{- end}}
-			},
-			{{- end}}
+		RequestBody: {{requestBodyLiteral $op.RequestBody}},
+		{{- end}}
 		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
 		Output: {{outputHintsLiteral $op.Output}},
 		{{- end}}

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -347,8 +347,8 @@ func validateRuntimeSchemaOverride(specs []runtime.CommandSpec, target runtime.C
 	if source.OperationID == target.OperationID {
 		return fmt.Errorf("schema operation must differ from the target operation")
 	}
-	if source.Method != "GET" && source.Method != "HEAD" {
-		return fmt.Errorf("schema operation %q must be read-only (GET or HEAD)", configured.OperationID)
+	if source.Method != "GET" {
+		return fmt.Errorf("schema operation %q must use GET", configured.OperationID)
 	}
 	if source.Output.Streaming != nil || !jsonMediaType(source.Output.ResponseMediaType) {
 		return fmt.Errorf("schema operation %q must return non-streaming JSON", configured.OperationID)

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -350,6 +350,9 @@ func validateRuntimeSchemaOverride(specs []runtime.CommandSpec, target runtime.C
 	if source.Method != "GET" {
 		return fmt.Errorf("schema operation %q must use GET", configured.OperationID)
 	}
+	if source.RequestBody != nil && source.RequestBody.Required {
+		return fmt.Errorf("schema operation %q must not require a request body", configured.OperationID)
+	}
 	if source.Output.Streaming != nil || !jsonMediaType(source.Output.ResponseMediaType) {
 		return fmt.Errorf("schema operation %q must return non-streaming JSON", configured.OperationID)
 	}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -564,10 +564,12 @@ func TestRenderModule_RuntimeBodySchema(t *testing.T) {
 		}
 	}
 
-	bad := preflight
-	bad.Method = "POST"
-	if err := ValidateOverlayModule([]runtime.CommandSpec{bad, run}, overlay.Module{Commands: overrides}); err == nil || !strings.Contains(err.Error(), "read-only") {
-		t.Fatalf("validation error = %v", err)
+	for _, method := range []string{"POST", "HEAD"} {
+		bad := preflight
+		bad.Method = method
+		if err := ValidateOverlayModule([]runtime.CommandSpec{bad, run}, overlay.Module{Commands: overrides}); err == nil {
+			t.Fatalf("%s schema operation accepted", method)
+		}
 	}
 	run.Params[0].Required = false
 	if err := ValidateOverlayModule([]runtime.CommandSpec{preflight, run}, overlay.Module{Commands: overrides}); err == nil || !strings.Contains(err.Error(), "optional target parameter") {

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -528,6 +528,53 @@ func TestMergeOverlayModule_StreamPolicy(t *testing.T) {
 	}
 }
 
+func TestRenderModule_RuntimeBodySchema(t *testing.T) {
+	chdirWithGoMod(t)
+	preflight := runtime.CommandSpec{
+		Group: "Apps", Use: "describe", OperationID: "Apps_Describe", Method: "GET", PathTpl: "/apps/{app_id}",
+		Params: []runtime.ParamSpec{
+			{Name: "app_id", Flag: "app-id", In: runtime.InPath, GoType: "string", Required: true},
+			{Name: "fields", Flag: "fields", In: runtime.InQuery, GoType: "string"},
+		},
+		Output: runtime.OutputHints{ResponseMediaType: "application/json"}, Security: &runtime.SecurityHint{Public: true},
+	}
+	run := runtime.CommandSpec{
+		Group: "Apps", Use: "run", OperationID: "Apps_Run", Method: "POST", PathTpl: "/apps/{app_id}:run",
+		Params:      []runtime.ParamSpec{{Name: "app_id", Flag: "app-id", In: runtime.InPath, GoType: "string", Required: true}},
+		RequestBody: &runtime.RequestBody{Required: true, MediaType: "application/json"},
+		Security:    &runtime.SecurityHint{Public: true},
+	}
+	overrides := map[string]overlay.Override{"run": {Body: &overlay.BodyOverride{RuntimeSchema: &overlay.RuntimeSchemaOverride{
+		OperationID: "Apps_Describe", ResponsePath: "input_schema",
+		Params: map[string]string{"app_id": "${params.app_id}", "fields": "input_schema"},
+	}}}}
+
+	if err := RenderModule("demo", "", []runtime.CommandSpec{preflight, run}, overrides); err != nil {
+		t.Fatalf("RenderModule: %v", err)
+	}
+	got := generatedModule(t, "demo")
+	for _, want := range []string{
+		`RuntimeSchema: &runtime.RuntimeSchemaSource{`,
+		`OperationID: "Apps_Describe"`,
+		`ResponsePath: "input_schema"`,
+		`"app_id": "${params.app_id}"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated module missing %q\n%s", want, got)
+		}
+	}
+
+	bad := preflight
+	bad.Method = "POST"
+	if err := ValidateOverlayModule([]runtime.CommandSpec{bad, run}, overlay.Module{Commands: overrides}); err == nil || !strings.Contains(err.Error(), "read-only") {
+		t.Fatalf("validation error = %v", err)
+	}
+	run.Params[0].Required = false
+	if err := ValidateOverlayModule([]runtime.CommandSpec{preflight, run}, overlay.Module{Commands: overrides}); err == nil || !strings.Contains(err.Error(), "optional target parameter") {
+		t.Fatalf("validation error = %v", err)
+	}
+}
+
 func TestRenderModule_NilOverrides(t *testing.T) {
 	chdirWithGoMod(t)
 

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -571,6 +571,11 @@ func TestRenderModule_RuntimeBodySchema(t *testing.T) {
 			t.Fatalf("%s schema operation accepted", method)
 		}
 	}
+	requiresBody := preflight
+	requiresBody.RequestBody = &runtime.RequestBody{Required: true, MediaType: "application/json"}
+	if err := ValidateOverlayModule([]runtime.CommandSpec{requiresBody, run}, overlay.Module{Commands: overrides}); err == nil {
+		t.Fatal("schema operation with required request body accepted")
+	}
 	run.Params[0].Required = false
 	if err := ValidateOverlayModule([]runtime.CommandSpec{preflight, run}, overlay.Module{Commands: overrides}); err == nil || !strings.Contains(err.Error(), "optional target parameter") {
 		t.Fatalf("validation error = %v", err)

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -526,6 +526,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- A configured stream pause is successful (`exit 0`); inspect the collected output field mapped from the pause event instead of treating it as an error.\n")
 	b.WriteString("- For collected streams, choose one mode: `-o json` for one stable document, `--stream` in the default output mode when catalog `output.streaming.policy.live` is present, or `-o raw` for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
+	b.WriteString("- When `body.runtime_schema` is present, find the catalog command with its `operation_id`, execute that command path with the mapped `params`, read the schema at `response_path`, then build the body. The target command repeats this preflight and validates before its API request.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
 	return b.String()
 }
@@ -555,7 +556,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `http`: HTTP method and path template.\n")
 	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, input modes, and help.\n")
-	b.WriteString("- `body`: request body requirement and media type.\n")
+	b.WriteString("- `body`: request body requirement, media type, and optional runtime schema source.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
 	b.WriteString("- `examples`: runnable examples with optional body shape, output hints, and follow-up commands.\n")
 	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints; a streaming policy describes collection, terminal outcomes, and optional live projection.\n")
@@ -576,6 +577,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--file -`: read a JSON body from stdin.\n")
 	b.WriteString("- `--set key.path=value`: build JSON with type inference for booleans, null, integers, and floats.\n")
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
+	b.WriteString("When `body.runtime_schema` is present, find the catalog command with its `operation_id`, execute that command path with the mapped `params`, and read the schema at `response_path`. The target command performs the same preflight and validates the body before its API request. `--dry-run` sends no requests, so it cannot perform dynamic validation.\n\n")
 	b.WriteString("## Output\n\n")
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
@@ -972,10 +974,12 @@ func bodySummary(body *runtime.RequestBody) string {
 		if merge == "" {
 			merge = "the document root"
 		}
-		return state + "; templated body, set inputs under `" + merge + "` with --set/--set-str/--file"
+		state += "; templated body, set inputs under `" + merge + "` with --set/--set-str/--file"
+	} else if body.MediaType != "" {
+		state += "; media type `" + body.MediaType + "`"
 	}
-	if body.MediaType != "" {
-		return state + "; media type `" + body.MediaType + "`"
+	if body.RuntimeSchema != nil {
+		state += "; runtime schema from operation `" + body.RuntimeSchema.Operation.OperationID + "` at `" + body.RuntimeSchema.ResponsePath + "`"
 	}
 	return state
 }

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -32,6 +32,15 @@ func TestBodySummary_PlainBodyUnchanged(t *testing.T) {
 	}
 }
 
+func TestBodySummary_RuntimeSchemaSource(t *testing.T) {
+	got := bodySummary(&runtime.RequestBody{Required: true, MediaType: "application/json", RuntimeSchema: &runtime.RuntimeSchemaSource{
+		Operation: runtime.CommandSpec{OperationID: "Apps_Describe"}, ResponsePath: "input_schema",
+	}})
+	if !strings.Contains(got, "Apps_Describe") || !strings.Contains(got, "input_schema") {
+		t.Errorf("bodySummary = %q", got)
+	}
+}
+
 func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	dir := t.TempDir()
 	manifest := &config.Manifest{

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -231,17 +231,17 @@ func buildGeneratedApp(cfg *sourceconfig.Config, overlays map[string]overlay.Mod
 		}
 
 		specs := normalize.Normalize(mod)
+		if src.DefaultHostname != nil {
+			for i := range specs {
+				specs[i].DefaultHostname = *src.DefaultHostname
+			}
+		}
 		if err := render.ValidateOverlayModule(specs, overlays[src.Name]); err != nil {
 			return nil, fmt.Errorf("source %q overlay: %w", src.Name, err)
 		}
 		specs = render.MergeOverlayModule(specs, overlays[src.Name])
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("source %q produced no commands: check its entry/file list, expose policy, and overlay ignore rules", src.Name)
-		}
-		if src.DefaultHostname != nil {
-			for i := range specs {
-				specs[i].DefaultHostname = *src.DefaultHostname
-			}
 		}
 		cliName := moduleNames[i]
 		flat, err := render.ResolveFlatCommandPath(manifest.CLI.CommandPath, len(ordered), specs)

--- a/internal/lathecmd/lathecmd_test.go
+++ b/internal/lathecmd/lathecmd_test.go
@@ -290,6 +290,80 @@ func TestRunCodegen_CommandPathFlatRewritesGeneratedExamples(t *testing.T) {
 	}
 }
 
+func TestRunCodegen_RuntimeSchemaInheritsDefaultHostname(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	seedCodegenProject(t, true)
+	writeCodegenFile(t, "specs/sources.yaml", `sources:
+  acme:
+    repo_url: https://example.com/acme.git
+    pinned_tag: v1.0.0
+    backend: openapi3
+    default_hostname: api.example.com
+    openapi3:
+      files: [openapi.yaml]
+`)
+	writeCodegenFile(t, ".cache/specs-sync/acme/openapi.yaml", `openapi: "3.0.3"
+paths:
+  /apps/{app_id}:
+    get:
+      operationId: Apps_Describe
+      tags: [Apps]
+      parameters:
+        - name: app_id
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: {type: object}
+  /apps/{app_id}:run:
+    post:
+      operationId: Apps_Run
+      tags: [Apps]
+      parameters:
+        - name: app_id
+          in: path
+          required: true
+          schema: {type: string}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {type: object}
+      responses:
+        "200":
+          content:
+            application/json:
+              schema: {type: object}
+`)
+	writeCodegenFile(t, "overlays/acme.yaml", `commands:
+  run:
+    body:
+      runtime_schema:
+        operation_id: Apps_Describe
+        response_path: input_schema
+        params:
+          app_id: ${params.app_id}
+`)
+
+	if err := RunCodegen([]string{"-sources", "specs/sources.yaml", "-cache", ".cache", "-overlay", "overlays"}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	generated := readCodegenFile(t, "internal/generated/acme/acme_gen.go")
+	start := strings.Index(generated, "RuntimeSchema:")
+	if start < 0 {
+		t.Fatalf("generated module missing runtime schema:\n%s", generated)
+	}
+	runtimeSchema := generated[start:]
+	end := strings.Index(runtimeSchema, "ResponsePath:")
+	if end < 0 || !strings.Contains(runtimeSchema[:end], `DefaultHostname: "api.example.com"`) {
+		t.Fatalf("embedded runtime schema operation missing default hostname:\n%s", generated)
+	}
+}
+
 func TestRunCodegen_UsesSkillConfigFromManifest(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -25,7 +25,18 @@ type Override struct {
 	Notes         []string                 `yaml:"notes"`
 	Prerequisites []string                 `yaml:"prerequisites"`
 	KnownErrors   []KnownError             `yaml:"known_errors"`
+	Body          *BodyOverride            `yaml:"body"`
 	Output        *OutputOverride          `yaml:"output"`
+}
+
+type BodyOverride struct {
+	RuntimeSchema *RuntimeSchemaOverride `yaml:"runtime_schema"`
+}
+
+type RuntimeSchemaOverride struct {
+	OperationID  string            `yaml:"operation_id"`
+	ResponsePath string            `yaml:"response_path"`
+	Params       map[string]string `yaml:"params"`
 }
 
 type OutputOverride struct {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1316,6 +1316,31 @@ func TestRuntimeBodySchema_IntegerUsesNumericValue(t *testing.T) {
 	}
 }
 
+func TestRuntimeBodySchema_EnumNumbersUseNumericValue(t *testing.T) {
+	for _, tc := range []struct {
+		schema string
+		value  string
+		valid  bool
+	}{
+		{`{"enum":[2]}`, `2.0`, true},
+		{`{"enum":[{"values":[2]}]}`, `{"values":[2e0]}`, true},
+		{`{"enum":[2]}`, `2.5`, false},
+	} {
+		schema, err := decodeJSON([]byte(tc.schema))
+		if err != nil {
+			t.Fatalf("decode schema %s: %v", tc.schema, err)
+		}
+		value, err := decodeJSON([]byte(tc.value))
+		if err != nil {
+			t.Fatalf("decode value %s: %v", tc.value, err)
+		}
+		err = validateRuntimeJSONSchema(schema, value, "$", "$schema")
+		if (err == nil) != tc.valid {
+			t.Errorf("validate %s against %s: error = %v, valid = %v", tc.value, tc.schema, err, tc.valid)
+		}
+	}
+}
+
 func TestBuild_PaginationFlagsAttached(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:   "Items",

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -1157,6 +1158,141 @@ func TestBuild_InvalidOutputBlocksBeforeRequest(t *testing.T) {
 	err := root.Execute()
 	if err == nil || ClassifyError(err).Code != CodeUsage {
 		t.Fatalf("error = %v, want usage", err)
+	}
+	if hits != 0 {
+		t.Fatalf("server hits = %d, want 0", hits)
+	}
+}
+
+func TestBuild_RuntimeBodySchemaPreflightsAndValidatesBeforeTarget(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	tests := []struct {
+		name       string
+		sets       []string
+		wantCode   string
+		wantTarget int
+		schema     string
+	}{
+		{name: "valid", sets: []string{"query=hello", "inputs.industry=health", "inputs.tier=pro", "inputs.count=2"}, wantTarget: 1},
+		{name: "missing required", sets: []string{"query=hello", "inputs.tier=pro"}, wantCode: CodeUsage},
+		{name: "unknown input", sets: []string{"query=hello", "inputs.industry=health", "inputs.unknown=value"}, wantCode: CodeUsage},
+		{name: "wrong type", sets: []string{"query=hello", "inputs.industry=health", "inputs.count=many"}, wantCode: CodeUsage},
+		{name: "invalid enum", sets: []string{"query=hello", "inputs.industry=health", "inputs.tier=trial"}, wantCode: CodeUsage},
+		{name: "unsupported schema", sets: []string{"query=hello", "inputs.industry=health"}, wantCode: CodeAPIError, schema: `{"type":"object","properties":{"unused":{"type":"string","pattern":"secret"}}}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var preflightHits, targetHits int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/apps/app-1":
+					preflightHits++
+					if got := r.URL.Query().Get("fields"); got != "input_schema" {
+						t.Errorf("preflight fields = %q", got)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					schema := tc.schema
+					if schema == "" {
+						schema = `{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"query":{"type":"string","minLength":1},"inputs":{"type":"object","properties":{"industry":{"type":"string","maxLength":20},"tier":{"type":"string","enum":["free","pro"]},"count":{"type":"number"}},"required":["industry"],"additionalProperties":false}},"required":["query","inputs"]}`
+					}
+					_, _ = fmt.Fprintf(w, `{"input_schema":%s}`, schema)
+				case "/apps/app-1:run":
+					targetHits++
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"ok":true}`))
+				default:
+					t.Errorf("unexpected path %q", r.URL.Path)
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			preflight := CommandSpec{
+				Group: "Apps", Use: "describe", OperationID: "Apps_Describe", Method: "GET", PathTpl: "/apps/{app_id}",
+				Params: []ParamSpec{
+					{Name: "app_id", Flag: "app-id", In: InPath, GoType: "string", Required: true},
+					{Name: "fields", Flag: "fields", In: InQuery, GoType: "string"},
+				},
+				Output:   OutputHints{ResponseMediaType: "application/json"},
+				Security: &SecurityHint{Public: true},
+			}
+			run := CommandSpec{
+				Group: "Apps", Use: "run", OperationID: "Apps_Run", Method: "POST", PathTpl: "/apps/{app_id}:run",
+				Params: []ParamSpec{{Name: "app_id", Flag: "app-id", In: InPath, GoType: "string", Required: true}},
+				RequestBody: &RequestBody{
+					Required: true, MediaType: "application/json",
+					RuntimeSchema: &RuntimeSchemaSource{
+						Operation: preflight, ResponsePath: "input_schema",
+						Params: map[string]string{"app_id": "${params.app_id}", "fields": "input_schema"},
+					},
+				},
+				Security: &SecurityHint{Public: true},
+			}
+
+			root := newRootWithModuleGroup()
+			root.SetOut(io.Discard)
+			root.SetErr(io.Discard)
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "raw", "")
+			mustBuild(t, root, "demo", []CommandSpec{preflight, run})
+			args := []string{"--hostname", srv.URL, "demo", "apps", "run", "--app-id", "app-1"}
+			for _, set := range tc.sets {
+				args = append(args, "--set", set)
+			}
+			root.SetArgs(args)
+
+			err := root.Execute()
+			if tc.wantCode == "" {
+				if err != nil {
+					t.Fatalf("Execute: %v", err)
+				}
+			} else if err == nil || ClassifyError(err).Code != tc.wantCode {
+				t.Fatalf("error = %v, code = %q, want %q", err, ClassifyError(err).Code, tc.wantCode)
+			}
+			if preflightHits != 1 {
+				t.Fatalf("preflight hits = %d, want 1", preflightHits)
+			}
+			if targetHits != tc.wantTarget {
+				t.Fatalf("target hits = %d, want %d", targetHits, tc.wantTarget)
+			}
+		})
+	}
+}
+
+func TestBuild_RuntimeBodySchemaDryRunDoesNotPreflight(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	preflight := CommandSpec{OperationID: "Apps_Describe", Method: "GET", PathTpl: "/apps/{app_id}", Params: []ParamSpec{{Name: "app_id", Flag: "app-id", In: InPath, GoType: "string", Required: true}}, Security: &SecurityHint{Public: true}}
+	run := CommandSpec{
+		Group: "Apps", Use: "run", Method: "POST", PathTpl: "/apps/{app_id}:run",
+		Params: []ParamSpec{{Name: "app_id", Flag: "app-id", In: InPath, GoType: "string", Required: true}},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json", RuntimeSchema: &RuntimeSchemaSource{
+			Operation: preflight, ResponsePath: "input_schema", Params: map[string]string{"app_id": "${params.app_id}"},
+		}},
+		Security: &SecurityHint{Public: true},
+	}
+
+	root := newRootWithModuleGroup()
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", []CommandSpec{preflight, run})
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "apps", "run", "--app-id", "app-1", "--set", "inputs.unknown=value", "--dry-run"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
 	}
 	if hits != 0 {
 		t.Fatalf("server hits = %d, want 0", hits)

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1181,6 +1181,8 @@ func TestBuild_RuntimeBodySchemaPreflightsAndValidatesBeforeTarget(t *testing.T)
 		{name: "wrong type", sets: []string{"query=hello", "inputs.industry=health", "inputs.count=many"}, wantCode: CodeUsage},
 		{name: "invalid enum", sets: []string{"query=hello", "inputs.industry=health", "inputs.tier=trial"}, wantCode: CodeUsage},
 		{name: "unsupported schema", sets: []string{"query=hello", "inputs.industry=health"}, wantCode: CodeAPIError, schema: `{"type":"object","properties":{"unused":{"type":"string","pattern":"secret"}}}`},
+		{name: "null properties", sets: []string{"query=hello"}, wantCode: CodeAPIError, schema: `{"type":"object","properties":null}`},
+		{name: "null required", sets: []string{"query=hello"}, wantCode: CodeAPIError, schema: `{"type":"object","required":null}`},
 	}
 
 	for _, tc := range tests {
@@ -1249,8 +1251,10 @@ func TestBuild_RuntimeBodySchemaPreflightsAndValidatesBeforeTarget(t *testing.T)
 				if err != nil {
 					t.Fatalf("Execute: %v", err)
 				}
-			} else if err == nil || ClassifyError(err).Code != tc.wantCode {
-				t.Fatalf("error = %v, code = %q, want %q", err, ClassifyError(err).Code, tc.wantCode)
+			} else if err == nil {
+				t.Fatalf("error = nil, want code %q", tc.wantCode)
+			} else if code := ClassifyError(err).Code; code != tc.wantCode {
+				t.Fatalf("error = %v, code = %q, want %q", err, code, tc.wantCode)
 			}
 			if preflightHits != 1 {
 				t.Fatalf("preflight hits = %d, want 1", preflightHits)
@@ -1337,6 +1341,22 @@ func TestRuntimeBodySchema_EnumNumbersUseNumericValue(t *testing.T) {
 		err = validateRuntimeJSONSchema(schema, value, "$", "$schema")
 		if (err == nil) != tc.valid {
 			t.Errorf("validate %s against %s: error = %v, valid = %v", tc.value, tc.schema, err, tc.valid)
+		}
+	}
+}
+
+func TestRuntimeBodySchema_LengthBoundsUseNumericValue(t *testing.T) {
+	for _, tc := range []struct {
+		bound string
+		valid bool
+	}{{"2.0", true}, {"2e0", true}, {"2.5", false}} {
+		schema, err := decodeJSON([]byte(`{"type":"string","minLength":` + tc.bound + `}`))
+		if err != nil {
+			t.Fatalf("decode minLength %s: %v", tc.bound, err)
+		}
+		err = validateRuntimeSchemaDefinition(schema, "$schema")
+		if (err == nil) != tc.valid {
+			t.Errorf("validate minLength %s: error = %v, valid = %v", tc.bound, err, tc.valid)
 		}
 	}
 }

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1299,6 +1299,23 @@ func TestBuild_RuntimeBodySchemaDryRunDoesNotPreflight(t *testing.T) {
 	}
 }
 
+func TestRuntimeBodySchema_IntegerUsesNumericValue(t *testing.T) {
+	schema := map[string]any{"type": "integer"}
+	for _, tc := range []struct {
+		literal string
+		valid   bool
+	}{{"2.0", true}, {"2e0", true}, {"2.5", false}} {
+		value, err := decodeJSON([]byte(tc.literal))
+		if err != nil {
+			t.Fatalf("decode %s: %v", tc.literal, err)
+		}
+		err = validateRuntimeJSONSchema(schema, value, "$", "$schema")
+		if (err == nil) != tc.valid {
+			t.Errorf("validate %s: error = %v, valid = %v", tc.literal, err, tc.valid)
+		}
+	}
+}
+
 func TestBuild_PaginationFlagsAttached(t *testing.T) {
 	specs := []CommandSpec{{
 		Group:   "Items",

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 15
+const CatalogSchemaVersion = 16
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -105,11 +105,19 @@ type CatalogAuth struct {
 }
 
 type CatalogBody struct {
-	Required  bool        `json:"required"`
-	MediaType string      `json:"media_type,omitempty"`
-	Schema    *SchemaSpec `json:"schema,omitempty"`
-	Template  string      `json:"template,omitempty"`
-	MergePath string      `json:"merge_path,omitempty"`
+	Required      bool                  `json:"required"`
+	MediaType     string                `json:"media_type,omitempty"`
+	Schema        *SchemaSpec           `json:"schema,omitempty"`
+	RuntimeSchema *CatalogRuntimeSchema `json:"runtime_schema,omitempty"`
+	Template      string                `json:"template,omitempty"`
+	MergePath     string                `json:"merge_path,omitempty"`
+}
+
+type CatalogRuntimeSchema struct {
+	OperationID  string            `json:"operation_id"`
+	HTTP         CatalogHTTP       `json:"http"`
+	ResponsePath string            `json:"response_path"`
+	Params       map[string]string `json:"params,omitempty"`
 }
 
 type CatalogFlag struct {
@@ -388,14 +396,31 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 	}
 	if spec.RequestBody != nil {
 		cmd.Body = &CatalogBody{
-			Required:  spec.RequestBody.Required,
-			MediaType: spec.RequestBody.MediaType,
-			Schema:    spec.RequestBody.Schema,
-			Template:  spec.RequestBody.Template,
-			MergePath: spec.RequestBody.MergePath,
+			Required:      spec.RequestBody.Required,
+			MediaType:     spec.RequestBody.MediaType,
+			Schema:        spec.RequestBody.Schema,
+			RuntimeSchema: catalogRuntimeSchema(spec.RequestBody.RuntimeSchema),
+			Template:      spec.RequestBody.Template,
+			MergePath:     spec.RequestBody.MergePath,
 		}
 	}
 	return cmd
+}
+
+func catalogRuntimeSchema(source *RuntimeSchemaSource) *CatalogRuntimeSchema {
+	if source == nil {
+		return nil
+	}
+	return &CatalogRuntimeSchema{
+		OperationID: source.Operation.OperationID,
+		HTTP: CatalogHTTP{
+			Method:          source.Operation.Method,
+			PathTemplate:    source.Operation.PathTpl,
+			DefaultHostname: source.Operation.DefaultHostname,
+		},
+		ResponsePath: source.ResponsePath,
+		Params:       copyStringMap(source.Params),
+	}
 }
 
 func catalogWorkflowConditions(conditions []WorkflowCondition) []CatalogWorkflowCondition {

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -294,6 +294,26 @@ func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
 	}
 }
 
+func TestBuildCatalog_RuntimeBodySchema(t *testing.T) {
+	root := newRootWithModuleGroup()
+	preflight := CommandSpec{OperationID: "Apps_Describe", Method: "GET", PathTpl: "/apps/{app_id}"}
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group: "Apps", Use: "run", OperationID: "Apps_Run", Method: "POST", PathTpl: "/apps/{app_id}:run",
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json", RuntimeSchema: &RuntimeSchemaSource{
+			Operation: preflight, ResponsePath: "input_schema", Params: map[string]string{"app_id": "${params.app_id}"},
+		}},
+	}})
+
+	body := BuildCatalog(root, CatalogOptions{}).Commands[0].Body
+	if body == nil || body.RuntimeSchema == nil {
+		t.Fatalf("body = %+v", body)
+	}
+	got := body.RuntimeSchema
+	if got.OperationID != "Apps_Describe" || got.HTTP.Method != "GET" || got.HTTP.PathTemplate != "/apps/{app_id}" || got.ResponsePath != "input_schema" || got.Params["app_id"] != "${params.app_id}" {
+		t.Fatalf("runtime schema = %+v", got)
+	}
+}
+
 func TestBuildCatalog_SensitiveFlagInputModes(t *testing.T) {
 	root := newRootWithModuleGroup()
 	mustBuild(t, root, "demo", []CommandSpec{{
@@ -475,8 +495,8 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 
 	catalog := BuildCatalog(root, CatalogOptions{})
-	if catalog.CatalogSchemaVersion != 15 {
-		t.Fatalf("schema version = %d, want 15", catalog.CatalogSchemaVersion)
+	if catalog.CatalogSchemaVersion != 16 {
+		t.Fatalf("schema version = %d, want 16", catalog.CatalogSchemaVersion)
 	}
 	var step *CatalogWorkflowStep
 	for i, entry := range catalog.Commands {

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -139,6 +139,39 @@ func TestInvokeOperation_RedactsQueryCredentialFromTransportError(t *testing.T) 
 	}
 }
 
+func TestRuntimeBodySchema_RedactsMappedSensitiveQuery(t *testing.T) {
+	const secret = "runtime-schema-secret"
+	var gotSecret string
+	source := CommandSpec{
+		Method: "GET", PathTpl: "/schema",
+		Params: []ParamSpec{{Name: "id", Flag: "id", In: InQuery, GoType: "string"}},
+	}
+	target := CommandSpec{
+		Params: []ParamSpec{{Name: "password", Flag: "password", In: InQuery, GoType: "string", Format: "password"}},
+		RequestBody: &RequestBody{RuntimeSchema: &RuntimeSchemaSource{
+			Operation: source, ResponsePath: "schema", Params: map[string]string{"id": "${params.password}"},
+		}},
+	}
+	err := validateRuntimeRequestBody(context.Background(), target, OperationInput{
+		Values: map[string]any{"password": secret}, Changed: map[string]bool{"password": true},
+	}, map[string]any{}, OperationOptions{Hostname: "example.com", Client: ClientOptions{
+		MaxRetries: -1,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			gotSecret = req.URL.Query().Get("id")
+			return nil, errors.New("dial failed")
+		}),
+	}})
+	if err == nil {
+		t.Fatal("runtime schema request returned nil error")
+	}
+	if gotSecret != secret {
+		t.Fatalf("runtime schema query = %q", gotSecret)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("runtime schema error leaked mapped credential: %v", err)
+	}
+}
+
 func TestDoRaw_RedactsMalformedRedirectLocation(t *testing.T) {
 	const password = "redirect-userinfo-secret"
 	const signature = "redirect-signature-secret"

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -75,6 +75,11 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		}
 		return OperationResult{DryRun: &out, Outcome: OperationOutcomeCompleted}, nil
 	}
+	if s.RequestBody != nil && s.RequestBody.RuntimeSchema != nil {
+		if err := validateRuntimeRequestBody(ctx, s, input, body, opts); err != nil {
+			return OperationResult{}, err
+		}
+	}
 
 	var data []byte
 	outcome := OperationOutcomeCompleted

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -1,0 +1,400 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+var runtimeSchemaAnnotations = map[string]bool{
+	"$schema": true, "$id": true, "title": true, "description": true,
+	"default": true, "examples": true, "readOnly": true, "writeOnly": true,
+	"deprecated": true,
+}
+
+func validateRuntimeRequestBody(ctx context.Context, target CommandSpec, input OperationInput, body any, opts OperationOptions) error {
+	source := target.RequestBody.RuntimeSchema
+	if source.Operation.Method != "GET" && source.Operation.Method != "HEAD" {
+		return newAPIError(fmt.Errorf("runtime schema operation must be read-only"), 0)
+	}
+	if source.Operation.Output.Streaming != nil || source.Operation.RequestBody != nil && source.Operation.RequestBody.RuntimeSchema != nil {
+		return newAPIError(fmt.Errorf("runtime schema operation must be non-streaming and non-recursive"), 0)
+	}
+	sourceInput, err := runtimeSchemaOperationInput(target, input, source)
+	if err != nil {
+		return newAPIError(err, 0)
+	}
+	result, err := InvokeOperation(ctx, source.Operation, sourceInput, OperationOptions{Hostname: opts.Hostname, Client: opts.Client})
+	if err != nil {
+		return err
+	}
+
+	response, err := decodeJSON(result.Data)
+	if err != nil {
+		return newAPIError(fmt.Errorf("decode runtime schema response: %w", err), 0)
+	}
+	schema, ok := getNestedPath(response, source.ResponsePath)
+	if !ok {
+		return newAPIError(fmt.Errorf("runtime schema response path %q not found", source.ResponsePath), 0)
+	}
+	value, err := requestBodyJSONValue(body)
+	if err != nil {
+		return NewError(CodeUsage, ExitUsage, "request body does not match runtime schema", "inspect the declared schema operation and correct the request body", err)
+	}
+	if err := validateRuntimeSchemaDefinition(schema, "$schema"); err != nil {
+		return newAPIError(err, 0)
+	}
+	if err := validateRuntimeJSONSchema(schema, value, "$", "$schema"); err != nil {
+		return NewError(CodeUsage, ExitUsage, "request body does not match runtime schema", "inspect the declared schema operation and correct the request body", err)
+	}
+	return nil
+}
+
+func runtimeSchemaOperationInput(target CommandSpec, input OperationInput, source *RuntimeSchemaSource) (OperationInput, error) {
+	out := OperationInput{Values: map[string]any{}, Changed: map[string]bool{}}
+	for key, expression := range source.Params {
+		param, ok := findOperationParam(source.Operation.Params, key)
+		if !ok {
+			return OperationInput{}, fmt.Errorf("runtime schema parameter %q does not exist", key)
+		}
+		value := any(expression)
+		if ref, ok := runtimeSchemaParamRef(expression); ok {
+			targetParam, found := findOperationParam(target.Params, ref)
+			if !found {
+				return OperationInput{}, fmt.Errorf("runtime schema target parameter %q does not exist", ref)
+			}
+			resolved, changed, err := operationValue(input, targetParam)
+			if err != nil {
+				return OperationInput{}, err
+			}
+			if !changed {
+				if !param.Required || param.Default != "" {
+					continue
+				}
+				return OperationInput{}, fmt.Errorf("runtime schema target parameter %q is not set", ref)
+			}
+			value = resolved
+		}
+		out.Values[param.Name] = value
+		out.Changed[param.Name] = true
+	}
+	return out, nil
+}
+
+func runtimeSchemaParamRef(value string) (string, bool) {
+	const prefix = "${params."
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, "}") {
+		return "", false
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(value, prefix), "}")
+	return name, name != "" && !strings.ContainsAny(name, "${}")
+}
+
+func findOperationParam(params []ParamSpec, name string) (ParamSpec, bool) {
+	for _, param := range params {
+		if param.Name == name || param.Flag == name {
+			return param, true
+		}
+	}
+	return ParamSpec{}, false
+}
+
+func requestBodyJSONValue(body any) (any, error) {
+	if body == nil {
+		return nil, nil
+	}
+	if data, ok := body.([]byte); ok {
+		return decodeJSON(data)
+	}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	return decodeJSON(data)
+}
+
+func decodeJSON(data []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("unexpected data after JSON value")
+	}
+	return value, nil
+}
+
+func validateRuntimeSchemaDefinition(schema any, path string) error {
+	if _, ok := schema.(bool); ok {
+		return nil
+	}
+	object, ok := schema.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must be an object or boolean", path)
+	}
+	for keyword := range object {
+		if runtimeSchemaAnnotations[keyword] {
+			continue
+		}
+		switch keyword {
+		case "type", "properties", "required", "additionalProperties", "items", "enum", "minLength", "maxLength":
+		default:
+			return fmt.Errorf("%s uses unsupported keyword %q", path, keyword)
+		}
+	}
+	if rawType, exists := object["type"]; exists {
+		typeName, ok := rawType.(string)
+		if !ok || !runtimeJSONTypeSupported(typeName) {
+			return fmt.Errorf("%s.type is unsupported", path)
+		}
+	}
+	properties, err := schemaObject(object["properties"], path+".properties")
+	if err != nil {
+		return err
+	}
+	for name, child := range properties {
+		if err := validateRuntimeSchemaDefinition(child, path+".properties."+name); err != nil {
+			return err
+		}
+	}
+	if _, err := schemaStringArray(object["required"], path+".required"); err != nil {
+		return err
+	}
+	if additional, exists := object["additionalProperties"]; exists {
+		if _, ok := additional.(bool); !ok {
+			if err := validateRuntimeSchemaDefinition(additional, path+".additionalProperties"); err != nil {
+				return err
+			}
+		}
+	}
+	if items, exists := object["items"]; exists {
+		if err := validateRuntimeSchemaDefinition(items, path+".items"); err != nil {
+			return err
+		}
+	}
+	if enum, exists := object["enum"]; exists {
+		values, ok := enum.([]any)
+		if !ok || len(values) == 0 {
+			return fmt.Errorf("%s.enum must be a non-empty array", path)
+		}
+	}
+	minimum, hasMinimum := object["minLength"]
+	if hasMinimum {
+		if _, err := schemaNonNegativeInt(minimum, path+".minLength"); err != nil {
+			return err
+		}
+	}
+	maximum, hasMaximum := object["maxLength"]
+	if hasMaximum {
+		if _, err := schemaNonNegativeInt(maximum, path+".maxLength"); err != nil {
+			return err
+		}
+	}
+	if hasMinimum && hasMaximum {
+		min, _ := schemaNonNegativeInt(minimum, path+".minLength")
+		max, _ := schemaNonNegativeInt(maximum, path+".maxLength")
+		if min > max {
+			return fmt.Errorf("%s.minLength exceeds maxLength", path)
+		}
+	}
+	return nil
+}
+
+func validateRuntimeJSONSchema(schema, value any, valuePath, schemaPath string) error {
+	if allowed, ok := schema.(bool); ok {
+		if !allowed {
+			return fmt.Errorf("%s is not allowed", valuePath)
+		}
+		return nil
+	}
+	object, ok := schema.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s must be an object or boolean", schemaPath)
+	}
+	for keyword := range object {
+		if runtimeSchemaAnnotations[keyword] {
+			continue
+		}
+		switch keyword {
+		case "type", "properties", "required", "additionalProperties", "items", "enum", "minLength", "maxLength":
+		default:
+			return fmt.Errorf("%s uses unsupported keyword %q", schemaPath, keyword)
+		}
+	}
+	if rawType, exists := object["type"]; exists {
+		typeName, ok := rawType.(string)
+		if !ok {
+			return fmt.Errorf("%s.type must be a string", schemaPath)
+		}
+		if !runtimeJSONTypeMatches(typeName, value) {
+			return fmt.Errorf("%s must be %s", valuePath, typeName)
+		}
+	}
+	if enum, exists := object["enum"]; exists {
+		values, ok := enum.([]any)
+		if !ok {
+			return fmt.Errorf("%s.enum must be an array", schemaPath)
+		}
+		matched := false
+		for _, candidate := range values {
+			if reflect.DeepEqual(candidate, value) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("%s is not an allowed value", valuePath)
+		}
+	}
+	if text, ok := value.(string); ok {
+		length := utf8.RuneCountInString(text)
+		if raw, exists := object["minLength"]; exists {
+			minimum, err := schemaNonNegativeInt(raw, schemaPath+".minLength")
+			if err != nil {
+				return err
+			}
+			if length < minimum {
+				return fmt.Errorf("%s must contain at least %d characters", valuePath, minimum)
+			}
+		}
+		if raw, exists := object["maxLength"]; exists {
+			maximum, err := schemaNonNegativeInt(raw, schemaPath+".maxLength")
+			if err != nil {
+				return err
+			}
+			if length > maximum {
+				return fmt.Errorf("%s must contain at most %d characters", valuePath, maximum)
+			}
+		}
+	}
+	if objectValue, ok := value.(map[string]any); ok {
+		properties, err := schemaObject(object["properties"], schemaPath+".properties")
+		if err != nil {
+			return err
+		}
+		required, err := schemaStringArray(object["required"], schemaPath+".required")
+		if err != nil {
+			return err
+		}
+		for _, name := range required {
+			if _, exists := objectValue[name]; !exists {
+				return fmt.Errorf("%s.%s is required", valuePath, name)
+			}
+		}
+		for name, child := range objectValue {
+			if childSchema, exists := properties[name]; exists {
+				if err := validateRuntimeJSONSchema(childSchema, child, valuePath+"."+name, schemaPath+".properties."+name); err != nil {
+					return err
+				}
+				continue
+			}
+			additional, exists := object["additionalProperties"]
+			if !exists || additional == true {
+				continue
+			}
+			if additional == false {
+				return fmt.Errorf("%s.%s is not allowed", valuePath, name)
+			}
+			if err := validateRuntimeJSONSchema(additional, child, valuePath+"."+name, schemaPath+".additionalProperties"); err != nil {
+				return err
+			}
+		}
+	}
+	if items, exists := object["items"]; exists {
+		array, ok := value.([]any)
+		if !ok {
+			return nil
+		}
+		for index, child := range array {
+			if err := validateRuntimeJSONSchema(items, child, fmt.Sprintf("%s[%d]", valuePath, index), schemaPath+".items"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func runtimeJSONTypeMatches(typeName string, value any) bool {
+	switch typeName {
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "number":
+		_, ok := value.(json.Number)
+		return ok
+	case "integer":
+		number, ok := value.(json.Number)
+		return ok && !strings.ContainsAny(number.String(), ".eE")
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "null":
+		return value == nil
+	default:
+		return false
+	}
+}
+
+func runtimeJSONTypeSupported(typeName string) bool {
+	switch typeName {
+	case "object", "array", "string", "number", "integer", "boolean", "null":
+		return true
+	default:
+		return false
+	}
+}
+
+func schemaObject(value any, path string) (map[string]any, error) {
+	if value == nil {
+		return nil, nil
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object", path)
+	}
+	return object, nil
+}
+
+func schemaStringArray(value any, path string) ([]string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	array, ok := value.([]any)
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", path)
+	}
+	out := make([]string, 0, len(array))
+	for _, item := range array {
+		text, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s must contain only strings", path)
+		}
+		out = append(out, text)
+	}
+	return out, nil
+}
+
+func schemaNonNegativeInt(value any, path string) (int, error) {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0, fmt.Errorf("%s must be a non-negative integer", path)
+	}
+	parsed, err := number.Int64()
+	if err != nil || parsed < 0 {
+		return 0, fmt.Errorf("%s must be a non-negative integer", path)
+	}
+	return int(parsed), nil
+}

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -26,11 +26,11 @@ func validateRuntimeRequestBody(ctx context.Context, target CommandSpec, input O
 	if source.Operation.Output.Streaming != nil || source.Operation.RequestBody != nil && source.Operation.RequestBody.RuntimeSchema != nil {
 		return newAPIError(fmt.Errorf("runtime schema operation must be non-streaming and non-recursive"), 0)
 	}
-	sourceInput, err := runtimeSchemaOperationInput(target, input, source)
+	sourceOperation, sourceInput, err := runtimeSchemaOperationInput(target, input, source)
 	if err != nil {
 		return newAPIError(err, 0)
 	}
-	result, err := InvokeOperation(ctx, source.Operation, sourceInput, OperationOptions{Hostname: opts.Hostname, Client: opts.Client})
+	result, err := InvokeOperation(ctx, sourceOperation, sourceInput, OperationOptions{Hostname: opts.Hostname, Client: opts.Client})
 	if err != nil {
 		return err
 	}
@@ -56,35 +56,45 @@ func validateRuntimeRequestBody(ctx context.Context, target CommandSpec, input O
 	return nil
 }
 
-func runtimeSchemaOperationInput(target CommandSpec, input OperationInput, source *RuntimeSchemaSource) (OperationInput, error) {
+func runtimeSchemaOperationInput(target CommandSpec, input OperationInput, source *RuntimeSchemaSource) (CommandSpec, OperationInput, error) {
+	operation := source.Operation
+	operation.Params = append([]ParamSpec(nil), source.Operation.Params...)
 	out := OperationInput{Values: map[string]any{}, Changed: map[string]bool{}}
 	for key, expression := range source.Params {
 		param, ok := findOperationParam(source.Operation.Params, key)
 		if !ok {
-			return OperationInput{}, fmt.Errorf("runtime schema parameter %q does not exist", key)
+			return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema parameter %q does not exist", key)
 		}
 		value := any(expression)
 		if ref, ok := runtimeSchemaParamRef(expression); ok {
 			targetParam, found := findOperationParam(target.Params, ref)
 			if !found {
-				return OperationInput{}, fmt.Errorf("runtime schema target parameter %q does not exist", ref)
+				return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema target parameter %q does not exist", ref)
 			}
 			resolved, changed, err := operationValue(input, targetParam)
 			if err != nil {
-				return OperationInput{}, err
+				return CommandSpec{}, OperationInput{}, err
 			}
 			if !changed {
 				if !param.Required || param.Default != "" {
 					continue
 				}
-				return OperationInput{}, fmt.Errorf("runtime schema target parameter %q is not set", ref)
+				return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema target parameter %q is not set", ref)
+			}
+			if param.In == InQuery && isSensitiveStringParam(targetParam) {
+				for i := range operation.Params {
+					if operation.Params[i].Name == param.Name {
+						operation.Params[i].Format = "password"
+						break
+					}
+				}
 			}
 			value = resolved
 		}
 		out.Values[param.Name] = value
 		out.Changed[param.Name] = true
 	}
-	return out, nil
+	return operation, out, nil
 }
 
 func runtimeSchemaParamRef(value string) (string, bool) {
@@ -156,7 +166,7 @@ func validateRuntimeSchemaDefinition(schema any, path string) error {
 			return fmt.Errorf("%s.type is unsupported", path)
 		}
 	}
-	properties, err := schemaObject(object["properties"], path+".properties")
+	properties, err := schemaObject(object, "properties", path+".properties")
 	if err != nil {
 		return err
 	}
@@ -165,7 +175,7 @@ func validateRuntimeSchemaDefinition(schema any, path string) error {
 			return err
 		}
 	}
-	if _, err := schemaStringArray(object["required"], path+".required"); err != nil {
+	if _, err := schemaStringArray(object, "required", path+".required"); err != nil {
 		return err
 	}
 	if additional, exists := object["additionalProperties"]; exists {
@@ -276,11 +286,11 @@ func validateRuntimeJSONSchema(schema, value any, valuePath, schemaPath string) 
 		}
 	}
 	if objectValue, ok := value.(map[string]any); ok {
-		properties, err := schemaObject(object["properties"], schemaPath+".properties")
+		properties, err := schemaObject(object, "properties", schemaPath+".properties")
 		if err != nil {
 			return err
 		}
-		required, err := schemaStringArray(object["required"], schemaPath+".required")
+		required, err := schemaStringArray(object, "required", schemaPath+".required")
 		if err != nil {
 			return err
 		}
@@ -401,8 +411,9 @@ func runtimeJSONTypeSupported(typeName string) bool {
 	}
 }
 
-func schemaObject(value any, path string) (map[string]any, error) {
-	if value == nil {
+func schemaObject(schema map[string]any, keyword, path string) (map[string]any, error) {
+	value, exists := schema[keyword]
+	if !exists {
 		return nil, nil
 	}
 	object, ok := value.(map[string]any)
@@ -412,8 +423,9 @@ func schemaObject(value any, path string) (map[string]any, error) {
 	return object, nil
 }
 
-func schemaStringArray(value any, path string) ([]string, error) {
-	if value == nil {
+func schemaStringArray(schema map[string]any, keyword, path string) ([]string, error) {
+	value, exists := schema[keyword]
+	if !exists {
 		return nil, nil
 	}
 	array, ok := value.([]any)
@@ -436,9 +448,13 @@ func schemaNonNegativeInt(value any, path string) (int, error) {
 	if !ok {
 		return 0, fmt.Errorf("%s must be a non-negative integer", path)
 	}
-	parsed, err := number.Int64()
-	if err != nil || parsed < 0 {
+	parsed, ok := new(big.Rat).SetString(number.String())
+	if !ok || !parsed.IsInt() || parsed.Sign() < 0 || !parsed.Num().IsInt64() {
 		return 0, fmt.Errorf("%s must be a non-negative integer", path)
 	}
-	return int(parsed), nil
+	integer := parsed.Num().Int64()
+	if int64(int(integer)) != integer {
+		return 0, fmt.Errorf("%s must be a non-negative integer", path)
+	}
+	return int(integer), nil
 }

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -245,7 +245,7 @@ func validateRuntimeJSONSchema(schema, value any, valuePath, schemaPath string) 
 		}
 		matched := false
 		for _, candidate := range values {
-			if reflect.DeepEqual(candidate, value) {
+			if runtimeJSONEqual(candidate, value) {
 				matched = true
 				break
 			}
@@ -320,6 +320,45 @@ func validateRuntimeJSONSchema(schema, value any, valuePath, schemaPath string) 
 		}
 	}
 	return nil
+}
+
+func runtimeJSONEqual(left, right any) bool {
+	if leftNumber, ok := left.(json.Number); ok {
+		rightNumber, ok := right.(json.Number)
+		if !ok {
+			return false
+		}
+		leftRat, leftOK := new(big.Rat).SetString(leftNumber.String())
+		rightRat, rightOK := new(big.Rat).SetString(rightNumber.String())
+		return leftOK && rightOK && leftRat.Cmp(rightRat) == 0
+	}
+	switch left := left.(type) {
+	case []any:
+		right, ok := right.([]any)
+		if !ok || len(left) != len(right) {
+			return false
+		}
+		for i := range left {
+			if !runtimeJSONEqual(left[i], right[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		right, ok := right.(map[string]any)
+		if !ok || len(left) != len(right) {
+			return false
+		}
+		for key, value := range left {
+			rightValue, ok := right[key]
+			if !ok || !runtimeJSONEqual(value, rightValue) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(left, right)
+	}
 }
 
 func runtimeJSONTypeMatches(typeName string, value any) bool {

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"reflect"
 	"strings"
 	"unicode/utf8"
@@ -19,8 +20,8 @@ var runtimeSchemaAnnotations = map[string]bool{
 
 func validateRuntimeRequestBody(ctx context.Context, target CommandSpec, input OperationInput, body any, opts OperationOptions) error {
 	source := target.RequestBody.RuntimeSchema
-	if source.Operation.Method != "GET" && source.Operation.Method != "HEAD" {
-		return newAPIError(fmt.Errorf("runtime schema operation must be read-only"), 0)
+	if source.Operation.Method != "GET" {
+		return newAPIError(fmt.Errorf("runtime schema operation must use GET"), 0)
 	}
 	if source.Operation.Output.Streaming != nil || source.Operation.RequestBody != nil && source.Operation.RequestBody.RuntimeSchema != nil {
 		return newAPIError(fmt.Errorf("runtime schema operation must be non-streaming and non-recursive"), 0)
@@ -337,7 +338,11 @@ func runtimeJSONTypeMatches(typeName string, value any) bool {
 		return ok
 	case "integer":
 		number, ok := value.(json.Number)
-		return ok && !strings.ContainsAny(number.String(), ".eE")
+		if !ok {
+			return false
+		}
+		rat, ok := new(big.Rat).SetString(number.String())
+		return ok && rat.IsInt()
 	case "boolean":
 		_, ok := value.(bool)
 		return ok

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -75,12 +75,19 @@ const (
 )
 
 type RequestBody struct {
-	Required  bool
-	MediaType string      `json:",omitempty"`
-	Schema    *SchemaSpec `json:",omitempty"`
+	Required      bool
+	MediaType     string               `json:",omitempty"`
+	Schema        *SchemaSpec          `json:",omitempty"`
+	RuntimeSchema *RuntimeSchemaSource `json:",omitempty"`
 
 	Template  string `json:",omitempty"`
 	MergePath string `json:",omitempty"`
+}
+
+type RuntimeSchemaSource struct {
+	Operation    CommandSpec
+	ResponsePath string
+	Params       map[string]string
 }
 
 type SchemaSpec struct {


### PR DESCRIPTION
## Summary

- Add a provider-neutral body.runtime_schema overlay binding to a visible, same-host, read-only schema operation.
- Preflight and validate JSON request bodies before the target request while keeping dry-run network-free and failing closed on unsupported schema assertions.
- Expose the runtime schema source through catalog schema 16 and generated Skill guidance.

## Verification

- make check
- go test -race ./...
- go test ./pkg/runtime ./internal/overlay ./internal/codegen/render -count=1
- Generated CLI __lathe verify --json
- Generated CLI loopback: valid body preflighted then executed; unknown and missing fields exited 2 with zero target requests; dry-run sent zero requests

## Compatibility

- Existing generated commands remain compatible and unchanged unless body.runtime_schema is configured.
- Catalog schema changes from 15 to 16 to expose the optional runtime schema source.
- Unsupported runtime JSON Schema assertion keywords fail before the target request.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under internal/generated/, .cache/, and ad-hoc skills/<cli-name>/ directories is not committed.
- [x] Commits are signed off when this is ready to merge.