### PR TITLE
feat(lathe): expose top-level shell completion command

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -433,9 +433,9 @@ Rules:
    `--<flag>-stdin` for sensitive values.
 8. Branch on structured `error.code` and process exit status, not error prose.
 
-Framework commands such as `auth`, `commands`, `search`, `skill`, `update`,
-and `__lathe` are documented by `--help`; generated API operations and
-workflows are documented by the runtime catalog.
+Framework commands such as `auth`, `commands`, `completion`, `search`,
+`skill`, `update`, and `__lathe` are documented by `--help`; generated API
+operations and workflows are documented by the runtime catalog.
 
 ## Examples
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -37,7 +37,7 @@ workflow:
 
 `use` must be one root command name. Codegen rejects conflicts with generated
 modules, shortcuts, other workflows, and the reserved roots `__lathe`,
-`auth`, `commands`, `help`, `login`, `search`, `skill`, and `update`.
+`auth`, `commands`, `completion`, `help`, `login`, `search`, `skill`, and `update`.
 
 Workflow inputs become Cobra flags. Supported types are `string`, `int64`,
 `float64`, `bool`, and their slice forms. Inputs also support the normal

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -224,14 +224,15 @@ func rootCommandName(use string) string {
 }
 
 var reservedRootCommands = map[string]bool{
-	"__lathe":  true,
-	"auth":     true,
-	"commands": true,
-	"help":     true,
-	"login":    true,
-	"search":   true,
-	"skill":    true,
-	"update":   true,
+	"__lathe":    true,
+	"auth":       true,
+	"commands":   true,
+	"completion": true,
+	"help":       true,
+	"login":      true,
+	"search":     true,
+	"skill":      true,
+	"update":     true,
 }
 
 // ValidateModuleNames rejects namespaced module mount names that would shadow

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -1044,7 +1044,7 @@ func TestValidateModuleNames(t *testing.T) {
 	if err := ValidateModuleNames([]string{"pets", "billing"}); err != nil {
 		t.Fatalf("distinct module names should pass: %v", err)
 	}
-	for _, reserved := range []string{"__lathe", "auth", "commands", "help", "login", "search", "skill", "update"} {
+	for _, reserved := range []string{"__lathe", "auth", "commands", "completion", "help", "login", "search", "skill", "update"} {
 		err := ValidateModuleNames([]string{"pets", reserved})
 		if err == nil || !strings.Contains(err.Error(), "reserved root command") {
 			t.Fatalf("module name %q should be rejected, got %v", reserved, err)

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -46,7 +46,6 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		return runtime.UsageError(cmd, err)
 	})
-	cmd.CompletionOptions.DisableDefaultCmd = true
 	cmd.SetVersionTemplate("{{.Use}} {{.Version}}\n")
 	cmd.PersistentFlags().String("hostname", "", fmt.Sprintf("Server hostname (overrides $%s)", m.CLI.HostEnv))
 	cmd.PersistentFlags().StringP("output", "o", "table", "Output format: table|json|yaml|raw")

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -32,6 +32,39 @@ func TestRootHelpExposesAgentHint(t *testing.T) {
 	}
 }
 
+func TestTopLevelCompletionExposed(t *testing.T) {
+	root := NewApp(testManifest())
+
+	out, err := execute(root, "completion", "bash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "# bash completion V2 for myctl") {
+		t.Fatalf("completion bash output missing script header:\n%s", out)
+	}
+
+	help, err := execute(root, "--help")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(help, "completion") {
+		t.Fatalf("--help missing completion:\n%s", help)
+	}
+
+	meta, _, err := root.Find([]string{metaCommandName, "completion", "bash"})
+	if err != nil || meta == nil || meta.Name() != "bash" {
+		t.Fatalf("%s completion missing: %v", metaCommandName, err)
+	}
+
+	catalogOut, err := execute(root, "commands", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(catalogOut, "completion") {
+		t.Fatalf("catalog must not list framework completion commands:\n%s", catalogOut)
+	}
+}
+
 func TestNewAppBindsManifest(t *testing.T) {
 	m := testManifest()
 	root := NewApp(m)

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -27,11 +27,16 @@ func AssertSchema(generated int) error {
 	return nil
 }
 
+// completionRootName is cobra's shell completion command. Cobra adds it
+// lazily at Execute time, so findChildCommand cannot observe it while
+// mounting; a mounted command using that name would silently suppress it.
+const completionRootName = "completion"
+
 // Build mounts a service command tree under root, driven entirely by specs.
 // Replaces the previous per-operation function approach: every operation is
 // data, the execution path is a single function.
 func Build(root *cobra.Command, service string, specs []CommandSpec) error {
-	if findChildCommand(root, service) != nil {
+	if findChildCommand(root, service) != nil || service == completionRootName {
 		return fmt.Errorf("module command %q conflicts with an existing root command", service)
 	}
 	groups, err := buildGroups(service, specs)
@@ -63,7 +68,7 @@ func BuildFlat(root *cobra.Command, service string, specs []CommandSpec) error {
 			return fmt.Errorf("flat mount command %q conflicts with another generated command", name)
 		}
 		seen[name] = true
-		if findChildCommand(root, name) != nil {
+		if findChildCommand(root, name) != nil || name == completionRootName {
 			return fmt.Errorf("flat mount command %q conflicts with existing root command", name)
 		}
 	}
@@ -584,7 +589,7 @@ func ValidateShortcuts(specs []CommandSpec, rootNames []string) error {
 }
 
 func rootCommandNames(root *cobra.Command, planned ...*cobra.Command) []string {
-	var names []string
+	names := []string{completionRootName}
 	for _, cmd := range root.Commands() {
 		names = append(names, cmd.Name())
 		names = append(names, cmd.Aliases...)

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -57,6 +57,39 @@ func TestBuild_RejectsExistingRootCommandConflict(t *testing.T) {
 	}
 }
 
+func TestBuild_RejectsCompletionModuleName(t *testing.T) {
+	root := newRootWithModuleGroup()
+	if err := Build(root, "completion", nil); err == nil || !strings.Contains(err.Error(), `module command "completion" conflicts`) {
+		t.Fatalf("expected completion conflict error, got %v", err)
+	}
+	if len(root.Commands()) != 0 {
+		t.Fatalf("completion module must not be mounted; root commands = %v", cmdNames(root.Commands()))
+	}
+
+	root = newRootWithModuleGroup()
+	err := Build(root, "demo", []CommandSpec{{
+		Group:     "Users",
+		Use:       "get-user",
+		Method:    "GET",
+		PathTpl:   "/users/{id}",
+		Shortcuts: []CommandShortcut{{Use: "completion"}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected completion shortcut conflict error, got %v", err)
+	}
+}
+
+func TestBuildFlat_RejectsCompletionGroupName(t *testing.T) {
+	root := newRootWithModuleGroup()
+	err := BuildFlat(root, "demo", []CommandSpec{{Group: "Completion", Use: "list", Method: "GET", PathTpl: "/x"}})
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("expected completion group conflict error, got %v", err)
+	}
+	if len(root.Commands()) != 0 {
+		t.Fatalf("completion group must not be mounted; root commands = %v", cmdNames(root.Commands()))
+	}
+}
+
 func TestBuild_PopulatesGroupAndOpTree(t *testing.T) {
 	specs := []CommandSpec{
 		{

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -39,11 +39,11 @@ func (e *WorkflowError) Unwrap() error {
 
 func BuildWorkflows(root *cobra.Command, specs []WorkflowSpec) error {
 	for _, spec := range specs {
-		if findChildCommand(root, spec.Use) != nil {
+		if findChildCommand(root, spec.Use) != nil || spec.Use == completionRootName {
 			return fmt.Errorf("workflow command %q conflicts with existing root command", spec.Use)
 		}
 		for _, alias := range spec.Aliases {
-			if findChildCommand(root, alias) != nil {
+			if findChildCommand(root, alias) != nil || alias == completionRootName {
 				return fmt.Errorf("workflow command %q alias %q conflicts with existing root command", spec.Use, alias)
 			}
 		}

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -180,6 +180,29 @@ func TestBuildWorkflows_StopsOnPausedStream(t *testing.T) {
 	}
 }
 
+func TestBuildWorkflows_RejectsCompletionNameAndAlias(t *testing.T) {
+	spec := WorkflowSpec{
+		Use:   "completion",
+		Steps: []WorkflowStepSpec{{ID: "health", Operation: publicGetSpec("health", "/health")}},
+	}
+	root := newWorkflowRoot(io.Discard)
+	if err := BuildWorkflows(root, []WorkflowSpec{spec}); err == nil || !strings.Contains(err.Error(), `workflow command "completion" conflicts`) {
+		t.Fatalf("expected completion conflict error, got %v", err)
+	}
+	if len(root.Commands()) != 0 {
+		t.Fatalf("completion workflow must not be mounted; root commands = %v", cmdNames(root.Commands()))
+	}
+
+	aliased := spec
+	aliased.Use = "doctor"
+	aliased.Aliases = []string{"completion"}
+	root = newWorkflowRoot(io.Discard)
+	err := BuildWorkflows(root, []WorkflowSpec{aliased})
+	if err == nil || !strings.Contains(err.Error(), `alias "completion" conflicts`) {
+		t.Fatalf("expected completion alias conflict error, got %v", err)
+	}
+}
+
 func TestBuildWorkflows_RejectsInvalidInputEnum(t *testing.T) {
 	root := newWorkflowRoot(io.Discard)
 	if err := BuildWorkflows(root, []WorkflowSpec{{


### PR DESCRIPTION
## Summary

- Generated CLIs had cobra's built-in `completion` command disabled at the root (moved under the hidden `__lathe` meta command in #64), so `<cli> completion` did not exist.
- This removes the one-line `DisableDefaultCmd = true`, restoring cobra's native top-level `bash`/`zsh`/`fish`/`powershell` completion command; `__lathe completion` keeps working unchanged.
- Catalog and search are unaffected: cobra's stock completion commands carry no catalog annotations and never appear in `commands --json`.

## Verification

- `go test -count=1 ./pkg/lathe/ ./pkg/runtime/` (includes new `TestTopLevelCompletionExposed`: top-level script generation, `--help` listing, `__lathe completion` still present, catalog excludes it)
- `make check`
- End-to-end: rebuilt a downstream generated CLI (tokener-cli) against this change via `go mod edit -replace`; `--help` lists `completion` under Additional Commands, `completion zsh` emits a working script, `commands --json` has zero completion entries.

## Compatibility

- CLI-visible change: generated CLIs gain the standard cobra top-level `completion` command in `--help`; no generated command shape, catalog schema, auth/body/output, or docs changes beyond listing `completion` as a framework command.
- Same pre-existing risk class as other framework commands (`auth`, `commands`, `search`): an upstream spec module literally named `completion` conflicts at mount time (`runtime.Build` error), not silently.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
