### PR TITLE
feat(codegen): add OpenAPI operation allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ sources:
     openapi3:
       files:
         - api/openapi.yaml
+      expose:
+        operation_ids: [Payments_List, Payments_Get, Payments_Create]
 
   console:
     repo_url: https://github.com/acme/graphql-console.git
@@ -318,6 +320,7 @@ Declares which upstream specs become modules.
 | `backend` | Yes | One of `swagger`, `openapi3`, `proto`, or `graphql`. |
 | `swagger.files` | Swagger only | One or more Swagger 2.0 JSON specs. |
 | `openapi3.files` | OpenAPI 3 only | JSON or YAML OpenAPI specs. |
+| `openapi3.expose` | OpenAPI 3 only | Optional exact `operation_ids` allowlist. Every entry must match exactly one operation or codegen fails closed. |
 | `proto.staging` | Proto only | Files staged into the `protoc` include root before parsing. |
 | `proto.entries` | Proto only | Entry proto files. Only RPCs declared in these files, and annotated with `google.api.http`, become commands; imported files, including dependencies, never contribute commands. |
 | `proto.import_roots` | Proto only | Additional staged include roots passed to `protoc`. |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -183,6 +183,8 @@ sources:
     openapi3:
       files:
         - openapi.yaml
+      expose:
+        operation_ids: [Users_List, Users_Get, Users_Create]
 
   billing:
     repo_url: https://github.com/acme/billing-api.git
@@ -233,6 +235,12 @@ sources:
 
 Use immutable tags for reproducibility. `lathe specsync` resolves each tag to a
 commit SHA and writes sync state under `.cache/specs-sync/`.
+
+For `backend: openapi3`, optional `openapi3.expose.operation_ids` is an exact
+allowlist applied before commands are normalized or rendered. Each configured
+ID must match exactly one operation across all declared files; missing or
+duplicate matches fail codegen instead of silently widening or narrowing the
+CLI surface. Omitting `expose` preserves the existing expose-all behavior.
 
 Use `local_path` instead of `repo_url`/`pinned_tag` for a working-tree source.
 Relative paths resolve from `specs/sources.yaml`; sync state records the

--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -227,6 +227,13 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 	all := &oas3Doc{
 		Paths: map[string]*pathItem{},
 	}
+	allowedOperationIDs := map[string]bool{}
+	matchedOperationIDs := map[string]int{}
+	if src.OpenAPI3.Expose != nil {
+		for _, operationID := range src.OpenAPI3.Expose.OperationIDs {
+			allowedOperationIDs[operationID] = true
+		}
+	}
 	for _, rel := range src.OpenAPI3.Files {
 		p := filepath.Join(syncDir, rel)
 		data, err := os.ReadFile(p)
@@ -238,9 +245,56 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
 		applyServerBasePaths(&doc, src.Name, p)
+		countExposedOperationIDs(&doc, allowedOperationIDs, matchedOperationIDs)
 		mergeDoc(all, &doc, src.Name, p)
 	}
