### PR TITLE
feat(runtime): validate request bodies with fetched schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,8 @@ Relay-style outputs with `list_path: data.<operation>.nodes` or `.edges`,
 
 ### Overlays
 
-Overlays polish generated commands without changing the upstream spec or editing
-generated Go code.
+Overlays polish generated commands and bind bounded runtime behavior that the
+upstream spec cannot express, without editing generated Go code.
 
 `internal/overlay/iam.yaml`:
 
@@ -401,6 +401,30 @@ required when an upstream spec is incomplete; it does not create new flags.
 Command `shortcuts` add root-level commands that execute the same generated
 operation with preset values for existing parameters. Shortcut params may use
 the parameter name or flag name; invocation flags can still override the preset.
+
+When a read-only operation returns the JSON Schema for another operation's
+request body, bind it as a preflight:
+
+```yaml
+commands:
+  run-app:
+    body:
+      runtime_schema:
+        operation_id: describeApp
+        response_path: input_schema
+        params:
+          app_id: ${params.app_id}
+          fields: input_schema
+```
+
+The source must be a visible, non-streaming, bodyless `GET` in the same module
+and use the same hostname with no stronger auth than the target. Mappings use
+source parameter names or flags; values are literals or exact
+`${params.<target-name-or-flag>}` references. Normal execution fetches the
+schema and validates the JSON body before the target request. The schema's
+declared draft is honored; schemas without `$schema` use Draft 2020-12.
+External `$ref` loading is disabled. `--dry-run` remains network-free and skips
+the preflight.
 
 For an SSE or NDJSON operation whose event semantics are not described by the
 API spec, an overlay can collect JSON frames into one stable result:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,7 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 | `Deprecated` | `deprecated` / proto option | bool + message | overlay > spec |
 | `Security` | `security` / proto option | override (post-v0.1) | overlay > spec |
 | `RequestBody.MediaType` | `consumes[0]` | override | overlay > spec |
+| `RequestBody.RuntimeSchema` | — | read-only schema operation, response path, and parameter mapping | overlay-only |
 | `Output.Streaming.Policy` | streaming media type supplies transport only | JSON event collection and live projection | overlay > spec transport |
 | `Ignore` (command filter) | — | bool | overlay-only |
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -29,7 +29,8 @@ file; when this page and the code disagree, trust the code and fix this page.
 - This is the agent-facing discovery contract and the source of truth for
   generated operation details: HTTP method and path template, auth
   requirements, source parameter names, CLI flags and positional alternatives,
-  body schema, output, pagination, and stream collection hints.
+  body schema (including any runtime schema source), output, pagination, and
+  stream collection hints.
 - `catalog.cli.capabilities` lists compiled first-party capabilities such as
   `skill.bundle`. Capability commands are not catalog operations.
 - Only generated API operation commands carry catalog entries. Framework

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.25.13
 
 require (
 	github.com/lathe-cli/kitup/go v0.1.3
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/vektah/gqlparser/v2 v2.5.36
 	golang.org/x/term v0.45.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529
@@ -16,6 +18,6 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/text v0.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -21,6 +23,8 @@ github.com/lathe-cli/kitup/go v0.1.3/go.mod h1:dZgJDmFRKjaFBZyaP1qlzOB9IEafnf1/a
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3 h1:1EYB5IzjZawrrnELUi78f9fPu57HuXjmddZPjrls/28=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -35,6 +39,8 @@ golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 h1:zUWMZsvo/IJcD1t6MNCPO/azZTwz0TvwCBqr5aifoVY=
 google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529/go.mod h1:a5OGAgyRr4lqco7AG9hQM9Fwh0N2ZV4grR0eXFEsXQg=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -370,8 +370,14 @@ func validateRuntimeSchemaSource(target, source runtime.CommandSpec, binding *ov
 			return fmt.Errorf("param %q has invalid reference %q", key, value)
 		}
 		if isRef {
-			if _, count := paramByNameOrFlag(target.Params, name); count != 1 {
+			targetIndex, count := paramByNameOrFlag(target.Params, name)
+			if count != 1 {
 				return fmt.Errorf("target param %q is missing or ambiguous", name)
+			}
+			sourceParam := source.Params[sourceIndex]
+			targetParam := target.Params[targetIndex]
+			if sourceParam.Required && sourceParam.Default == "" && !targetParam.Required && targetParam.Default == "" {
+				return fmt.Errorf("required source param %q maps optional target param %q", sourceParam.Name, targetParam.Name)
 			}
 		}
 	}

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -361,6 +361,9 @@ func validateRuntimeSchemaSource(target, source runtime.CommandSpec, binding *ov
 		if count != 1 {
 			return fmt.Errorf("source param %q is missing or ambiguous", key)
 		}
+		if mapped[sourceIndex] {
+			return fmt.Errorf("source param %q is mapped more than once", source.Params[sourceIndex].Name)
+		}
 		mapped[sourceIndex] = true
 		name, isRef, malformed := runtimeSchemaParamReference(value)
 		if malformed {

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -258,6 +258,12 @@ func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Over
 }
 
 func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
+	merged := mergeOverlaySpecs(specs, mod)
+	applyRuntimeSchemaBindings(specs, merged, mod)
+	return merged
+}
+
+func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
 	var merged []runtime.CommandSpec
 	for _, s := range specs {
 		o, ok := mod.Commands[s.Use]
@@ -294,7 +300,166 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 			}
 		}
 	}
