### PR TITLE
fix(codegen): preserve openapi security semantics

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -245,6 +245,7 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
 		applyServerBasePaths(&doc, src.Name, p)
+		applyEffectiveSecurity(&doc)
 		countExposedOperationIDs(&doc, allowedOperationIDs, matchedOperationIDs)
 		mergeDoc(all, &doc, src.Name, p)
 	}
@@ -311,6 +312,20 @@ func applyServerBasePaths(doc *oas3Doc, module, origin string) {
 			op.serverBasePath = basePath
 			if op.Servers != nil {
 				op.serverBasePath = resolveServerBasePath(*op.Servers, module, origin)
+			}
+		}
+	}
+}
+
+func applyEffectiveSecurity(doc *oas3Doc) {
+	security := doc.Security
+	if security == nil {
+		security = []map[string][]string{}
+	}
+	for _, item := range doc.Paths {
+		for _, op := range []*operation{item.Get, item.Post, item.Put, item.Delete, item.Patch} {
+			if op != nil && op.Security == nil {
+				op.Security = &security
 			}
 		}
 	}

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -435,6 +435,30 @@ func TestParse_ServerOverridePrecedence(t *testing.T) {
 	}
 }
 
+func TestParse_SecuritySemantics(t *testing.T) {
+	cases := []struct {
+		name              string
+		documentSecurity  string
+		operationSecurity string
+		wantPublic        bool
+		wantScopes        []string
+	}{
+		{name: "absent is public", wantPublic: true},
+		{name: "document inherited", documentSecurity: `,"security":[{"oauth":["read"]}]`, wantScopes: []string{"read"}},
+		{name: "operation empty is public", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[]`, wantPublic: true},
+		{name: "operation overrides document", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `{"openapi":"3.0.3"` + tc.documentSecurity + `,"paths":{"/health":{"get":{"operationId":"Health_Get"` + tc.operationSecurity + `,"responses":{"200":{}}}}}}`
+			security := parseNormalized(t, input)[0].Security
+			if security == nil || security.Public != tc.wantPublic || !reflect.DeepEqual(security.Scopes, tc.wantScopes) {
+				t.Fatalf("security = %#v, want public=%t scopes=%v", security, tc.wantPublic, tc.wantScopes)
+			}
+		})
+	}
+}
+
 func parseNormalized(t *testing.T, input string) []runtime.CommandSpec {
 	t.Helper()
 	syncDir := t.TempDir()

--- a/internal/codegen/backends/openapi3/testdata/path-and-query-params.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/path-and-query-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/path-level-params.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/path-level-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     },
     {
       "Group": "Orgs",
@@ -62,7 +62,7 @@
       },
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/petstore-min.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/petstore-min.golden.json
@@ -29,7 +29,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": null
+      "Security": []
     },
     {
       "Group": "Pets",
@@ -66,7 +66,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/ref-resolution.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/ref-resolution.golden.json
@@ -33,7 +33,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
@@ -28,7 +28,7 @@
       },
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/request-body.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/request-body.golden.json
@@ -44,7 +44,7 @@
         }
       },
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/yaml-input.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/yaml-input.golden.json
@@ -29,7 +29,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/backend.go
+++ b/internal/codegen/backends/swagger/backend.go
@@ -98,9 +98,25 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 		if err := json.Unmarshal(data, &sw); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", p, err)
 		}
+		applyEffectiveSecurity(&sw)
 		mergeDoc(all, &sw, src.Name, p)
 	}
 	return toRawIR(src.Name, all), nil
+}
+
+func applyEffectiveSecurity(doc *swaggerDoc) {
+	security := doc.Security
+	if security == nil {
+		security = []map[string][]string{}
+	}
+	for _, methods := range doc.Paths {
+		for method, op := range methods {
+			if op.Security == nil {
+				op.Security = &security
+				methods[method] = op
+			}
+		}
+	}
 }
 
 func mergeDoc(dst, add *swaggerDoc, module, origin string) {

--- a/internal/codegen/backends/swagger/backend_test.go
+++ b/internal/codegen/backends/swagger/backend_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/lathe-cli/lathe/internal/codegen/normalize"
 	"github.com/lathe-cli/lathe/internal/codegen/rawir"
 	"github.com/lathe-cli/lathe/internal/sourceconfig"
 	"github.com/lathe-cli/lathe/internal/testutil"
@@ -99,6 +100,39 @@ func TestParse_DeduplicatesSwaggerParameters(t *testing.T) {
 	}
 	if got := len(mod.Operations[0].Parameters); got != 1 {
 		t.Fatalf("parameters = %d, want one unique parameter", got)
+	}
+}
+
+func TestParse_SecuritySemantics(t *testing.T) {
+	cases := []struct {
+		name              string
+		documentSecurity  string
+		operationSecurity string
+		wantPublic        bool
+		wantScopes        []string
+	}{
+		{name: "absent is public", wantPublic: true},
+		{name: "document inherited", documentSecurity: `,"security":[{"oauth":["read"]}]`, wantScopes: []string{"read"}},
+		{name: "operation empty is public", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[]`, wantPublic: true},
+		{name: "operation overrides document", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `{"swagger":"2.0"` + tc.documentSecurity + `,"paths":{"/health":{"get":{"operationId":"Health_Get"` + tc.operationSecurity + `,"responses":{"200":{}}}}}}`
+			syncDir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(syncDir, "swagger.json"), []byte(input), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			src := &sourceconfig.Source{Name: "demo", Swagger: &sourceconfig.SwaggerConfig{Files: []string{"swagger.json"}}}
+			mod, err := Parse(src, syncDir)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			security := normalize.Normalize(mod)[0].Security
+			if security == nil || security.Public != tc.wantPublic || !reflect.DeepEqual(security.Scopes, tc.wantScopes) {
+				t.Fatalf("security = %#v, want public=%t scopes=%v", security, tc.wantPublic, tc.wantScopes)
+			}
+		})
 	}
 }
 

