### PR TITLE
fix: preserve generated CLI compatibility

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -87,7 +87,6 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 		}
 		return specs[i].OperationID < specs[j].OperationID
 	})
-	disambiguateUse(specs)
 	return specs
 }
 
@@ -220,31 +219,6 @@ func collapseDashes(s string) string {
 	return b.String()
 }
 
-// disambiguateUse makes each command's Group+Use unique. Distinct operations can
-// still normalize to the same command name (e.g. GET /groups and GET /Groups);
-// without this, codegen aborts on the collision instead of exposing both
-// endpoints. Runs after the sort so the suffix assignment is deterministic.
-func disambiguateUse(specs []runtime.CommandSpec) {
-	used := map[string]bool{}
-	for i := range specs {
-		key := specs[i].Group + "\x00" + specs[i].Use
-		if !used[key] {
-			used[key] = true
-			continue
-		}
-		base := specs[i].Use
-		for n := 2; ; n++ {
-			cand := base + "-" + strconv.Itoa(n)
-			ck := specs[i].Group + "\x00" + cand
-			if !used[ck] {
-				specs[i].Use = cand
-				used[ck] = true
-				break
-			}
-		}
-	}
-}
-
 func applyRawOutputHints(spec *runtime.CommandSpec, hints *rawir.RawOutputHints) {
 	if hints == nil {
 		return
@@ -278,10 +252,27 @@ func group(op rawir.RawOperation) string {
 // Blind prefix stripping collapses create_chunk/update_chunk/delete_chunk onto one name.
 func opNameFromID(id, group, module string) string {
 	idx := strings.Index(id, "_")
-	if idx <= 0 || !sameToken(id[:idx], group) && !sameToken(id[:idx], module) {
+	if idx <= 0 {
 		return id
 	}
-	return id[idx+1:]
+	prefix, suffix := id[:idx], id[idx+1:]
+	if repeatsIDPrefix(prefix, suffix) {
+		return suffix
+	}
+	if sameToken(prefix, group) || sameToken(prefix, module) {
+		return suffix
+	}
+	return id
+}
+
+func repeatsIDPrefix(prefix, suffix string) bool {
+	if !strings.HasPrefix(suffix, prefix) {
+		return false
+	}
+	for _, next := range suffix[len(prefix):] {
+		return next == '_' || next == '-' || unicode.IsUpper(next) || unicode.IsDigit(next)
+	}
+	return true
 }
 
 // kebabFromID renders an operationId as a command name. Edge separators are

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -613,24 +613,9 @@ func securityScopes() *rawir.RawModule {
 	}
 }
 
-func TestDisambiguateUseCollisions(t *testing.T) {
-	// Same group, same derived name: distinct operations must both survive with
-	// distinct command names rather than aborting codegen.
-	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
-		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/groups"},
-		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/Groups"},
-	}}
-	specs := Normalize(mod)
-	if len(specs) != 2 {
-		t.Fatalf("want 2 specs, got %d", len(specs))
-	}
-	if specs[0].Use == specs[1].Use {
-		t.Errorf("colliding command names not disambiguated: both %q", specs[0].Use)
-	}
-}
-
-// A leading id segment is redundant only when it repeats the group. Stripping
-// it unconditionally collapsed every CRUD verb onto the same command name.
+// A leading id segment is not redundant merely because it precedes an
+// underscore. Stripping it unconditionally collapsed every CRUD verb onto one
+// command name.
 func TestOpNameKeepsVerbWhenPrefixIsNotTheGroup(t *testing.T) {
 	mod := &rawir.RawModule{Operations: []rawir.RawOperation{
 		{Group: "Chunk", OperationID: "create_chunk", Method: "POST", Path: "/api/chunk"},
@@ -665,6 +650,27 @@ func TestOpNameDropsModulePrefix(t *testing.T) {
 	specs := Normalize(mod)
 	if got := specs[0].Use; got != "list-apps" {
 		t.Fatalf("Use = %q, want list-apps", got)
+	}
+}
+
+func TestOpNameDropsExactRepeatedPrefix(t *testing.T) {
+	mod := &rawir.RawModule{
+		Name: "skoala",
+		Operations: []rawir.RawOperation{
+			{Group: "Gateway", OperationID: "GatewayOverview_GatewayOverviewAPIStats", Method: "GET", Path: "/stats/api"},
+			{Group: "Gateway", OperationID: "User_UserlandStats", Method: "GET", Path: "/stats/userland"},
+		},
+	}
+	got := map[string]string{}
+	for _, spec := range Normalize(mod) {
+		got[spec.OperationID] = spec.Use
+	}
+	want := map[string]string{
+		"GatewayOverview_GatewayOverviewAPIStats": "gateway-overview-api-stats",
+		"User_UserlandStats":                      "user-userland-stats",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("uses = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -269,6 +269,7 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 	var merged []runtime.CommandSpec
 	var overrides []overlay.Override
 	var matched []bool
+	var matchedLegacyUses []string
 	legacyUses := legacyOverlayUses(specs)
 	for i, s := range specs {
 		o, ok := commandOverride(mod, s, legacyUses[i])
@@ -276,13 +277,14 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 			continue
 		}
 		cs := cloneCommandSpec(s)
-		applyBulkDefaults(&cs, mod.Defaults)
 		merged = append(merged, cs)
 		overrides = append(overrides, o)
 		matched = append(matched, ok)
+		matchedLegacyUses = append(matchedLegacyUses, legacyUses[i])
 	}
 	disambiguateUse(merged)
 	for i := range merged {
+		applyBulkDefaults(&merged[i], mod.Defaults, matchedLegacyUses[i])
 		if matched[i] {
 			applyCommandOverride(&merged[i], overrides[i])
 		}
@@ -307,6 +309,11 @@ func commandOverride(mod overlay.Module, spec runtime.CommandSpec, legacyUse str
 		if override, ok := mod.Commands[legacyUse]; ok && overrideMatches(spec, override) {
 			return override, true
 		}
+		override, ok := mod.Commands[spec.Use]
+		if !ok || override.Match.Method == "" && override.Match.Path == "" {
+			return overlay.Override{}, false
+		}
+		return override, overrideMatches(spec, override)
 	}
 	override, ok := mod.Commands[spec.Use]
 	return override, ok && overrideMatches(spec, override)
@@ -695,8 +702,8 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	return cloned
 }
 
-func applyBulkDefaults(spec *runtime.CommandSpec, defaults overlay.Defaults) {
-	if defaults.Pagination == nil || !matchesAny(defaults.Pagination.MatchCommands, spec.Use) {
+func applyBulkDefaults(spec *runtime.CommandSpec, defaults overlay.Defaults, legacyUse string) {
+	if defaults.Pagination == nil || !matchesAny(defaults.Pagination.MatchCommands, spec.Use) && !matchesAny(defaults.Pagination.MatchCommands, legacyUse) {
 		return
 	}
 	for i := range spec.Params {

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -269,11 +269,9 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 	var merged []runtime.CommandSpec
 	var overrides []overlay.Override
 	var matched []bool
-	for _, s := range specs {
-		o, ok := mod.Commands[s.Use]
-		if ok && !overrideMatches(s, o) {
-			ok = false
-		}
+	legacyUses := legacyOverlayUses(specs)
+	for i, s := range specs {
+		o, ok := commandOverride(mod, s, legacyUses[i])
 		if ok && o.Ignore {
 			continue
 		}
@@ -290,6 +288,28 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 		}
 	}
 	return merged
+}
+
+// legacyOverlayUses reproduces the pre-v0.6 collision keys so existing
+// overlays still resolve before ignored operations are removed.
+func legacyOverlayUses(specs []runtime.CommandSpec) []string {
+	legacy := append([]runtime.CommandSpec(nil), specs...)
+	disambiguateUse(legacy)
+	uses := make([]string, len(legacy))
+	for i := range legacy {
+		uses[i] = legacy[i].Use
+	}
+	return uses
+}
+
+func commandOverride(mod overlay.Module, spec runtime.CommandSpec, legacyUse string) (overlay.Override, bool) {
+	if legacyUse != spec.Use {
+		if override, ok := mod.Commands[legacyUse]; ok && overrideMatches(spec, override) {
+			return override, true
+		}
+	}
+	override, ok := mod.Commands[spec.Use]
+	return override, ok && overrideMatches(spec, override)
 }
 
 // disambiguateUse runs after ignored operations are removed so a filtered
@@ -316,9 +336,10 @@ func disambiguateUse(specs []runtime.CommandSpec) {
 }
 
 func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) error {
-	for _, spec := range specs {
-		override, ok := mod.Commands[spec.Use]
-		if !ok || !overrideMatches(spec, override) {
+	legacyUses := legacyOverlayUses(specs)
+	for i, spec := range specs {
+		override, ok := commandOverride(mod, spec, legacyUses[i])
+		if !ok {
 			continue
 		}
 		if err := validateArguments(spec, override.Params); err != nil {
@@ -362,9 +383,10 @@ func applyGroupOverrides(specs []runtime.CommandSpec, groups map[string]overlay.
 }
 
 func validateRuntimeSchemaBindings(original, merged []runtime.CommandSpec, mod overlay.Module) error {
-	for _, spec := range original {
-		override, ok := mod.Commands[spec.Use]
-		if !ok || override.Ignore || !overrideMatches(spec, override) || override.Body == nil || override.Body.RuntimeSchema == nil {
+	legacyUses := legacyOverlayUses(original)
+	for i, spec := range original {
+		override, ok := commandOverride(mod, spec, legacyUses[i])
+		if !ok || override.Ignore || override.Body == nil || override.Body.RuntimeSchema == nil {
 			continue
 		}
 		target, count := operationByID(merged, spec.OperationID)
@@ -448,9 +470,10 @@ func validateRuntimeSchemaSource(target, source runtime.CommandSpec, binding *ov
 }
 
 func applyRuntimeSchemaBindings(original, merged []runtime.CommandSpec, mod overlay.Module) {
-	for _, spec := range original {
-		override, ok := mod.Commands[spec.Use]
-		if !ok || override.Ignore || !overrideMatches(spec, override) || override.Body == nil || override.Body.RuntimeSchema == nil {
+	legacyUses := legacyOverlayUses(original)
+	for i, spec := range original {
+		override, ok := commandOverride(mod, spec, legacyUses[i])
+		if !ok || override.Ignore || override.Body == nil || override.Body.RuntimeSchema == nil {
 			continue
 		}
 		target, targetCount := operationByID(merged, spec.OperationID)

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -266,6 +267,8 @@ func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runti
 
 func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
 	var merged []runtime.CommandSpec
+	var overrides []overlay.Override
+	var matched []bool
 	for _, s := range specs {
 		o, ok := mod.Commands[s.Use]
 		if ok && !overrideMatches(s, o) {
@@ -276,14 +279,40 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 		}
 		cs := cloneCommandSpec(s)
 		applyBulkDefaults(&cs, mod.Defaults)
-		if !ok {
-			merged = append(merged, cs)
-			continue
-		}
-		applyCommandOverride(&cs, o)
 		merged = append(merged, cs)
+		overrides = append(overrides, o)
+		matched = append(matched, ok)
+	}
+	disambiguateUse(merged)
+	for i := range merged {
+		if matched[i] {
+			applyCommandOverride(&merged[i], overrides[i])
+		}
 	}
 	return merged
+}
+
+// disambiguateUse runs after ignored operations are removed so a filtered
+// collision cannot leave the surviving public command with a stale -N suffix.
+func disambiguateUse(specs []runtime.CommandSpec) {
+	used := map[string]bool{}
+	for i := range specs {
+		key := specs[i].Group + "\x00" + specs[i].Use
+		if !used[key] {
+			used[key] = true
+			continue
+		}
+		base := specs[i].Use
+		for n := 2; ; n++ {
+			candidate := base + "-" + strconv.Itoa(n)
+			key = specs[i].Group + "\x00" + candidate
+			if !used[key] {
+				specs[i].Use = candidate
+				used[key] = true
+				break
+			}
+		}
+	}
 }
 
 func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) error {

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -315,7 +315,7 @@ func TestMergeOverlayModule_IgnoresCollisionBeforeDisambiguation(t *testing.T) {
 		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/v2/groups"},
 	}})
 	mod := overlay.Module{Commands: map[string]overlay.Override{
-		"list": {Match: overlay.OperationMatch{Path: "/v1/groups"}, Ignore: true},
+		"list": {Match: overlay.OperationMatch{Path: "/v2/groups"}, Ignore: true},
 	}}
 	merged := MergeOverlayModule(specs, mod)
 	if len(merged) != 1 {
@@ -324,8 +324,8 @@ func TestMergeOverlayModule_IgnoresCollisionBeforeDisambiguation(t *testing.T) {
 	if got := merged[0].Use; got != "list" {
 		t.Fatalf("surviving Use = %q, want list", got)
 	}
-	if got := merged[0].PathTpl; got != "/v2/groups" {
-		t.Fatalf("surviving path = %q, want /v2/groups", got)
+	if got := merged[0].PathTpl; got != "/v1/groups" {
+		t.Fatalf("surviving path = %q, want /v1/groups", got)
 	}
 }
 
@@ -358,6 +358,15 @@ func TestMergeOverlayModule_PreservesLegacyCollisionOverlayKey(t *testing.T) {
 		merged := MergeOverlayModule(specs, mod)
 		if len(merged) != 2 || merged[0].Short == "Legacy second command" || merged[1].Short != "Legacy second command" {
 			t.Fatalf("merged = %#v, want override only on second command", merged)
+		}
+	})
+
+	t.Run("unsuffixed override remains first", func(t *testing.T) {
+		merged := MergeOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+			"list": {Short: "First command only"},
+		}})
+		if len(merged) != 2 || merged[0].Short != "First command only" || merged[1].Short == "First command only" {
+			t.Fatalf("merged = %#v, want unsuffixed override only on first command", merged)
 		}
 	})
 }
@@ -661,6 +670,20 @@ func TestMergeOverlayModule_BulkPaginationDefaults(t *testing.T) {
 	}
 	if got := paramDefault(t, bulk, "get-user", "id"); got != "" {
 		t.Fatalf("non-matching command default = %q, want empty", got)
+	}
+}
+
+func TestMergeOverlayModule_BulkDefaultsUseLegacyCollisionName(t *testing.T) {
+	specs := normalize.Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/v1/groups", Parameters: []rawir.RawParameter{{Name: "page", In: "query", Type: "integer"}}},
+		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/v2/groups", Parameters: []rawir.RawParameter{{Name: "page", In: "query", Type: "integer"}}},
+	}})
+	merged := MergeOverlayModule(specs, overlay.Module{Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
+		MatchCommands: []string{"list-2"},
+		Params:        map[string]string{"page": "2"},
+	}}})
+	if len(merged) != 2 || merged[0].Params[0].Default != "" || merged[1].Params[0].Default != "2" {
+		t.Fatalf("merged = %#v, want bulk default only on list-2", merged)
 	}
 }
 

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -329,6 +329,39 @@ func TestMergeOverlayModule_IgnoresCollisionBeforeDisambiguation(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayModule_PreservesLegacyCollisionOverlayKey(t *testing.T) {
+	specs := normalize.Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/v1/groups"},
+		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/v2/groups"},
+	}})
+
+	t.Run("ignore", func(t *testing.T) {
+		mod := overlay.Module{Commands: map[string]overlay.Override{
+			"list-2": {Match: overlay.OperationMatch{Path: "/v2/groups"}, Ignore: true},
+		}}
+		if err := ValidateOverlayModule(specs, mod); err != nil {
+			t.Fatalf("ValidateOverlayModule: %v", err)
+		}
+		merged := MergeOverlayModule(specs, mod)
+		if len(merged) != 1 || merged[0].PathTpl != "/v1/groups" || merged[0].Use != "list" {
+			t.Fatalf("merged = %#v, want only /v1/groups as list", merged)
+		}
+	})
+
+	t.Run("override", func(t *testing.T) {
+		mod := overlay.Module{Commands: map[string]overlay.Override{
+			"list-2": {Match: overlay.OperationMatch{Path: "/v2/groups"}, Short: "Legacy second command"},
+		}}
+		if err := ValidateOverlayModule(specs, mod); err != nil {
+			t.Fatalf("ValidateOverlayModule: %v", err)
+		}
+		merged := MergeOverlayModule(specs, mod)
+		if len(merged) != 2 || merged[0].Short == "Legacy second command" || merged[1].Short != "Legacy second command" {
+			t.Fatalf("merged = %#v, want override only on second command", merged)
+		}
+	})
+}
+
 func TestMergeOverlayModule_DisambiguatesSurvivingCollisions(t *testing.T) {
 	specs := normalize.Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{
 		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/Groups"},

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lathe-cli/lathe/internal/codegen/normalize"
+	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 	"github.com/lathe-cli/lathe/internal/overlay"
 	"github.com/lathe-cli/lathe/pkg/runtime"
 )
@@ -304,6 +306,40 @@ func TestValidateOverlayModule_RejectsInvalidGroups(t *testing.T) {
 				t.Fatalf("validation error = %v", err)
 			}
 		})
+	}
+}
+
+func TestMergeOverlayModule_IgnoresCollisionBeforeDisambiguation(t *testing.T) {
+	specs := normalize.Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/v1/groups"},
+		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/v2/groups"},
+	}})
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"list": {Match: overlay.OperationMatch{Path: "/v1/groups"}, Ignore: true},
+	}}
+	merged := MergeOverlayModule(specs, mod)
+	if len(merged) != 1 {
+		t.Fatalf("merged command count = %d, want 1", len(merged))
+	}
+	if got := merged[0].Use; got != "list" {
+		t.Fatalf("surviving Use = %q, want list", got)
+	}
+	if got := merged[0].PathTpl; got != "/v2/groups" {
+		t.Fatalf("surviving path = %q, want /v2/groups", got)
+	}
+}
+
+func TestMergeOverlayModule_DisambiguatesSurvivingCollisions(t *testing.T) {
+	specs := normalize.Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{
+		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/Groups"},
+		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/groups"},
+	}})
+	merged := MergeOverlayModule(specs, overlay.Module{})
+	if len(merged) != 2 {
+		t.Fatalf("merged command count = %d, want 2", len(merged))
+	}
+	if merged[0].Use == merged[1].Use {
+		t.Fatalf("colliding commands both use %q", merged[0].Use)
 	}
 }
 

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -227,25 +227,11 @@ func resolveRequest(ctx context.Context, hostname, method, path string, body any
 	if err != nil {
 		return nil, nil, "", err
 	}
-	req, err := newRequest(ctx, method, joinRequestURL(base, path), bodyBytes, contentType, opts)
+	req, err := newRequest(ctx, method, base+path, bodyBytes, contentType, opts)
 	if err != nil {
 		return nil, nil, "", err
 	}
 	return req, bodyBytes, contentType, nil
-}
-
-func joinRequestURL(base, requestPath string) string {
-	u, err := url.Parse(base)
-	if err != nil || u.RawQuery != "" || u.Fragment != "" {
-		return base + requestPath
-	}
-	basePath := strings.TrimRight(u.EscapedPath(), "/")
-	if basePath == "" || requestPath != basePath && !strings.HasPrefix(requestPath, basePath+"/") && !strings.HasPrefix(requestPath, basePath+"?") {
-		return base + requestPath
-	}
-	u.Path = ""
-	u.RawPath = ""
-	return strings.TrimRight(u.String(), "/") + requestPath
 }
 
 func newRequest(ctx context.Context, method, u string, body []byte, contentType string, opts ClientOptions) (*http.Request, error) {

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -227,11 +227,25 @@ func resolveRequest(ctx context.Context, hostname, method, path string, body any
 	if err != nil {
 		return nil, nil, "", err
 	}
-	req, err := newRequest(ctx, method, base+path, bodyBytes, contentType, opts)
+	req, err := newRequest(ctx, method, joinRequestURL(base, path), bodyBytes, contentType, opts)
 	if err != nil {
 		return nil, nil, "", err
 	}
 	return req, bodyBytes, contentType, nil
+}
+
+func joinRequestURL(base, requestPath string) string {
+	u, err := url.Parse(base)
+	if err != nil || u.RawQuery != "" || u.Fragment != "" {
+		return base + requestPath
+	}
+	basePath := strings.TrimRight(u.EscapedPath(), "/")
+	if basePath == "" || requestPath != basePath && !strings.HasPrefix(requestPath, basePath+"/") && !strings.HasPrefix(requestPath, basePath+"?") {
+		return base + requestPath
+	}
+	u.Path = ""
+	u.RawPath = ""
+	return strings.TrimRight(u.String(), "/") + requestPath
 }
 
 func newRequest(ctx context.Context, method, u string, body []byte, contentType string, opts ClientOptions) (*http.Request, error) {

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -45,14 +45,14 @@ func TestDoRaw_SendsMethodPathAndQuery(t *testing.T) {
 	}
 }
 
-func TestDoRaw_JoinsHostnameBasePathWithoutDuplication(t *testing.T) {
+func TestDoRaw_PreservesHostnameBasePath(t *testing.T) {
 	tests := []struct {
 		name string
 		base string
 		path string
 		want string
 	}{
-		{name: "overlap", base: "/api/v1", path: "/api/v1/users", want: "/api/v1/users"},
+		{name: "intentional repetition", base: "/api", path: "/api/users", want: "/api/api/users"},
 		{name: "relative", base: "/api/v1", path: "/users", want: "/api/v1/users"},
 		{name: "partial prefix", base: "/api", path: "/apiary/users", want: "/api/apiary/users"},
 	}

--- a/pkg/runtime/client_test.go
+++ b/pkg/runtime/client_test.go
@@ -45,6 +45,36 @@ func TestDoRaw_SendsMethodPathAndQuery(t *testing.T) {
 	}
 }
 
+func TestDoRaw_JoinsHostnameBasePathWithoutDuplication(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		path string
+		want string
+	}{
+		{name: "overlap", base: "/api/v1", path: "/api/v1/users", want: "/api/v1/users"},
+		{name: "relative", base: "/api/v1", path: "/users", want: "/api/v1/users"},
+		{name: "partial prefix", base: "/api", path: "/apiary/users", want: "/api/apiary/users"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Path
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			if _, err := DoRaw(context.Background(), srv.URL+tc.base, http.MethodGet, tc.path, nil, ClientOptions{Timeout: 5 * time.Second}); err != nil {
+				t.Fatalf("DoRaw: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("request path = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDoRaw_SendsAuthorizationWhenTokenProvided(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- apply path-scoped overlay ignores before adding collision suffixes, so filtered duplicate API versions do not leak or rename the surviving command
- collapse only exact repeated operation ID prefixes while preserving meaningful prefixes and CRUD verbs
- avoid duplicating an API base path when both the resolved hostname and generated OpenAPI path contain the same complete path prefix

## Real downstream verification

### DaoCloud/daocloud-skills

Tested current main at `9a0a8dd03f77e348a7e29527c665c8062a989321` with a local replace to this Lathe checkout.

- regenerated all 21 modules from pinned specs
- `go test -race ./...`
- build passed
- `dce __lathe verify --json`: 2481 checks, 0 failures
- 2476 commands, with no transport additions or removals versus Lathe v0.4.5
- confirmed stale v1alpha1 operations remain ignored, surviving commands have no stale `-2` suffix, and repeated gateway prefixes are gone
- bearer-authenticated HTTP smoke reached the expected kpanda path and returned the mock response

### langgenius/mosoo-connector

Tested current main at `7eaa23b0598a28b48193a2ab7e87f88b87f78b4c` against mosoo `0e3d2ad98c6a1b43dc0842ff0c53c6bdc1ca4ec9`, with a local replace to this Lathe checkout. The temporary downstream migration bound helper commands by OperationID and re-keyed overlays while preserving the existing public command names; it is not part of this PR.

- generation and build passed
- `go test -race ./...`
- `mosoo __lathe verify --json`: 134 checks, 0 failures
- 129 commands, with no public command additions, removals, or renames versus Lathe v0.4.4
- dry runs resolved exactly `/api/v1/threads/...` and `/api/access-tokens`, without doubled base paths
- bearer-authenticated HTTP smokes passed for both Public Thread API and Console REST

## Lathe verification

- `make check`
- `go test -race ./...`