-	return toRawIR(src.Name, all), nil
+	mod := toRawIR(src.Name, all)
+	if src.OpenAPI3.Expose == nil {
+		return mod, nil
+	}
+	return filterExposedOperations(src.Name, mod, src.OpenAPI3.Expose.OperationIDs, matchedOperationIDs)
+}
+
+func countExposedOperationIDs(doc *oas3Doc, allowed map[string]bool, matched map[string]int) {
+	if len(allowed) == 0 {
+		return
+	}
+	for _, item := range doc.Paths {
+		for _, op := range []*operation{item.Get, item.Post, item.Put, item.Delete, item.Patch} {
+			if op != nil && allowed[op.OperationID] {
+				matched[op.OperationID]++
+			}
+		}
+	}
+}
+
+func filterExposedOperations(source string, mod *rawir.RawModule, operationIDs []string, matched map[string]int) (*rawir.RawModule, error) {
+	allowed := make(map[string]bool, len(operationIDs))
+	for _, operationID := range operationIDs {
+		allowed[operationID] = true
+		if matched[operationID] == 0 {
+			return nil, fmt.Errorf("openapi3.expose.operation_ids entry %q matched no operations in source %q", operationID, source)
+		}
+		if matched[operationID] > 1 {
+			return nil, fmt.Errorf("openapi3.expose.operation_ids entry %q is ambiguous in source %q: matched %d operations", operationID, source, matched[operationID])
+		}
+	}
+
+	operations := mod.Operations[:0]
+	generated := map[string]bool{}
+	for _, op := range mod.Operations {
+		if allowed[op.OperationID] {
+			operations = append(operations, op)
+			generated[op.OperationID] = true
+		}
+	}
+	for _, operationID := range operationIDs {
+		if !generated[operationID] {
+			return nil, fmt.Errorf("openapi3.expose.operation_ids entry %q was discarded while merging source %q", operationID, source)
+		}
+	}
+	mod.Operations = operations
+	return mod, nil
 }
 
 func applyServerBasePaths(doc *oas3Doc, module, origin string) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -81,6 +81,81 @@ func TestParse_OpenAPI31NullableTypeArray(t *testing.T) {
 	}
 }
 
