### PR TITLE
fix(codegen): treat a missing security block as unspecified, not public

### DIFF
--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -318,10 +318,14 @@ func applyServerBasePaths(doc *oas3Doc, module, origin string) {
 }
 
 func applyEffectiveSecurity(doc *oas3Doc) {
-	security := doc.Security
-	if security == nil {
-		security = []map[string][]string{}
+	// A document with no security block says nothing about authentication. It
+	// must not be turned into an empty requirement list, which in OpenAPI means
+	// "explicitly public" and would mark every operation as needing no auth.
+	// Leaving the operation unset keeps the conservative default downstream.
+	if doc.Security == nil {
+		return
 	}
+	security := doc.Security
 	for _, item := range doc.Paths {
 		for _, op := range []*operation{item.Get, item.Post, item.Put, item.Delete, item.Patch} {
 			if op != nil && op.Security == nil {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -440,18 +440,30 @@ func TestParse_SecuritySemantics(t *testing.T) {
 		name              string
 		documentSecurity  string
 		operationSecurity string
+		wantUnspecified   bool
 		wantPublic        bool
 		wantScopes        []string
 	}{
-		{name: "absent is public", wantPublic: true},
+		// A document that never mentions security has not declared its
+		// operations public; it has said nothing. Only an empty requirement
+		// list is an explicit "no auth needed".
+		{name: "absent is unspecified", wantUnspecified: true},
 		{name: "document inherited", documentSecurity: `,"security":[{"oauth":["read"]}]`, wantScopes: []string{"read"}},
+		{name: "document empty is public", documentSecurity: `,"security":[]`, wantPublic: true},
 		{name: "operation empty is public", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[]`, wantPublic: true},
 		{name: "operation overrides document", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
+		{name: "operation declared without document", operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			input := `{"openapi":"3.0.3"` + tc.documentSecurity + `,"paths":{"/health":{"get":{"operationId":"Health_Get"` + tc.operationSecurity + `,"responses":{"200":{}}}}}}`
 			security := parseNormalized(t, input)[0].Security
+			if tc.wantUnspecified {
+				if security != nil {
+					t.Fatalf("security = %#v, want nil so the runtime keeps requiring auth", security)
+				}
+				return
+			}
 			if security == nil || security.Public != tc.wantPublic || !reflect.DeepEqual(security.Scopes, tc.wantScopes) {
 				t.Fatalf("security = %#v, want public=%t scopes=%v", security, tc.wantPublic, tc.wantScopes)
 			}

--- a/internal/codegen/backends/openapi3/testdata/path-and-query-params.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/path-and-query-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/path-level-params.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/path-level-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     },
     {
       "Group": "Orgs",
@@ -62,7 +62,7 @@
       },
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/petstore-min.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/petstore-min.golden.json
@@ -29,7 +29,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": []
+      "Security": null
     },
     {
       "Group": "Pets",
@@ -66,7 +66,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/ref-resolution.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/ref-resolution.golden.json
@@ -33,7 +33,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/request-body-non-json.golden.json
@@ -28,7 +28,7 @@
       },
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/openapi3/testdata/request-body.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/request-body.golden.json
@@ -44,7 +44,7 @@
         }
       },
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/openapi3/testdata/yaml-input.golden.json
+++ b/internal/codegen/backends/openapi3/testdata/yaml-input.golden.json
@@ -29,7 +29,7 @@
       "Produces": [
         "application/json"
       ],
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/backend.go
+++ b/internal/codegen/backends/swagger/backend.go
@@ -105,10 +105,14 @@ func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
 }
 
 func applyEffectiveSecurity(doc *swaggerDoc) {
-	security := doc.Security
-	if security == nil {
-		security = []map[string][]string{}
+	// A document with no security block says nothing about authentication. It
+	// must not be turned into an empty requirement list, which in OpenAPI means
+	// "explicitly public" and would mark every operation as needing no auth.
+	// Leaving the operation unset keeps the conservative default downstream.
+	if doc.Security == nil {
+		return
 	}
+	security := doc.Security
 	for _, methods := range doc.Paths {
 		for method, op := range methods {
 			if op.Security == nil {

--- a/internal/codegen/backends/swagger/backend_test.go
+++ b/internal/codegen/backends/swagger/backend_test.go
@@ -108,13 +108,19 @@ func TestParse_SecuritySemantics(t *testing.T) {
 		name              string
 		documentSecurity  string
 		operationSecurity string
+		wantUnspecified   bool
 		wantPublic        bool
 		wantScopes        []string
 	}{
-		{name: "absent is public", wantPublic: true},
+		// A document that never mentions security has not declared its
+		// operations public; it has said nothing. Only an empty requirement
+		// list is an explicit "no auth needed".
+		{name: "absent is unspecified", wantUnspecified: true},
 		{name: "document inherited", documentSecurity: `,"security":[{"oauth":["read"]}]`, wantScopes: []string{"read"}},
+		{name: "document empty is public", documentSecurity: `,"security":[]`, wantPublic: true},
 		{name: "operation empty is public", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[]`, wantPublic: true},
 		{name: "operation overrides document", documentSecurity: `,"security":[{"oauth":["read"]}]`, operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
+		{name: "operation declared without document", operationSecurity: `,"security":[{"oauth":["write"]}]`, wantScopes: []string{"write"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,6 +135,12 @@ func TestParse_SecuritySemantics(t *testing.T) {
 				t.Fatalf("Parse: %v", err)
 			}
 			security := normalize.Normalize(mod)[0].Security
+			if tc.wantUnspecified {
+				if security != nil {
+					t.Fatalf("security = %#v, want nil so the runtime keeps requiring auth", security)
+				}
+				return
+			}
 			if security == nil || security.Public != tc.wantPublic || !reflect.DeepEqual(security.Scopes, tc.wantScopes) {
 				t.Fatalf("security = %#v, want public=%t scopes=%v", security, tc.wantPublic, tc.wantScopes)
 			}

--- a/internal/codegen/backends/swagger/testdata/header-and-formdata.golden.json
+++ b/internal/codegen/backends/swagger/testdata/header-and-formdata.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/swagger/testdata/path-and-query-params.golden.json
+++ b/internal/codegen/backends/swagger/testdata/path-and-query-params.golden.json
@@ -35,7 +35,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}

--- a/internal/codegen/backends/swagger/testdata/petstore-min.golden.json
+++ b/internal/codegen/backends/swagger/testdata/petstore-min.golden.json
@@ -27,7 +27,7 @@
         }
       },
       "Produces": null,
-      "Security": []
+      "Security": null
     },
     {
       "Group": "Pets",
@@ -62,7 +62,7 @@
         }
       },
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/testdata/ref-resolution.golden.json
+++ b/internal/codegen/backends/swagger/testdata/ref-resolution.golden.json
@@ -30,7 +30,7 @@
         }
       },
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {

--- a/internal/codegen/backends/swagger/testdata/tags-fallback.golden.json
+++ b/internal/codegen/backends/swagger/testdata/tags-fallback.golden.json
@@ -12,7 +12,7 @@
       "RequestBody": null,
       "Responses": {},
       "Produces": null,
-      "Security": []
+      "Security": null
     }
   ],
   "Schemas": {}


### PR DESCRIPTION
## Problem

`applyEffectiveSecurity` (added in #153) substitutes an empty requirement list when a document has no `security` block, then pushes it onto every operation:

```go
security := doc.Security
if security == nil {
    security = []map[string][]string{}   // "nothing was said" becomes "[]"
}
for ... { if op.Security == nil { op.Security = &security } }
```

An empty list is not the absence of a statement. In OpenAPI it is an explicit *"no authentication required"*. So `deriveSecurity` correctly reads `len(security) == 0` as `Public: true`, and `catalogAuth` reports `auth.required=false`.

The result is that a spec which simply never mentions security is published as a set of public endpoints.

## Impact

Measured on a 21-source repository (DaoCloud/daocloud-skills, all Swagger 2.0):

| | auth.required=true | auth.required=false |
| --- | --- | --- |
| before #153 | 2476 | 0 |
| after #153 | 628 | **1848** |
| with this fix | 2476 | 0 |

The 1848 include `DELETE` operations on datasets, analyses and inference servings, and all 238 commands of the identity-and-access module.

Specs that omit `security` entirely are common — the API sits behind a gateway, or nobody wrote the block. One source here has no `security`, no `securityDefinitions`, and zero of its 108 operations declare anything. Those are precisely the specs where a conservative default matters most, and they were the ones losing it.

This also matters for the agent contract: `auth.required=false` tells an agent it can skip `auth status` and call straight through.

## Fix

Return early when the document declares no security, leaving each operation's `security` unset so the existing `nil` path keeps the conservative default. Same change in both backends.

Behavior that does not change:

- a document with `security` still propagates it to operations that do not override
- an explicit `security: []` on a document or an operation still means public
- an operation-level declaration still wins

## Tests

`TestParse_SecuritySemantics` in both backends. The `absent` case asserted `wantPublic: true`; it now asserts the security hint is nil. Two cases added: `document empty is public` (pins that an explicit `[]` is still public, distinguishing it from absence) and `operation declared without document`.

15 golden entries move from `"Security": []` back to `"Security": null`. Nothing else in the golden files changes.

## Verification

```
make check
```

Plus the regeneration of the 21-source repository quoted in the table above.
