### PR TITLE
test(runtime): stop after fatal nil assertions

### DIFF
--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -218,6 +218,7 @@ func TestBuild_ParameterFlagAliasesAndPositionalArgument(t *testing.T) {
 			describe := findChildCommand(mustFindChild(t, mustFindChild(t, root, "demo"), "apps"), "describe")
 			if describe == nil {
 				t.Fatal("describe command was not mounted")
+				return
 			}
 			if describe.Use != "describe [id] [tags]" {
 				t.Fatalf("use = %q, want describe [id] [tags]", describe.Use)

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -533,6 +533,7 @@ func TestBuildCatalog_WorkflowStepConditions(t *testing.T) {
 	}
 	if step == nil {
 		t.Fatal("no workflow step in catalog")
+		return
 	}
 	want := []CatalogWorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}}
 	if !reflect.DeepEqual(step.When, want) {


### PR DESCRIPTION
## Summary
- stop test execution after fatal nil assertions
- prevent staticcheck SA5011 nil-dereference reports in CI

## Test plan
- [x] `make check`