+func TestParse_ExposeOperationIDs(t *testing.T) {
+	syncDir := t.TempDir()
+	input := `{
+  "openapi": "3.0.3",
+  "paths": {
+    "/pets": {"get": {"operationId": "Pet_List", "responses": {"200": {}}}},
+    "/pets/{id}": {"get": {"operationId": "Pet_Get", "responses": {"200": {}}}},
+    "/health": {"get": {"operationId": "Health_Get", "responses": {"200": {}}}}
+  }
+}`
+	if err := os.WriteFile(filepath.Join(syncDir, "openapi.json"), []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := &sourceconfig.Source{
+		Name: "demo",
+		OpenAPI3: &sourceconfig.OpenAPI3Config{
+			Files:  []string{"openapi.json"},
+			Expose: &sourceconfig.OpenAPIExpose{OperationIDs: []string{"Pet_Get", "Pet_List"}},
+		},
+	}
+	mod, err := Parse(src, syncDir)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	got := map[string]bool{}
+	for _, op := range mod.Operations {
+		got[op.OperationID] = true
+	}
+	if !reflect.DeepEqual(got, map[string]bool{"Pet_Get": true, "Pet_List": true}) {
+		t.Fatalf("operations = %#v", got)
+	}
+}
+
+func TestParse_ExposeOperationIDsFailsClosed(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"unmatched", `{
+  "openapi": "3.0.3",
+  "paths": {"/pets": {"get": {"operationId": "Pet_List", "responses": {"200": {}}}}}
+}`, "matched no operations"},
+		{"ambiguous", `{
+  "openapi": "3.0.3",
+  "paths": {"/pets": {"get": {"operationId": "Pet_Get", "responses": {"200": {}}}}}
+}`, "ambiguous"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			syncDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(syncDir, "openapi.json"), []byte(tc.input), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			files := []string{"openapi.json"}
+			if tc.name == "ambiguous" {
+				if err := os.WriteFile(filepath.Join(syncDir, "duplicate.json"), []byte(tc.input), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				files = append(files, "duplicate.json")
+			}
+			src := &sourceconfig.Source{
+				Name: "demo",
+				OpenAPI3: &sourceconfig.OpenAPI3Config{
+					Files:  files,
+					Expose: &sourceconfig.OpenAPIExpose{OperationIDs: []string{"Pet_Get"}},
+				},
+			}
+			if _, err := Parse(src, syncDir); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Parse error = %v", err)
+			}
+		})
+	}
+}
+
 func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
 	input := `{
   "openapi": "3.1.0",

--- a/internal/sourceconfig/sources.go
+++ b/internal/sourceconfig/sources.go
@@ -66,7 +66,12 @@ type ProtoDependency struct {
 }
 
 type OpenAPI3Config struct {
-	Files []string `yaml:"files"`
+	Files  []string       `yaml:"files"`
+	Expose *OpenAPIExpose `yaml:"expose,omitempty"`
+}
+
+type OpenAPIExpose struct {
+	OperationIDs []string `yaml:"operation_ids"`
 }
 
 type GraphQLConfig struct {
@@ -215,6 +220,21 @@ func validate(s *Source, baseDir string) error {
 		}
 		if err := validateRelPathList("openapi3.files", s.OpenAPI3.Files); err != nil {
 			return err
+		}
+		if s.OpenAPI3.Expose != nil {
+			if len(s.OpenAPI3.Expose.OperationIDs) == 0 {
+				return fmt.Errorf("openapi3.expose requires non-empty operation_ids")
+			}
+			seen := map[string]bool{}
+			for _, operationID := range s.OpenAPI3.Expose.OperationIDs {
+				if strings.TrimSpace(operationID) == "" {
+					return fmt.Errorf("openapi3.expose.operation_ids must not contain empty values")
+				}
+				if seen[operationID] {
+					return fmt.Errorf("openapi3.expose.operation_ids contains duplicate %q", operationID)
+				}
+				seen[operationID] = true
+			}
 		}
 	case BackendGraphQL:
 		if s.GraphQL == nil || s.GraphQL.Schema == "" {

--- a/internal/sourceconfig/sources_test.go
+++ b/internal/sourceconfig/sources_test.go
@@ -223,6 +223,8 @@ func TestLoad_AcceptsOpenAPI3(t *testing.T) {
     backend: openapi3
     openapi3:
       files: [openapi.yaml]
+      expose:
+        operation_ids: [Pet_List, Pet_Get]
 `
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("seed yaml: %v", err)
@@ -233,6 +235,37 @@ func TestLoad_AcceptsOpenAPI3(t *testing.T) {
 	}
 	if cfg.Sources["demo"].Backend != BackendOpenAPI3 {
 		t.Errorf("backend = %q, want openapi3", cfg.Sources["demo"].Backend)
+	}
+	if got := cfg.Sources["demo"].OpenAPI3.Expose.OperationIDs; len(got) != 2 || got[0] != "Pet_List" || got[1] != "Pet_Get" {
+		t.Fatalf("operation_ids = %#v", got)
+	}
+}
+
+func TestLoad_RejectsInvalidOpenAPI3Expose(t *testing.T) {
+	for name, operationIDs := range map[string]string{
+		"empty":     "[]",
+		"blank":     "['']",
+		"duplicate": "[Pet_List, Pet_List]",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sources.yaml")
+			body := `sources:
+  demo:
+    repo_url: https://example.com/repo.git
+    pinned_tag: v2.0.0
+    backend: openapi3
+    openapi3:
+      files: [openapi.yaml]
+      expose:
+        operation_ids: ` + operationIDs + "\n"
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatalf("seed yaml: %v", err)
+			}
+			if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "openapi3.expose") {
+				t.Fatalf("Load error = %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add an optional exact `openapi3.expose.operation_ids` allowlist.
- Fail code generation when a configured operation ID is missing or ambiguous across declared files.
- Preserve expose-all behavior when the policy is omitted and document the new configuration.

## Verification

- `go test ./internal/sourceconfig ./internal/codegen/backends/openapi3 ./internal/lathecmd -count=1`
- `make check`
- `go test -race ./... -count=1`
- Generated CLI contract verification: 31/31 checks passed with the configured 25-operation surface.

## Compatibility

Additive source configuration. Omitting `openapi3.expose` preserves existing behavior. Configured allowlists intentionally fail closed when upstream operation IDs are renamed, missing, or duplicated. No runtime or catalog schema changes.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.