+	return validateRuntimeSchemaBindings(specs, mergeOverlaySpecs(specs, mod), mod)
+}
+
+func validateRuntimeSchemaBindings(original, merged []runtime.CommandSpec, mod overlay.Module) error {
+	for _, spec := range original {
+		override, ok := mod.Commands[spec.Use]
+		if !ok || override.Ignore || !overrideMatches(spec, override) || override.Body == nil || override.Body.RuntimeSchema == nil {
+			continue
+		}
+		target, count := operationByID(merged, spec.OperationID)
+		if spec.OperationID == "" || count != 1 {
+			return fmt.Errorf("command %q runtime schema target operation_id is missing or ambiguous", spec.Use)
+		}
+		binding := override.Body.RuntimeSchema
+		source, count := operationByID(merged, binding.OperationID)
+		if binding.OperationID == "" || count != 1 {
+			return fmt.Errorf("command %q runtime schema operation_id %q is missing or ambiguous", spec.Use, binding.OperationID)
+		}
+		if err := validateRuntimeSchemaSource(*target, *source, binding); err != nil {
+			return fmt.Errorf("command %q runtime schema: %w", spec.Use, err)
+		}
+	}
 	return nil
+}
+
+func validateRuntimeSchemaSource(target, source runtime.CommandSpec, binding *overlay.RuntimeSchemaOverride) error {
+	if target.RequestBody == nil || !jsonMediaType(target.RequestBody.MediaType) {
+		return fmt.Errorf("target must have a JSON request body")
+	}
+	if source.Hidden {
+		return fmt.Errorf("source operation %q must be visible", binding.OperationID)
+	}
+	if !strings.EqualFold(source.Method, "GET") {
+		return fmt.Errorf("source operation %q must use GET", binding.OperationID)
+	}
+	if source.RequestBody != nil {
+		return fmt.Errorf("source operation %q must not have a request body", binding.OperationID)
+	}
+	for _, param := range source.Params {
+		if param.In == runtime.InFormData {
+			return fmt.Errorf("source operation %q must not have form body parameters", binding.OperationID)
+		}
+	}
+	if source.Output.Streaming != nil {
+		return fmt.Errorf("source operation %q must not stream", binding.OperationID)
+	}
+	if !jsonMediaType(source.Output.ResponseMediaType) {
+		return fmt.Errorf("source operation %q must return JSON", binding.OperationID)
+	}
+	if source.DefaultHostname != target.DefaultHostname {
+		return fmt.Errorf("source operation %q must use the target hostname", binding.OperationID)
+	}
+	if !runtimeSchemaAuthAllowed(target.Security, source.Security) {
+		return fmt.Errorf("source operation %q requires stronger auth than the target", binding.OperationID)
+	}
+	mapped := map[int]bool{}
+	for key, value := range binding.Params {
+		sourceIndex, count := paramByNameOrFlag(source.Params, key)
+		if count != 1 {
+			return fmt.Errorf("source param %q is missing or ambiguous", key)
+		}
+		mapped[sourceIndex] = true
+		name, isRef, malformed := runtimeSchemaParamReference(value)
+		if malformed {
+			return fmt.Errorf("param %q has invalid reference %q", key, value)
+		}
+		if isRef {
+			if _, count := paramByNameOrFlag(target.Params, name); count != 1 {
+				return fmt.Errorf("target param %q is missing or ambiguous", name)
+			}
+		}
+	}
+	for i, param := range source.Params {
+		if param.Required && param.Default == "" && !mapped[i] {
+			return fmt.Errorf("required source param %q is not mapped", param.Name)
+		}
+	}
+	return nil
+}
+
+func applyRuntimeSchemaBindings(original, merged []runtime.CommandSpec, mod overlay.Module) {
+	for _, spec := range original {
+		override, ok := mod.Commands[spec.Use]
+		if !ok || override.Ignore || !overrideMatches(spec, override) || override.Body == nil || override.Body.RuntimeSchema == nil {
+			continue
+		}
+		target, targetCount := operationByID(merged, spec.OperationID)
+		source, sourceCount := operationByID(merged, override.Body.RuntimeSchema.OperationID)
+		if targetCount != 1 || sourceCount != 1 || target.RequestBody == nil {
+			continue
+		}
+		target.RequestBody.RuntimeSchema = &runtime.RuntimeSchemaSpec{
+			Operation:    cloneCommandSpec(*source),
+			ResponsePath: override.Body.RuntimeSchema.ResponsePath,
+			Params:       copyStringMap(override.Body.RuntimeSchema.Params),
+		}
+	}
+}
+
+func operationByID(specs []runtime.CommandSpec, operationID string) (*runtime.CommandSpec, int) {
+	var found *runtime.CommandSpec
+	count := 0
+	for i := range specs {
+		if specs[i].OperationID == operationID {
+			found = &specs[i]
+			count++
+		}
+	}
+	return found, count
+}
+
+func paramByNameOrFlag(params []runtime.ParamSpec, value string) (int, int) {
+	index, count := -1, 0
+	for i, param := range params {
+		if param.Name == value || param.Flag == value {
+			index = i
+			count++
+		}
+	}
+	return index, count
+}
+
+func runtimeSchemaParamReference(value string) (string, bool, bool) {
+	const prefix = "${params."
+	if !strings.HasPrefix(value, "${") {
+		return "", false, false
+	}
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, "}") {
+		return "", false, true
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(value, prefix), "}")
+	return name, true, name == "" || strings.Contains(name, "${") || strings.Contains(name, "}")
+}
+
+func jsonMediaType(value string) bool {
+	value = strings.ToLower(strings.TrimSpace(strings.SplitN(value, ";", 2)[0]))
+	return value == "" || value == "application/json" || strings.HasSuffix(value, "+json")
+}
+
+func runtimeSchemaAuthAllowed(target, source *runtime.SecurityHint) bool {
+	targetRequired := target == nil || !target.Public
+	sourceRequired := source == nil || !source.Public
+	if !targetRequired && sourceRequired {
+		return false
+	}
+	if !sourceRequired || source == nil || len(source.Scopes) == 0 {
+		return true
+	}
+	targetScopes := map[string]bool{}
+	if target != nil {
+		for _, scope := range target.Scopes {
+			targetScopes[scope] = true
+		}
+	}
+	for _, scope := range source.Scopes {
+		if !targetScopes[scope] {
+			return false
+		}
+	}
+	return true
 }
 
 func validateArguments(spec runtime.CommandSpec, overrides map[string]overlay.ParamOverride) error {
@@ -419,6 +584,15 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	for i := range cloned.Params {
 		cloned.Params[i].Aliases = append([]string(nil), spec.Params[i].Aliases...)
 		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
+	}
+	if spec.RequestBody != nil {
+		body := *spec.RequestBody
+		if spec.RequestBody.RuntimeSchema != nil {
+			runtimeSchema := *spec.RequestBody.RuntimeSchema
+			runtimeSchema.Params = copyStringMap(spec.RequestBody.RuntimeSchema.Params)
+			body.RuntimeSchema = &runtimeSchema
+		}
+		cloned.RequestBody = &body
 	}
 	if spec.Output.Streaming != nil {
 		streaming := *spec.Output.Streaming
@@ -977,8 +1151,23 @@ func requestBodyLiteral(body *runtime.RequestBody) string {
 	if body.Schema != nil {
 		fmt.Fprintf(&b, "Schema: %s,", schemaLiteral(body.Schema))
 	}
+	if body.RuntimeSchema != nil {
+		fmt.Fprintf(&b, "RuntimeSchema: %s,", runtimeSchemaLiteral(body.RuntimeSchema))
+	}
 	writeStringField(&b, "Template", body.Template)
 	writeStringField(&b, "MergePath", body.MergePath)
+	b.WriteByte('}')
+	return b.String()
+}
+
+func runtimeSchemaLiteral(binding *runtime.RuntimeSchemaSpec) string {
+	var b strings.Builder
+	b.WriteString("&runtime.RuntimeSchemaSpec{")
+	fmt.Fprintf(&b, "Operation: %s,", commandSpecLiteral(binding.Operation))
+	writeStringField(&b, "ResponsePath", binding.ResponsePath)
+	if len(binding.Params) > 0 {
+		fmt.Fprintf(&b, "Params: %s,", stringMapLiteral(binding.Params))
+	}
 	b.WriteByte('}')
 	return b.String()
 }
@@ -1177,9 +1366,10 @@ func writeSchemaSliceLiteral(b *strings.Builder, name string, schemas []*runtime
 }
 
 var moduleTmpl = template.Must(template.New("gen").Funcs(template.FuncMap{
-	"schemaLiteral":      schemaLiteral,
-	"stringMapLiteral":   stringMapLiteral,
-	"outputHintsLiteral": outputHintsLiteral,
+	"schemaLiteral":        schemaLiteral,
+	"runtimeSchemaLiteral": runtimeSchemaLiteral,
+	"stringMapLiteral":     stringMapLiteral,
+	"outputHintsLiteral":   outputHintsLiteral,
 }).Parse(`// Code generated by lathe codegen. DO NOT EDIT.
 
 package {{.Module}}
@@ -1292,6 +1482,9 @@ var Specs = []runtime.CommandSpec{
 				{{- end}}
 				{{- if $op.RequestBody.Schema}}
 				Schema: {{schemaLiteral $op.RequestBody.Schema}},
+				{{- end}}
+				{{- if $op.RequestBody.RuntimeSchema}}
+				RuntimeSchema: {{runtimeSchemaLiteral $op.RequestBody.RuntimeSchema}},
 				{{- end}}
 				{{- if $op.RequestBody.Template}}
 				Template: {{printf "%q" $op.RequestBody.Template}},

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -389,6 +389,23 @@ func TestMergeOverlayModule_RuntimeSchema(t *testing.T) {
 		t.Fatalf("duplicate mapping error = %v", err)
 	}
 
+	optionalTarget := []runtime.CommandSpec{cloneCommandSpec(specs[0]), cloneCommandSpec(specs[1])}
+	optionalTarget[0].Params[1].Required = true
+	optionalTarget[1].Params = append(optionalTarget[1].Params, runtime.ParamSpec{Name: "mode", Flag: "mode", In: runtime.InQuery, GoType: "string"})
+	optionalMapping := overlay.Module{Commands: map[string]overlay.Override{
+		"run-app": {Body: &overlay.BodyOverride{RuntimeSchema: &overlay.RuntimeSchemaOverride{
+			OperationID:  "describeApp",
+			ResponsePath: "input_schema",
+			Params: map[string]string{
+				"app_id": "${params.app-id}",
+				"fields": "${params.mode}",
+			},
+		}}},
+	}}
+	if err := ValidateOverlayModule(optionalTarget, optionalMapping); err == nil || !strings.Contains(err.Error(), "optional target param") {
+		t.Fatalf("optional target mapping error = %v", err)
+	}
+
 	for name, mutate := range map[string]func(*runtime.CommandSpec){
 		"non-GET":   func(source *runtime.CommandSpec) { source.Method = "HEAD" },
 		"body":      func(source *runtime.CommandSpec) { source.RequestBody = &runtime.RequestBody{} },

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -326,6 +326,71 @@ func TestValidateOverlayModule_RejectsUnknownArgumentParameter(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayModule_RuntimeSchema(t *testing.T) {
+	specs := []runtime.CommandSpec{
+		{
+			Group: "Apps", Use: "describe-app", OperationID: "describeApp", Method: "GET", PathTpl: "/apps/{app_id}", DefaultHostname: "https://api.example.com",
+			Params: []runtime.ParamSpec{
+				{Name: "app_id", Flag: "app-id", In: runtime.InPath, GoType: "string", Required: true},
+				{Name: "fields", Flag: "fields", In: runtime.InQuery, GoType: "string"},
+			},
+			Output:   runtime.OutputHints{ResponseMediaType: "application/json"},
+			Security: &runtime.SecurityHint{Scopes: []string{"apps:read"}},
+		},
+		{
+			Group: "Apps", Use: "run-app", OperationID: "runApp", Method: "POST", PathTpl: "/apps/{app_id}/run", DefaultHostname: "https://api.example.com",
+			Params:      []runtime.ParamSpec{{Name: "app_id", Flag: "app-id", In: runtime.InPath, GoType: "string", Required: true}},
+			RequestBody: &runtime.RequestBody{Required: true, MediaType: "application/json"},
+			Security:    &runtime.SecurityHint{Scopes: []string{"apps:read", "apps:run"}},
+		},
+	}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"run-app": {Body: &overlay.BodyOverride{RuntimeSchema: &overlay.RuntimeSchemaOverride{
+			OperationID:  "describeApp",
+			ResponsePath: "input_schema",
+			Params: map[string]string{
+				"app_id": "${params.app-id}",
+				"fields": "input_schema",
+			},
+		}}},
+	}}
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		t.Fatalf("ValidateOverlayModule: %v", err)
+	}
+	merged := MergeOverlayModule(specs, mod)
+	binding := merged[1].RequestBody.RuntimeSchema
+	if binding == nil || binding.Operation.OperationID != "describeApp" || binding.Operation.DefaultHostname != "https://api.example.com" || binding.Params["app_id"] != "${params.app-id}" {
+		t.Fatalf("runtime schema = %#v", binding)
+	}
+
+	chdirWithGoMod(t)
+	if err := RenderModule("demo", "", specs, mod.Commands); err != nil {
+		t.Fatalf("RenderModule: %v", err)
+	}
+	generated := generatedModule(t, "demo")
+	for _, want := range []string{"RuntimeSchema: &runtime.RuntimeSchemaSpec{", `OperationID: "describeApp"`, `ResponsePath: "input_schema"`} {
+		if !strings.Contains(generated, want) {
+			t.Errorf("generated module missing %q", want)
+		}
+	}
+
+	for name, mutate := range map[string]func(*runtime.CommandSpec){
+		"non-GET":   func(source *runtime.CommandSpec) { source.Method = "HEAD" },
+		"body":      func(source *runtime.CommandSpec) { source.RequestBody = &runtime.RequestBody{} },
+		"form body": func(source *runtime.CommandSpec) { source.Params[0].In = runtime.InFormData },
+		"hidden":    func(source *runtime.CommandSpec) { source.Hidden = true },
+		"stream":    func(source *runtime.CommandSpec) { source.Output.Streaming = &runtime.StreamingHint{Strategy: "sse"} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalid := []runtime.CommandSpec{cloneCommandSpec(specs[0]), cloneCommandSpec(specs[1])}
+			mutate(&invalid[0])
+			if err := ValidateOverlayModule(invalid, mod); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
 func TestMergeOverlay_ParamRequiredOverride(t *testing.T) {
 	specs := []runtime.CommandSpec{
 		{

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -374,6 +374,21 @@ func TestMergeOverlayModule_RuntimeSchema(t *testing.T) {
 		}
 	}
 
+	duplicateMapping := overlay.Module{Commands: map[string]overlay.Override{
+		"run-app": {Body: &overlay.BodyOverride{RuntimeSchema: &overlay.RuntimeSchemaOverride{
+			OperationID:  "describeApp",
+			ResponsePath: "input_schema",
+			Params: map[string]string{
+				"app_id": "${params.app-id}",
+				"app-id": "literal",
+				"fields": "input_schema",
+			},
+		}}},
+	}}
+	if err := ValidateOverlayModule(specs, duplicateMapping); err == nil || !strings.Contains(err.Error(), "mapped more than once") {
+		t.Fatalf("duplicate mapping error = %v", err)
+	}
+
 	for name, mutate := range map[string]func(*runtime.CommandSpec){
 		"non-GET":   func(source *runtime.CommandSpec) { source.Method = "HEAD" },
 		"body":      func(source *runtime.CommandSpec) { source.RequestBody = &runtime.RequestBody{} },

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -526,6 +526,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("- A configured stream pause is successful (`exit 0`); inspect the collected output field mapped from the pause event instead of treating it as an error.\n")
 	b.WriteString("- For collected streams, choose one mode: `-o json` for one stable document, `--stream` in the default output mode when catalog `output.streaming.policy.live` is present, or `-o raw` for wire events.\n")
 	b.WriteString("- Use `--file`, `--set`, or `--set-str` for JSON request bodies according to `commands show` body requirements.\n")
+	b.WriteString("- When `body.runtime_schema` is present, normal execution fetches and validates against that schema before the target request; `--dry-run` stays network-free and skips this preflight.\n")
 	b.WriteString("- For sensitive flags, prefer safe modes from `flags[].input_modes`: `--<flag>-env`, `--<flag>-file`, or `--<flag>-stdin`.\n")
 	return b.String()
 }
@@ -555,7 +556,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `http`: HTTP method and path template.\n")
 	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, input modes, and help.\n")
-	b.WriteString("- `body`: request body requirement and media type.\n")
+	b.WriteString("- `body`: request body requirement, media type, and optional `runtime_schema` preflight source.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
 	b.WriteString("- `examples`: runnable examples with optional body shape, output hints, and follow-up commands.\n")
 	b.WriteString("- `output`: list path, default columns, response media type, pagination, and streaming hints; a streaming policy describes collection, terminal outcomes, and optional live projection.\n")
@@ -576,6 +577,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `--file -`: read a JSON body from stdin.\n")
 	b.WriteString("- `--set key.path=value`: build JSON with type inference for booleans, null, integers, and floats.\n")
 	b.WriteString("- `--set-str key.path=value`: build JSON while forcing the value to remain a string.\n\n")
+	b.WriteString("If `body.runtime_schema` is present, normal execution fetches that JSON Schema and validates the body before the target request. `--dry-run` does not fetch it.\n\n")
 	b.WriteString("## Output\n\n")
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
@@ -975,7 +977,10 @@ func bodySummary(body *runtime.RequestBody) string {
 		return state + "; templated body, set inputs under `" + merge + "` with --set/--set-str/--file"
 	}
 	if body.MediaType != "" {
-		return state + "; media type `" + body.MediaType + "`"
+		state += "; media type `" + body.MediaType + "`"
+	}
+	if body.RuntimeSchema != nil {
+		state += "; runtime schema preflight"
 	}
 	return state
 }

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -117,7 +117,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 
 	catalog := readFile(t, dir, "skills/acmectl/references/catalog.md")
-	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero"} {
+	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "body.runtime_schema", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero"} {
 		if !strings.Contains(catalog, want) {
 			t.Errorf("catalog.md missing %q", want)
 		}

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -231,17 +231,17 @@ func buildGeneratedApp(cfg *sourceconfig.Config, overlays map[string]overlay.Mod
 		}
 
 		specs := normalize.Normalize(mod)
+		if src.DefaultHostname != nil {
+			for i := range specs {
+				specs[i].DefaultHostname = *src.DefaultHostname
+			}
+		}
 		if err := render.ValidateOverlayModule(specs, overlays[src.Name]); err != nil {
 			return nil, fmt.Errorf("source %q overlay: %w", src.Name, err)
 		}
 		specs = render.MergeOverlayModule(specs, overlays[src.Name])
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("source %q produced no commands: check its entry/file list, expose policy, and overlay ignore rules", src.Name)
-		}
-		if src.DefaultHostname != nil {
-			for i := range specs {
-				specs[i].DefaultHostname = *src.DefaultHostname
-			}
 		}
 		cliName := moduleNames[i]
 		flat, err := render.ResolveFlatCommandPath(manifest.CLI.CommandPath, len(ordered), specs)

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -25,7 +25,18 @@ type Override struct {
 	Notes         []string                 `yaml:"notes"`
 	Prerequisites []string                 `yaml:"prerequisites"`
 	KnownErrors   []KnownError             `yaml:"known_errors"`
+	Body          *BodyOverride            `yaml:"body"`
 	Output        *OutputOverride          `yaml:"output"`
+}
+
+type BodyOverride struct {
+	RuntimeSchema *RuntimeSchemaOverride `yaml:"runtime_schema"`
+}
+
+type RuntimeSchemaOverride struct {
+	OperationID  string            `yaml:"operation_id"`
+	ResponsePath string            `yaml:"response_path"`
+	Params       map[string]string `yaml:"params"`
 }
 
 type OutputOverride struct {

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -109,6 +109,12 @@ commands:
     known_errors:
       - status: 400
         cause: "missing user name"
+    body:
+      runtime_schema:
+        operation_id: describeUser
+        response_path: input_schema
+        params:
+          user_id: ${params.user_id}
     params:
       status:
         flag: user-status
@@ -156,6 +162,9 @@ commands:
 	}
 	if len(cu.KnownErrors) != 1 || cu.KnownErrors[0].Status != 400 || cu.KnownErrors[0].Cause != "missing user name" {
 		t.Errorf("known errors = %#v", cu.KnownErrors)
+	}
+	if cu.Body == nil || cu.Body.RuntimeSchema == nil || cu.Body.RuntimeSchema.OperationID != "describeUser" || cu.Body.RuntimeSchema.ResponsePath != "input_schema" || cu.Body.RuntimeSchema.Params["user_id"] != "${params.user_id}" {
+		t.Errorf("runtime schema = %#v", cu.Body)
 	}
 	sp := cu.Params["status"]
 	if sp.Flag != "user-status" {

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CatalogSchemaVersion = 15
+const CatalogSchemaVersion = 16
 const DefaultSearchLimit = 20
 
 const catalogCommandAnnotation = "lathe.catalog.command"
@@ -105,11 +105,19 @@ type CatalogAuth struct {
 }
 
 type CatalogBody struct {
-	Required  bool        `json:"required"`
-	MediaType string      `json:"media_type,omitempty"`
-	Schema    *SchemaSpec `json:"schema,omitempty"`
-	Template  string      `json:"template,omitempty"`
-	MergePath string      `json:"merge_path,omitempty"`
+	Required      bool                  `json:"required"`
+	MediaType     string                `json:"media_type,omitempty"`
+	Schema        *SchemaSpec           `json:"schema,omitempty"`
+	RuntimeSchema *CatalogRuntimeSchema `json:"runtime_schema,omitempty"`
+	Template      string                `json:"template,omitempty"`
+	MergePath     string                `json:"merge_path,omitempty"`
+}
+
+type CatalogRuntimeSchema struct {
+	OperationID  string            `json:"operation_id"`
+	HTTP         CatalogHTTP       `json:"http"`
+	ResponsePath string            `json:"response_path,omitempty"`
+	Params       map[string]string `json:"params,omitempty"`
 }
 
 type CatalogFlag struct {
@@ -393,6 +401,18 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 			Schema:    spec.RequestBody.Schema,
 			Template:  spec.RequestBody.Template,
 			MergePath: spec.RequestBody.MergePath,
+		}
+		if binding := spec.RequestBody.RuntimeSchema; binding != nil {
+			cmd.Body.RuntimeSchema = &CatalogRuntimeSchema{
+				OperationID: binding.Operation.OperationID,
+				HTTP: CatalogHTTP{
+					Method:          binding.Operation.Method,
+					PathTemplate:    binding.Operation.PathTpl,
+					DefaultHostname: binding.Operation.DefaultHostname,
+				},
+				ResponsePath: binding.ResponsePath,
+				Params:       copyStringMap(binding.Params),
+			}
 		}
 	}
 	return cmd

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -32,7 +32,16 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 				{Name: "user_id", Flag: "user-id", Aliases: []string{"user_id"}, Argument: "id", In: InPath, GoType: "string", Required: true, Help: "User id"},
 				{Name: "workspace", Flag: "workspace", In: InQuery, GoType: "string", Default: "default", Enum: []string{"default", "prod"}, Format: "slug", Help: "Target workspace"},
 			},
-			RequestBody: &RequestBody{Required: true, MediaType: "application/json", Schema: &SchemaSpec{Type: "object", Properties: map[string]*SchemaSpec{"name": {Type: "string"}}}},
+			RequestBody: &RequestBody{
+				Required:  true,
+				MediaType: "application/json",
+				Schema:    &SchemaSpec{Type: "object", Properties: map[string]*SchemaSpec{"name": {Type: "string"}}},
+				RuntimeSchema: &RuntimeSchemaSpec{
+					Operation:    CommandSpec{OperationID: "describeUser", Method: "GET", PathTpl: "/users/{id}", DefaultHostname: "api.example.com"},
+					ResponsePath: "input_schema",
+					Params:       map[string]string{"id": "${params.user_id}"},
+				},
+			},
 			Output: OutputHints{
 				ListPath:          "data.items",
 				DefaultColumns:    []string{"id", "name"},
@@ -96,6 +105,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	if cmd.Body.Schema == nil || cmd.Body.Schema.Properties["name"].Type != "string" {
 		t.Fatalf("body schema = %+v", cmd.Body.Schema)
 	}
+	if cmd.Body.RuntimeSchema == nil || cmd.Body.RuntimeSchema.OperationID != "describeUser" || cmd.Body.RuntimeSchema.HTTP.PathTemplate != "/users/{id}" || cmd.Body.RuntimeSchema.ResponsePath != "input_schema" || cmd.Body.RuntimeSchema.Params["id"] != "${params.user_id}" {
+		t.Fatalf("runtime schema = %+v", cmd.Body.RuntimeSchema)
+	}
 	if len(cmd.Flags) != 2 {
 		t.Fatalf("flags = %d, want 2", len(cmd.Flags))
 	}
@@ -140,6 +152,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if roundTrip.Commands[0].Body.Schema.Properties["name"].Type != "string" {
 		t.Fatalf("round-trip body schema = %+v", roundTrip.Commands[0].Body.Schema)
+	}
+	if roundTrip.Commands[0].Body.RuntimeSchema == nil || roundTrip.Commands[0].Body.RuntimeSchema.OperationID != "describeUser" {
+		t.Fatalf("round-trip runtime schema = %+v", roundTrip.Commands[0].Body.RuntimeSchema)
 	}
 	if !reflect.DeepEqual(roundTrip.Commands[0].KnownErrors, cmd.KnownErrors) {
 		t.Fatalf("round-trip known errors = %#v", roundTrip.Commands[0].KnownErrors)
@@ -475,8 +490,8 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 
 	catalog := BuildCatalog(root, CatalogOptions{})
-	if catalog.CatalogSchemaVersion != 15 {
-		t.Fatalf("schema version = %d, want 15", catalog.CatalogSchemaVersion)
+	if catalog.CatalogSchemaVersion != CatalogSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", catalog.CatalogSchemaVersion, CatalogSchemaVersion)
 	}
 	var step *CatalogWorkflowStep
 	for i, entry := range catalog.Commands {

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -75,6 +75,11 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		}
 		return OperationResult{DryRun: &out, Outcome: OperationOutcomeCompleted}, nil
 	}
+	if s.RequestBody != nil && s.RequestBody.RuntimeSchema != nil {
+		if err := validateRuntimeSchemaBody(ctx, s, input, body, opts); err != nil {
+			return OperationResult{}, err
+		}
+	}
 
 	var data []byte
 	outcome := OperationOutcomeCompleted

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -76,6 +76,7 @@ func runtimeSchemaInput(target CommandSpec, input OperationInput, binding Runtim
 	values := make(map[string]any, len(binding.Params))
 	changed := make(map[string]bool, len(binding.Params))
 	for key, value := range binding.Params {
+		mappedValue := any(value)
 		sourceIndex, ok := runtimeParamIndex(source.Params, key)
 		if !ok {
 			return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema source param %q not found", key)
@@ -92,13 +93,13 @@ func runtimeSchemaInput(target CommandSpec, input OperationInput, binding Runtim
 			if !present {
 				continue
 			}
-			value = operationStringValue(resolved)
+			mappedValue = resolved
 			if isSensitiveStringParam(target.Params[targetIndex]) {
 				source.Params[sourceIndex].Format = "password"
 			}
 		}
 		key := boundParamKey(source.Params[sourceIndex])
-		values[key] = value
+		values[key] = mappedValue
 		changed[key] = true
 	}
 	return source, OperationInput{Values: values, Changed: changed}, nil

--- a/pkg/runtime/runtime_schema.go
+++ b/pkg/runtime/runtime_schema.go
@@ -1,0 +1,137 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+const runtimeSchemaResource = "urn:lathe:runtime-schema"
+
+func validateRuntimeSchemaBody(ctx context.Context, target CommandSpec, input OperationInput, body any, opts OperationOptions) error {
+	binding := target.RequestBody.RuntimeSchema
+	if binding == nil || body == nil {
+		return nil
+	}
+	instance, err := requestBodyJSONValue(body)
+	if err != nil {
+		return runtimeSchemaUsageError(fmt.Errorf("decode request body: %w", err))
+	}
+
+	source, sourceInput, err := runtimeSchemaInput(target, input, *binding)
+	if err != nil {
+		return runtimeSchemaUsageError(err)
+	}
+	if err := validateOperationInput(source, sourceInput); err != nil {
+		return runtimeSchemaUsageError(fmt.Errorf("runtime schema source: %w", err))
+	}
+	sourceOpts := opts
+	sourceOpts.DryRun = false
+	sourceOpts.PaginateAll = false
+	sourceOpts.MaxPages = 0
+	sourceOpts.Wait = false
+	result, err := invokeOperation(ctx, source, sourceInput, sourceOpts, operationOutput{})
+	if err != nil {
+		return err
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(result.Data))
+	if err != nil {
+		return newAPIError(fmt.Errorf("decode runtime schema response: %w", err), 0)
+	}
+	schemaDoc, ok := getNestedPath(doc, binding.ResponsePath)
+	if !ok {
+		return newAPIError(fmt.Errorf("runtime schema response path %q not found", binding.ResponsePath), 0)
+	}
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	compiler.UseLoader(nil)
+	if err := compiler.AddResource(runtimeSchemaResource, schemaDoc); err != nil {
+		return newAPIError(fmt.Errorf("load runtime schema: %w", err), 0)
+	}
+	schema, err := compiler.Compile(runtimeSchemaResource)
+	if err != nil {
+		return newAPIError(fmt.Errorf("compile runtime schema: %w", err), 0)
+	}
+	if err := schema.Validate(instance); err != nil {
+		return runtimeSchemaUsageError(err)
+	}
+	return nil
+}
+
+func requestBodyJSONValue(body any) (any, error) {
+	raw, _, err := encodeRequestBody(body)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+}
+
+func runtimeSchemaInput(target CommandSpec, input OperationInput, binding RuntimeSchemaSpec) (CommandSpec, OperationInput, error) {
+	source := binding.Operation
+	source.Params = append([]ParamSpec(nil), binding.Operation.Params...)
+	values := make(map[string]any, len(binding.Params))
+	changed := make(map[string]bool, len(binding.Params))
+	for key, value := range binding.Params {
+		sourceIndex, ok := runtimeParamIndex(source.Params, key)
+		if !ok {
+			return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema source param %q not found", key)
+		}
+		if targetName, ref := runtimeSchemaReference(value); ref {
+			targetIndex, ok := runtimeParamIndex(target.Params, targetName)
+			if !ok {
+				return CommandSpec{}, OperationInput{}, fmt.Errorf("runtime schema target param %q not found", targetName)
+			}
+			resolved, present, err := operationValue(input, target.Params[targetIndex])
+			if err != nil {
+				return CommandSpec{}, OperationInput{}, err
+			}
+			if !present {
+				continue
+			}
+			value = operationStringValue(resolved)
+			if isSensitiveStringParam(target.Params[targetIndex]) {
+				source.Params[sourceIndex].Format = "password"
+			}
+		}
+		key := boundParamKey(source.Params[sourceIndex])
+		values[key] = value
+		changed[key] = true
+	}
+	return source, OperationInput{Values: values, Changed: changed}, nil
+}
+
+func runtimeParamIndex(params []ParamSpec, nameOrFlag string) (int, bool) {
+	index := -1
+	for i, param := range params {
+		if param.Name != nameOrFlag && param.Flag != nameOrFlag {
+			continue
+		}
+		if index != -1 {
+			return -1, false
+		}
+		index = i
+	}
+	return index, index != -1
+}
+
+func runtimeSchemaReference(value string) (string, bool) {
+	const prefix = "${params."
+	if !strings.HasPrefix(value, prefix) || !strings.HasSuffix(value, "}") {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(value, prefix), "}"), true
+}
+
+func runtimeSchemaUsageError(cause error) error {
+	return NewError(
+		CodeUsage,
+		ExitUsage,
+		"request body does not match the runtime schema",
+		"inspect the command schema and correct the request body",
+		cause,
+	)
+}

--- a/pkg/runtime/runtime_schema_test.go
+++ b/pkg/runtime/runtime_schema_test.go
@@ -1,0 +1,143 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestInvokeOperation_RuntimeSchema(t *testing.T) {
+	var schemaHits atomic.Int32
+	var targetHits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/apps/app-1":
+			schemaHits.Add(1)
+			if r.URL.Query().Get("fields") != "input_schema" {
+				t.Errorf("fields = %q", r.URL.Query().Get("fields"))
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"count":{"type":"integer"},"note":{"type":["string","null"]}},"required":["count"],"additionalProperties":false}}`)
+		case "/apps/app-1/run":
+			targetHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"ok":true}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	appID := ParamSpec{Name: "app_id", Flag: "app-id", In: InPath, GoType: "string", Required: true}
+	source := CommandSpec{
+		OperationID: "describeApp",
+		Method:      "GET",
+		PathTpl:     "/apps/{app_id}",
+		Params: []ParamSpec{
+			appID,
+			{Name: "fields", Flag: "fields", In: InQuery, GoType: "string"},
+		},
+		Output: OutputHints{ResponseMediaType: "application/json"},
+	}
+	target := CommandSpec{
+		OperationID: "runApp",
+		Method:      "POST",
+		PathTpl:     "/apps/{app_id}/run",
+		Params:      []ParamSpec{appID},
+		RequestBody: &RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			RuntimeSchema: &RuntimeSchemaSpec{
+				Operation:    source,
+				ResponsePath: "input_schema",
+				Params: map[string]string{
+					"app_id": "${params.app_id}",
+					"fields": "input_schema",
+				},
+			},
+		},
+	}
+	baseInput := OperationInput{Values: map[string]any{"app_id": "app-1"}, Changed: map[string]bool{"app_id": true}}
+	opts := OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}}
+
+	invalid := baseInput
+	invalid.FileBody = []byte(`{"count":2.0,"extra":true}`)
+	invalid.HasFile = true
+	if _, err := InvokeOperation(t.Context(), target, invalid, opts); err == nil || ClassifyError(err).Code != CodeUsage {
+		t.Fatalf("invalid body error = %v, want usage", err)
+	}
+	if schemaHits.Load() != 1 || targetHits.Load() != 0 {
+		t.Fatalf("invalid body hits = schema:%d target:%d", schemaHits.Load(), targetHits.Load())
+	}
+
+	valid := baseInput
+	valid.FileBody = []byte(`{"count":2.0,"note":null}`)
+	valid.HasFile = true
+	if _, err := InvokeOperation(t.Context(), target, valid, opts); err != nil {
+		t.Fatalf("valid body: %v", err)
+	}
+	if schemaHits.Load() != 2 || targetHits.Load() != 1 {
+		t.Fatalf("valid body hits = schema:%d target:%d", schemaHits.Load(), targetHits.Load())
+	}
+
+	optional := target
+	optional.RequestBody = &RequestBody{MediaType: "application/json", RuntimeSchema: target.RequestBody.RuntimeSchema}
+	if _, err := InvokeOperation(t.Context(), optional, baseInput, opts); err != nil {
+		t.Fatalf("optional body: %v", err)
+	}
+	if schemaHits.Load() != 2 || targetHits.Load() != 2 {
+		t.Fatalf("optional body hits = schema:%d target:%d", schemaHits.Load(), targetHits.Load())
+	}
+
+	dryRun := opts
+	dryRun.DryRun = true
+	if result, err := InvokeOperation(t.Context(), target, valid, dryRun); err != nil || result.DryRun == nil {
+		t.Fatalf("dry-run result = %+v, err = %v", result, err)
+	}
+	if schemaHits.Load() != 2 || targetHits.Load() != 2 {
+		t.Fatalf("dry-run hits = schema:%d target:%d", schemaHits.Load(), targetHits.Load())
+	}
+}
+
+func TestInvokeOperation_RuntimeSchemaDoesNotLoadExternalRefs(t *testing.T) {
+	var externalHits atomic.Int32
+	var targetHits atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/schema":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"schema":{"$ref":%q}}`, srv.URL+"/external")
+		case "/external":
+			externalHits.Add(1)
+			fmt.Fprint(w, `{}`)
+		case "/run":
+			targetHits.Add(1)
+			fmt.Fprint(w, `{}`)
+		}
+	}))
+	defer srv.Close()
+
+	target := CommandSpec{
+		Method:  "POST",
+		PathTpl: "/run",
+		RequestBody: &RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			RuntimeSchema: &RuntimeSchemaSpec{
+				Operation:    CommandSpec{Method: "GET", PathTpl: "/schema"},
+				ResponsePath: "schema",
+			},
+		},
+	}
+	input := OperationInput{FileBody: []byte(`{}`), HasFile: true}
+	_, err := InvokeOperation(t.Context(), target, input, OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}})
+	if classified := ClassifyError(err); classified == nil || classified.Code != CodeAPIError {
+		t.Fatalf("error = %v, want api_error", err)
+	}
+	if externalHits.Load() != 0 || targetHits.Load() != 0 {
+		t.Fatalf("hits = external:%d target:%d", externalHits.Load(), targetHits.Load())
+	}
+}

