### PR TITLE
fix(auth): surface actionable error when oauth login is not configured

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -78,7 +78,10 @@ func rootBool(cmd *cobra.Command, name string) bool {
 func oauthDeviceLogin(cmd *cobra.Command, m *config.Manifest, hostname string, provider string, insecure, noBrowser bool) (config.HostEntry, error) {
 	login := m.Auth.Login
 	if login == nil || login.Type != config.AuthLoginOAuthDevice {
-		return config.HostEntry{}, errors.New("auth.login with type oauth_device is required for --auth-type oauth")
+		return config.HostEntry{}, runtime.NewError(runtime.CodeUsage, runtime.ExitUsage,
+			"oauth login is not configured for this CLI",
+			fmt.Sprintf("use bearer, apikey, or basic auth; to enable oauth, add an auth.login block with type %q to cli.yaml and regenerate the CLI", config.AuthLoginOAuthDevice),
+			errors.New("auth.login with type oauth_device is required for --auth-type oauth"))
 	}
 	provider = strings.TrimSpace(provider)
 	deviceHostname, _ := os.Hostname()

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -96,6 +97,34 @@ func TestOAuthDeviceLoginSavesBearerHost(t *testing.T) {
 	}
 	if entry.AuthType != "bearer" || entry.LoginType != config.AuthLoginOAuthDevice || entry.LoginProvider != "github" || entry.OAuthToken != "access-1" || entry.OAuthRefreshToken != "refresh-1" || entry.User != "octo@example.com" || entry.OAuthExpiresAt == 0 {
 		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestOAuthDeviceLoginRequiresAuthLoginConfig(t *testing.T) {
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", "api.example.com", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--auth-type", "oauth"})
+
+	err := root.Execute()
+	var le *runtime.LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("error = %T %v, want *runtime.LatheError", err, err)
+	}
+	if le.Code != runtime.CodeUsage || le.ExitCode != runtime.ExitUsage {
+		t.Fatalf("code = %q exit = %d, want %q/%d", le.Code, le.ExitCode, runtime.CodeUsage, runtime.ExitUsage)
+	}
+	var buf strings.Builder
+	runtime.FormatError(err, "", &buf)
+	if !strings.Contains(buf.String(), "oauth login is not configured for this CLI") || !strings.Contains(buf.String(), "auth.login") {
+		t.Fatalf("formatted error = %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- `auth login --auth-type oauth` / `--device-auth` on a CLI whose manifest has no `auth.login` block failed with the generic `Error: command failed` / `Hint: check local configuration and retry`, hiding the actual cause.
- `oauthDeviceLogin` now returns an authored `LatheError` (`code=usage`, exit 2): message `oauth login is not configured for this CLI`, hint pointing users to another auth type and CLI authors to the missing `auth.login` block in `cli.yaml`.
- The cause is preserved but stays hidden, consistent with the deliberate no-leak contract in `pkg/runtime/errors.go` (authored message/hint are the display surface).

## Verification

- `go test -count=1 -run TestOAuthDeviceLogin ./internal/auth/` (includes new `TestOAuthDeviceLoginRequiresAuthLoginConfig` asserting code/exit and formatted output)
- `go test -count=1 ./pkg/runtime/`
- `make check`
- End-to-end: rebuilt a downstream generated CLI (tokener-cli) against this change via `go mod edit -replace`; `auth login --auth-type oauth` now prints the actionable message in text and `-o json`, exit code 2.

## Compatibility

- User-visible error contract change: the missing-`auth.login` oauth login path changes exit code 1 -> 2 and error code `general` -> `usage`; both codes are already documented in `docs/contracts.md`.
- No generated command shape, catalog schema, auth flow, body, or output-format changes. Runtime error classification is unchanged for all other paths.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.