### PR TITLE
fix(codegen): tie-break the spec sort on HTTP identity

### DIFF
--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -85,7 +85,18 @@ func Normalize(mod *rawir.RawModule) []runtime.CommandSpec {
 		if specs[i].Use != specs[j].Use {
 			return specs[i].Use < specs[j].Use
 		}
-		return specs[i].OperationID < specs[j].OperationID
+		if specs[i].OperationID != specs[j].OperationID {
+			return specs[i].OperationID < specs[j].OperationID
+		}
+		// Group+Use+OperationID is not a total order: a spec can reuse one
+		// operationId across API versions, e.g. the same Foo_Get on /v1alpha1
+		// and /v1alpha2. sort.Slice is not stable, so without a tie-break on
+		// the HTTP identity those specs come out in a different order on every
+		// run, and any later step keyed on position becomes nondeterministic.
+		if specs[i].PathTpl != specs[j].PathTpl {
+			return specs[i].PathTpl < specs[j].PathTpl
+		}
+		return specs[i].Method < specs[j].Method
 	})
 	return specs
 }

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -615,25 +615,21 @@ func securityScopes() *rawir.RawModule {
 
 // One operationId reused across API versions leaves Group+Use+OperationID
 // equal for both specs. sort.Slice is not stable, so without a tie-break on the
-// HTTP identity they swap places between runs and every position-keyed step
-// downstream — command numbering, overlay legacy keys — becomes nondeterministic.
+// HTTP identity the output follows the backend emission order — random per run
+// for map-iterated paths — and every position-keyed step downstream (command
+// numbering, overlay legacy keys) becomes nondeterministic. The contract is
+// that the output does not depend on the input order.
 func TestNormalizeIsDeterministicForDuplicateOperationIDs(t *testing.T) {
-	newModule := func() *rawir.RawModule {
-		return &rawir.RawModule{Operations: []rawir.RawOperation{
-			{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha2/things/{id}"},
-			{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha1/things/{id}"},
-		}}
+	opA := rawir.RawOperation{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha2/things/{id}"}
+	opB := rawir.RawOperation{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha1/things/{id}"}
+	fwd := Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{opA, opB}})
+	rev := Normalize(&rawir.RawModule{Operations: []rawir.RawOperation{opB, opA}})
+	if len(fwd) != 2 || len(rev) != 2 {
+		t.Fatalf("want 2 specs, got %d and %d", len(fwd), len(rev))
 	}
-	want := Normalize(newModule())
-	if len(want) != 2 {
-		t.Fatalf("want 2 specs, got %d", len(want))
-	}
-	for i := 0; i < 50; i++ {
-		got := Normalize(newModule())
-		for j := range got {
-			if got[j].PathTpl != want[j].PathTpl {
-				t.Fatalf("run %d: spec %d PathTpl = %q, want %q", i, j, got[j].PathTpl, want[j].PathTpl)
-			}
+	for j := range fwd {
+		if fwd[j].PathTpl != rev[j].PathTpl {
+			t.Fatalf("output depends on input order: fwd[%d]=%q, rev[%d]=%q", j, fwd[j].PathTpl, j, rev[j].PathTpl)
 		}
 	}
 }

--- a/internal/codegen/normalize/normalize_test.go
+++ b/internal/codegen/normalize/normalize_test.go
@@ -613,6 +613,31 @@ func securityScopes() *rawir.RawModule {
 	}
 }
 
+// One operationId reused across API versions leaves Group+Use+OperationID
+// equal for both specs. sort.Slice is not stable, so without a tie-break on the
+// HTTP identity they swap places between runs and every position-keyed step
+// downstream — command numbering, overlay legacy keys — becomes nondeterministic.
+func TestNormalizeIsDeterministicForDuplicateOperationIDs(t *testing.T) {
+	newModule := func() *rawir.RawModule {
+		return &rawir.RawModule{Operations: []rawir.RawOperation{
+			{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha2/things/{id}"},
+			{Group: "Svc", OperationID: "Svc_Get", Method: "GET", Path: "/apis/v1alpha1/things/{id}"},
+		}}
+	}
+	want := Normalize(newModule())
+	if len(want) != 2 {
+		t.Fatalf("want 2 specs, got %d", len(want))
+	}
+	for i := 0; i < 50; i++ {
+		got := Normalize(newModule())
+		for j := range got {
+			if got[j].PathTpl != want[j].PathTpl {
+				t.Fatalf("run %d: spec %d PathTpl = %q, want %q", i, j, got[j].PathTpl, want[j].PathTpl)
+			}
+		}
+	}
+}
+
 // A leading id segment is not redundant merely because it precedes an
 // underscore. Stripping it unconditionally collapsed every CRUD verb onto one
 // command name.


### PR DESCRIPTION
> Rebased onto main. #148 landed in the meantime and already fixes most of what this PR originally covered — the original description no longer applies. Scope is now two files.

## What is left

`Normalize` sorts on `Group`, `Use`, `OperationID`. That is not a total order: a spec can reuse one operationId across API versions — the same `Foo_Get` on `/v1alpha1/...` and `/v1alpha2/...` — leaving all three fields equal. `sort.Slice` is not stable, so those specs come out in a different order on every run.

This PR tie-breaks on `PathTpl` and `Method`.

## Why it still matters after #148

#148 moved `disambiguateUse` behind overlay merging and added `legacyOverlayUses`. That removed the visible symptom for sources whose duplicate operations are ignored by an overlay — verified on DaoCloud skoala (345 commands, duplicate operationIds across `v1alpha1`/`v1alpha2`), where v0.6.0 now produces byte-identical output across three consecutive runs.

The ordering itself is still unstable, so anything keyed on position can still vary between runs over identical input:

- `-N` suffixes for collisions that overlays do not resolve
- `legacyOverlayUses`, which derives the pre-numbering keys from the same ordering

This is a small guard against that class of bug rather than a fix for a currently reproducing failure.

## Test

`TestNormalizeIsDeterministicForDuplicateOperationIDs` — 50 runs over a module with one operationId on two versioned paths, asserting identical ordering. It fails without the tie-break.

## Verification

```
make check
```