--- a/pkg/runtime/runtime_schema_test.go
+++ b/pkg/runtime/runtime_schema_test.go
@@ -18,6 +18,9 @@ func TestInvokeOperation_RuntimeSchema(t *testing.T) {
 			if r.URL.Query().Get("fields") != "input_schema" {
 				t.Errorf("fields = %q", r.URL.Query().Get("fields"))
 			}
+			if got := r.URL.Query()["mode"]; len(got) != 2 || got[0] != "chat" || got[1] != "workflow" {
+				t.Errorf("mode = %#v", got)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, `{"input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object","properties":{"count":{"type":"integer"},"note":{"type":["string","null"]}},"required":["count"],"additionalProperties":false}}`)
 		case "/apps/app-1/run":
@@ -38,6 +41,7 @@ func TestInvokeOperation_RuntimeSchema(t *testing.T) {
 		Params: []ParamSpec{
 			appID,
 			{Name: "fields", Flag: "fields", In: InQuery, GoType: "string"},
+			{Name: "mode", Flag: "mode", In: InQuery, GoType: "[]string"},
 		},
 		Output: OutputHints{ResponseMediaType: "application/json"},
 	}
@@ -45,7 +49,10 @@ func TestInvokeOperation_RuntimeSchema(t *testing.T) {
 		OperationID: "runApp",
 		Method:      "POST",
 		PathTpl:     "/apps/{app_id}/run",
-		Params:      []ParamSpec{appID},
+		Params: []ParamSpec{
+			appID,
+			{Name: "mode", Flag: "mode", In: InQuery, GoType: "[]string"},
+		},
 		RequestBody: &RequestBody{
 			Required:  true,
 			MediaType: "application/json",
@@ -55,11 +62,15 @@ func TestInvokeOperation_RuntimeSchema(t *testing.T) {
 				Params: map[string]string{
 					"app_id": "${params.app_id}",
 					"fields": "input_schema",
+					"mode":   "${params.mode}",
 				},
 			},
 		},
 	}
-	baseInput := OperationInput{Values: map[string]any{"app_id": "app-1"}, Changed: map[string]bool{"app_id": true}}
+	baseInput := OperationInput{
+		Values:  map[string]any{"app_id": "app-1", "mode": []string{"chat", "workflow"}},
+		Changed: map[string]bool{"app_id": true, "mode": true},
+	}
 	opts := OperationOptions{Hostname: srv.URL, Client: ClientOptions{MaxRetries: -1}}
 
 	invalid := baseInput

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -75,12 +75,19 @@ const (
 )
 
 type RequestBody struct {
-	Required  bool
-	MediaType string      `json:",omitempty"`
-	Schema    *SchemaSpec `json:",omitempty"`
+	Required      bool
+	MediaType     string             `json:",omitempty"`
+	Schema        *SchemaSpec        `json:",omitempty"`
+	RuntimeSchema *RuntimeSchemaSpec `json:",omitempty"`
 
 	Template  string `json:",omitempty"`
 	MergePath string `json:",omitempty"`
+}
+
+type RuntimeSchemaSpec struct {
+	Operation    CommandSpec
+	ResponsePath string
+	Params       map[string]string
 }
 
 type SchemaSpec struct {


### PR DESCRIPTION
## Summary

- add an overlay-only `body.runtime_schema` binding to fetch JSON Schema from a visible, bodyless GET operation in the same module and host
- validate JSON request bodies with Draft 2020-12 support before sending the target request, while disabling external reference loading
- expose the preflight contract in the command catalog, generated Skill guidance, and documentation
- preserve network-free `--dry-run` behavior and skip preflight when an optional body is omitted

## Verification

- `make check`
- `go test -race ./... -count=1`
- generated Dify CLI: `__lathe verify --json`
- generated Dify CLI loopback: invalid bodies fetched the schema and sent no target POST; valid bodies fetched the schema and sent the target POST; dry-run succeeded with the server stopped
- Dify Cloud read-only smoke: OAuth device login, workspace/app discovery, live Draft 2020-12 `input_schema` fetch, and invalid-body preflight rejection with exit 2

## Compatibility

- bumps the agent-facing catalog schema from 15 to 16 to expose `body.runtime_schema`
- keeps the generated runtime schema version at 11 because existing generated command specs remain valid; projects must regenerate only to opt into the new overlay binding
- configured commands gain one read-only preflight request before target execution; commands without `body.runtime_schema` are unchanged
- no Dify-specific concepts are added to Lathe runtime

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
