### PR TITLE
feat(overlays): support command group descriptions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,6 +198,7 @@ Overlays apply at codegen-time. The runtime has no overlay types. This matrix sh
 |---|---|---|---|
 | `Use` | `operationId`-derived | rename | overlay > spec |
 | `Group` | `tags[0]` / service name | override | overlay > spec |
+| `GroupShort` | — | set by final group name | overlay-only |
 | `Short` | `summary` / first comment | override | overlay > spec |
 | `Long` | `description` / comment block | override | overlay > spec |
 | `Aliases` | — | append | overlay-only |

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -313,9 +313,24 @@ but not omitted. `.lathe-skill`, dotfiles, path traversal, and symlinks are
 rejected.
 
 OpenAPI parameter names are rendered as kebab-case flags. Generated commands
-continue accepting the previous snake-case spelling when it differs. An overlay
-can expose selected parameters as ordered positional alternatives without
-removing their flags:
+continue accepting the previous snake-case spelling when it differs.
+
+An overlay can replace the generic help text for a final command group without
+changing its path:
+
+```yaml
+groups:
+  users:
+    short: Manage users and access
+```
+
+Group keys match the final `group` value after command overrides. Unknown
+groups, empty descriptions, and multiline descriptions fail codegen. When no
+description is configured, existing CLIs keep the `<group> operations`
+fallback.
+
+An overlay can expose selected parameters as ordered positional alternatives
+without removing their flags:
 
 ```yaml
 commands:

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -25,6 +25,9 @@ commands: {}
 #     params:
 #       page: "1"
 #       pageSize: "20"
+# groups:
+#   Identity:
+#     short: "Manage users and access"
 # commands:
 #   create-user:
 #     use: create

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -260,6 +260,7 @@ func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Over
 func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
 	merged := mergeOverlaySpecs(specs, mod)
 	applyRuntimeSchemaBindings(specs, merged, mod)
+	applyGroupOverrides(merged, mod.Groups)
 	return merged
 }
 
@@ -300,7 +301,35 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 			}
 		}
 	}
-	return validateRuntimeSchemaBindings(specs, mergeOverlaySpecs(specs, mod), mod)
+	merged := mergeOverlaySpecs(specs, mod)
+	if err := validateGroupOverrides(merged, mod.Groups); err != nil {
+		return err
+	}
+	return validateRuntimeSchemaBindings(specs, merged, mod)
+}
+
+func validateGroupOverrides(specs []runtime.CommandSpec, groups map[string]overlay.GroupOverride) error {
+	known := make(map[string]bool, len(specs))
+	for _, spec := range specs {
+		known[spec.Group] = true
+	}
+	for name, group := range groups {
+		if !known[name] {
+			return fmt.Errorf("group %q does not exist after command overrides", name)
+		}
+		if group.Short == "" || strings.TrimSpace(group.Short) != group.Short || strings.ContainsAny(group.Short, "\r\n") {
+			return fmt.Errorf("group %q short must be one non-empty trimmed line", name)
+		}
+	}
+	return nil
+}
+
+func applyGroupOverrides(specs []runtime.CommandSpec, groups map[string]overlay.GroupOverride) {
+	for i := range specs {
+		if group, ok := groups[specs[i].Group]; ok {
+			specs[i].GroupShort = group.Short
+		}
+	}
 }
 
 func validateRuntimeSchemaBindings(original, merged []runtime.CommandSpec, mod overlay.Module) error {
@@ -1003,6 +1032,7 @@ func commandSpecLiteral(spec runtime.CommandSpec) string {
 	var b strings.Builder
 	b.WriteString("runtime.CommandSpec{")
 	writeStringField(&b, "Group", spec.Group)
+	writeStringField(&b, "GroupShort", spec.GroupShort)
 	writeStringField(&b, "Use", spec.Use)
 	writeStringSliceField(&b, "Aliases", spec.Aliases)
 	if len(spec.Shortcuts) > 0 {
@@ -1424,6 +1454,9 @@ var Specs = []runtime.CommandSpec{
 {{- range $op := .Ops}}
 	{
 		Group:       {{printf "%q" $op.Group}},
+		{{- if $op.GroupShort}}
+		GroupShort:  {{printf "%q" $op.GroupShort}},
+		{{- end}}
 		Use:         {{printf "%q" $op.Use}},
 		{{- if $op.Aliases}}
 		Aliases:     []string{ {{- range $op.Aliases}}{{printf "%q" .}}, {{end -}} },

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -251,11 +251,23 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 	specs := []runtime.CommandSpec{
 		{Group: "Default", Use: "get-item", Short: "get", Method: "GET", PathTpl: "/item"},
 	}
-	overrides := map[string]overlay.Override{
-		"get-item": {Group: "Items", Hidden: &hidden},
+	mod := overlay.Module{
+		Groups: map[string]overlay.GroupOverride{
+			"Items": {Short: "Inspect inventory items"},
+		},
+		Commands: map[string]overlay.Override{
+			"get-item": {Group: "Items", Hidden: &hidden},
+		},
 	}
-	if err := RenderModule("demo", "", specs, overrides); err != nil {
-		t.Fatalf("RenderModule: %v", err)
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		t.Fatalf("ValidateOverlayModule: %v", err)
+	}
+	merged := MergeOverlayModule(specs, mod)
+	if merged[0].GroupShort != "Inspect inventory items" {
+		t.Fatalf("group short = %q", merged[0].GroupShort)
+	}
+	if err := renderModuleSpecs("demo", "demo", merged); err != nil {
+		t.Fatalf("renderModuleSpecs: %v", err)
 	}
 	got := generatedModule(t, "demo")
 	if strings.Contains(got, `"Default"`) {
@@ -264,8 +276,34 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 	if !strings.Contains(got, `"Items"`) {
 		t.Error("group should be overridden to Items")
 	}
+	if !strings.Contains(got, `GroupShort: "Inspect inventory items"`) {
+		t.Error("group short should be generated")
+	}
 	if !strings.Contains(got, "Hidden:") {
 		t.Error("hidden should be set")
+	}
+}
+
+func TestValidateOverlayModule_RejectsInvalidGroups(t *testing.T) {
+	specs := []runtime.CommandSpec{{Group: "Users", Use: "list-users"}}
+	for _, tc := range []struct {
+		name  string
+		group string
+		short string
+		want  string
+	}{
+		{name: "unknown", group: "Missing", short: "Manage missing resources", want: `group "Missing" does not exist`},
+		{name: "empty short", group: "Users", want: `group "Users" short must be one non-empty trimmed line`},
+		{name: "multiline short", group: "Users", short: "Manage\nusers", want: `group "Users" short must be one non-empty trimmed line`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOverlayModule(specs, overlay.Module{Groups: map[string]overlay.GroupOverride{
+				tc.group: {Short: tc.short},
+			}})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validation error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -120,9 +120,14 @@ type KnownError struct {
 	Cause  string `yaml:"cause"`
 }
 
+type GroupOverride struct {
+	Short string `yaml:"short"`
+}
+
 type Module struct {
-	Defaults Defaults            `yaml:"defaults"`
-	Commands map[string]Override `yaml:"commands"`
+	Defaults Defaults                 `yaml:"defaults"`
+	Groups   map[string]GroupOverride `yaml:"groups"`
+	Commands map[string]Override      `yaml:"commands"`
 }
 
 type Defaults struct {

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -95,6 +95,9 @@ func TestLoadDir_ParsesExtendedFields(t *testing.T) {
     params:
       page: "1"
       pageSize: "20"
+groups:
+  Identity:
+    short: "Manage user identities"
 commands:
   create-user:
     match:
@@ -140,6 +143,9 @@ commands:
 		t.Fatalf("LoadDir: %v", err)
 	}
 	mod := got["iam"]
+	if mod.Groups["Identity"].Short != "Manage user identities" {
+		t.Fatalf("group override = %#v", mod.Groups["Identity"])
+	}
 	if mod.Defaults.Pagination == nil {
 		t.Fatal("pagination defaults were not parsed")
 	}

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -80,11 +80,17 @@ func buildGroups(service string, specs []CommandSpec) ([]*cobra.Command, error) 
 	ordered := make([]*cobra.Command, 0)
 	for i := range specs {
 		s := specs[i]
+		groupShort := s.GroupShort
+		if groupShort == "" {
+			groupShort = s.Group + " operations"
+		}
 		g, ok := groups[s.Group]
 		if !ok {
-			g = helpCommand(strings.ToLower(s.Group), s.Group+" operations")
+			g = helpCommand(strings.ToLower(s.Group), groupShort)
 			groups[s.Group] = g
 			ordered = append(ordered, g)
+		} else if g.Short != groupShort {
+			return nil, fmt.Errorf("group %q has conflicting descriptions", s.Group)
 		}
 		c := buildCmd(s)
 		for _, name := range append([]string{c.Name()}, c.Aliases...) {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -60,11 +60,12 @@ func TestBuild_RejectsExistingRootCommandConflict(t *testing.T) {
 func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 	specs := []CommandSpec{
 		{
-			Group:   "Users",
-			Use:     "get-user",
-			Short:   "Get a user",
-			Method:  "GET",
-			PathTpl: "/users/{id}",
+			Group:      "Users",
+			GroupShort: "Manage user accounts",
+			Use:        "get-user",
+			Short:      "Get a user",
+			Method:     "GET",
+			PathTpl:    "/users/{id}",
 			Params: []ParamSpec{
 				{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true, Help: "User id"},
 				{Name: "limit", Flag: "limit", In: InQuery, GoType: "int64", Help: "Page size"},
@@ -88,6 +89,12 @@ func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 	svc := mustFindChild(t, root, "demo")
 	usersGroup := mustFindChild(t, svc, "users")
 	itemsGroup := mustFindChild(t, svc, "items")
+	if usersGroup.Short != "Manage user accounts" {
+		t.Errorf("users group short = %q", usersGroup.Short)
+	}
+	if itemsGroup.Short != "Items operations" {
+		t.Errorf("items group fallback short = %q", itemsGroup.Short)
+	}
 
 	if len(usersGroup.Commands()) != 1 || usersGroup.Commands()[0].Use != "get-user" {
 		t.Errorf("users group commands = %v, want [get-user]", cmdNames(usersGroup.Commands()))

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -10,6 +10,7 @@ const SchemaVersion = 11
 
 type CommandSpec struct {
 	Group           string
+	GroupShort      string `json:",omitempty"`
 	Use             string
 	Aliases         []string
 	Shortcuts       []CommandShortcut `json:",omitempty"`


### PR DESCRIPTION
## Summary

- Add optional `groups.<name>.short` overlay metadata for generated command groups.
- Validate group names after command overrides and reject empty or multiline descriptions.
- Preserve the existing `<group> operations` fallback when no description is configured.
- Document the overlay contract and example configuration.

## Verification

- `make check`
- `go test -race ./...`
- Generated and built the Petstore example with a custom group description.
- Generated and built the Dify CLI fixture, then ran `difyctl __lathe verify --json`.
- Confirmed an unknown overlay group fails codegen.

## Compatibility

The overlay field is optional. Existing projects retain byte-compatible normalized output and the current generic group-help fallback. Configured projects emit an additive `GroupShort` field in generated command specs. The command catalog schema and command paths are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