--- a/internal/codegen/backends/swagger/testdata/header-and-formdata.golden.json
+++ b/internal/codegen/backends/swagger/testdata/header-and-formdata.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/swagger/testdata/path-and-query-params.golden.json
+++ b/internal/codegen/backends/swagger/testdata/path-and-query-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/swagger/testdata/petstore-min.golden.json
+++ b/internal/codegen/backends/swagger/testdata/petstore-min.golden.json
@@ -27,7 +27,7 @@
         }
       },
       "Produces": null,
-      "Security": null
+      "Security": []
     },
     {
       "Group": "Pets",
@@ -62,7 +62,7 @@
         }
       },
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/testdata/ref-resolution.golden.json
+++ b/internal/codegen/backends/swagger/testdata/ref-resolution.golden.json
@@ -30,7 +30,7 @@
         }
       },
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/testdata/tags-fallback.golden.json
+++ b/internal/codegen/backends/swagger/testdata/tags-fallback.golden.json
@@ -12,7 +12,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": null
+      "Security": []
     }
   ],
   "Schemas": {}


### PR DESCRIPTION
## Summary

- Resolve effective OpenAPI 3 and Swagger 2.0 security per source document before merging operations.
- Treat operations with no document-level or operation-level security declaration as public while preserving inheritance and explicit overrides.
- Add focused regression coverage and refresh backend RawIR fixtures.

Closes #115.

## Verification

- `go test ./internal/codegen/backends/openapi3 -run TestParse_SecuritySemantics -count=1`
- `go test ./internal/codegen/backends/swagger -run TestParse_SecuritySemantics -count=1`
- `make check`

## Compatibility

Regenerated OpenAPI and Swagger CLIs now expose operations with no security declaration as public. Document-level security is inherited, `security: []` remains an explicit public override, and operation-level security overrides the document declaration. Proto and GraphQL defaults, generated command shape, and catalog schema are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented above; no product documentation update is required because this restores source-spec semantics.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.