### PR TITLE
feat(runtime): persist a user-selected default host

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ order. `generated.MountModules` remains a compatibility alias.
 | `internal/latheskill` | distribution | Embeds Lathe's own Agent Skill. |
 | `pkg/config` | runtime | Loads the embedded manifest and persists per-host credentials and active contexts. |
 | `pkg/runtime` | runtime | Builds operation/workflow commands, catalog data, requests, auth, body handling, pagination, streaming, polling, output, and stable errors. |
-| `internal/auth` | runtime | Implements `auth login`, `logout`, `status`, and context commands. |
+| `internal/auth` | runtime | Implements `auth login`, `logout`, `status`, `host default`, and context commands. |
 | `pkg/lathe` | runtime | Provides the generated-CLI entrypoint, framework commands, version/update support, and `__lathe verify`. |
 
 `internal/**` is implementation-only. `pkg/**` is linked by downstream generated
@@ -157,8 +157,10 @@ but it is outside Lathe's generated capability contract.
    syntax or file locations.
 6. Generated output is static Go and Skill data. Building or running a generated
    CLI does not invoke codegen or require spec tooling.
-7. Host selection is per invocation. Active account contexts are stored under a
-   selected host; they do not create an ambient global host.
+7. Host selection is per invocation by default. A user may explicitly elect a
+   persisted default host; when elected, it is always visible together with its
+   resolution source and always overridable per invocation. Active account
+   contexts are stored under a selected host.
 8. API commands, workflow steps, catalog entries, generated Skills, and verify
    checks must describe the same compiled command surface.
 9. Generated files are outputs. Change specs, `cli.yaml`, or overlays, then

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -436,9 +436,14 @@ Rules:
    `--<flag>-stdin` for sensitive values.
 8. Branch on structured `error.code` and process exit status, not error prose.
 
-Framework commands such as `auth`, `commands`, `completion`, `search`,
+Framework commands such as `auth`, `host`, `commands`, `completion`, `search`,
 `skill`, `update`, and `__lathe` are documented by `--help`; generated API
 operations and workflows are documented by the runtime catalog.
+
+A persisted default host is optional. Resolve with `--hostname`, then the
+configured host environment variable, then `host default`, then codegen
+`default_hostname`, then the unique host in `hosts.yml`. `auth status --json`
+and `--dry-run` expose the resolved host and its source.
 
 ## Examples
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -30,8 +30,8 @@ the contract from the running CLI:
 
 `commands schema --json` reports `catalog_schema_version`, the committed
 `surfaces`, and `dry_run.result`. `dry_run.result=http_preview` means a
-preview prints the resolved HTTP request JSON (`method`, `url`, `headers`,
-`body`, `auth`, `output`).
+preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`,
+`host_source`, `headers`, `body`, `auth`, `output`).
 
 Catalog entries have two kinds:
 
@@ -49,7 +49,7 @@ operations are classified from the request template (`query` / `mutation`),
 not from HTTP POST. Other methods stay `unknown` unless the template proves
 otherwise.
 
-Framework commands such as `auth`, `commands`, `search`, `skill`, `update`, and
+Framework commands such as `auth`, `host`, `commands`, `search`, `skill`, `update`, and
 `__lathe` are discovered through `--help`; they are not operation entries.
 `catalog.cli.capabilities` reports compiled first-party capabilities such as
 `skill.bundle` and `workflow.dsl`.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -466,6 +466,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 			}
 
+			elected := false
 			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
 				current, _ := hosts.Get(hostname)
 				contexts := maps.Clone(current.Contexts)
@@ -477,11 +478,18 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 				entry.Contexts = contexts
 				hosts.Set(hostname, entry)
+				if hosts.Default() == "" {
+					hosts.SetDefault(hostname)
+					elected = true
+				}
 				return nil
 			}); err != nil {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "✓ Logged in to %s\n", hostname)
+			if elected {
+				fmt.Fprintf(os.Stderr, "✓ Set %s as the default host (no default was set)\n", hostname)
+			}
 			return nil
 		},
 	}
@@ -498,8 +506,23 @@ func newLogin(m *config.Manifest) *cobra.Command {
 	return cmd
 }
 
+type authStatusReport struct {
+	Hostname string           `json:"hostname,omitempty"`
+	Source   string           `json:"source,omitempty"`
+	Default  string           `json:"default,omitempty"`
+	Hosts    []authHostStatus `json:"hosts"`
+}
+
+type authHostStatus struct {
+	Hostname string `json:"hostname"`
+	User     string `json:"user,omitempty"`
+	Auth     string `json:"auth"`
+	Login    string `json:"login,omitempty"`
+}
+
 func newStatus() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "View authentication status",
 		Args:  runtime.UsageArgs(cobra.NoArgs),
@@ -514,20 +537,60 @@ func newStatus() *cobra.Command {
 				return runtime.NewNotAuthenticatedError()
 			}
 			if hostname != "" {
-				e, ok := hosts.Get(hostname)
-				if !ok {
+				if _, ok := hosts.Get(hostname); !ok {
 					return runtime.NewNotAuthenticatedError()
 				}
-				printStatus(hostname, e)
-				return nil
 			}
-			for _, n := range names {
+			res, _ := runtime.ResolveHostWithSource(cmd)
+			listed := names
+			if hostname != "" {
+				listed = []string{config.NormalizeHostname(hostname)}
+			}
+			if jsonOut {
+				out := authStatusReport{
+					Hostname: res.Hostname,
+					Source:   res.Source,
+					Default:  hosts.Default(),
+					Hosts:    make([]authHostStatus, 0, len(listed)),
+				}
+				for _, n := range listed {
+					e, _ := hosts.Get(n)
+					item := authHostStatus{Hostname: n, User: e.User, Auth: e.AuthType}
+					if item.Auth == "" {
+						item.Auth = "bearer"
+					}
+					if e.LoginType != "" {
+						item.Login = e.LoginType
+						if e.LoginProvider != "" {
+							item.Login += " (" + e.LoginProvider + ")"
+						}
+					}
+					out.Hosts = append(out.Hosts, item)
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+			if res.Hostname != "" {
+				fmt.Fprintf(os.Stdout, "Current host: %s (%s)\n", res.Hostname, res.Source)
+			} else {
+				fmt.Fprintln(os.Stdout, "Current host: (none)")
+			}
+			if d := hosts.Default(); d != "" {
+				fmt.Fprintf(os.Stdout, "Default host: %s\n", d)
+			} else {
+				fmt.Fprintln(os.Stdout, "Default host: (none)")
+			}
+			fmt.Fprintln(os.Stdout)
+			for _, n := range listed {
 				e, _ := hosts.Get(n)
 				printStatus(n, e)
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit status as JSON")
+	return cmd
 }
 
 func newLogout() *cobra.Command {

--- a/internal/auth/host.go
+++ b/internal/auth/host.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+// NewHostCommand is the top-level `host` command for the persisted default host.
+func NewHostCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "host",
+		Short: "Manage configured hosts",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newHostDefault())
+	return cmd
+}
+
+func newHostDefault() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "default",
+		Short: "Show the persisted default host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			hosts, err := config.LoadHosts()
+			if err != nil {
+				return err
+			}
+			if d := hosts.Default(); d != "" {
+				fmt.Fprintln(cmd.OutOrStdout(), d)
+				return nil
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "No default host is set")
+			return nil
+		},
+	}
+	cmd.AddCommand(newHostDefaultSet(), newHostDefaultUnset())
+	return cmd
+}
+
+func newHostDefaultSet() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <host>",
+		Short: "Persist a default host among logged-in hosts",
+		Args:  runtime.UsageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := config.NormalizeHostname(args[0])
+			if hostname == "" {
+				return runtime.UsageError(cmd, fmt.Errorf("host is required"))
+			}
+			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
+				if _, ok := hosts.Get(hostname); !ok {
+					names := hosts.Names()
+					if len(names) == 0 {
+						return runtime.NewNotAuthenticatedError()
+					}
+					return fmt.Errorf("host %q is not logged in (have: %s); run `%s auth login --hostname %s`", hostname, strings.Join(names, ", "), config.Active().CLI.Name, hostname)
+				}
+				hosts.SetDefault(hostname)
+				return nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "✓ Default host set to %s\n", hostname)
+			return nil
+		},
+	}
+}
+
+func newHostDefaultUnset() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unset",
+		Short: "Clear the persisted default host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
+				hosts.ClearDefault()
+				return nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, "✓ Default host unset")
+			return nil
+		},
+	}
+}

--- a/internal/auth/host_test.go
+++ b/internal/auth/host_test.go
@@ -1,0 +1,189 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func bindAuthTestManifest(t *testing.T) *config.Manifest {
+	t.Helper()
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEMO_HOST", "")
+	return m
+}
+
+func saveAuthHosts(t *testing.T, defaultHost string, names ...string) {
+	t.Helper()
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range names {
+		hosts.Set(name, config.HostEntry{AuthType: "bearer", OAuthToken: "tok", User: "octo"})
+	}
+	if defaultHost != "" {
+		hosts.SetDefault(defaultHost)
+	}
+	if err := hosts.Save(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func execRoot(t *testing.T, m *config.Manifest, args ...string) (string, string, error) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	root := &cobra.Command{Use: "demo"}
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	root.AddCommand(NewCommand(m))
+	root.AddCommand(NewHostCommand())
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), errOut.String() + captureIfNeeded(), err
+}
+
+func captureIfNeeded() string { return "" }
+
+func TestHostDefaultSetAndUnset(t *testing.T) {
+	m := bindAuthTestManifest(t)
+	saveAuthHosts(t, "", "prod.example.com", "staging.example.com")
+
+	out, _, err := execRoot(t, m, "host", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No default host is set") {
+		t.Fatalf("default = %q", out)
+	}
+
+	if _, _, err := execRoot(t, m, "host", "default", "set", "staging.example.com"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	out, _, err = execRoot(t, m, "host", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out) != "staging.example.com" {
+		t.Fatalf("default after set = %q", out)
+	}
+
+	if _, _, err := execRoot(t, m, "host", "default", "set", "missing.example.com"); err == nil {
+		t.Fatal("set unknown host succeeded")
+	}
+
+	if _, _, err := execRoot(t, m, "host", "default", "unset"); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "" {
+		t.Fatalf("default after unset = %q", hosts.Default())
+	}
+}
+
+func TestAuthLoginElectsDefaultOnlyWhenUnset(t *testing.T) {
+	m := bindAuthTestManifest(t)
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", "first.example.com", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--with-token", "--skip-validate"})
+	stdin, input, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := input.WriteString("token-one\n"); err != nil {
+		t.Fatal(err)
+	}
+	input.Close()
+	old := os.Stdin
+	os.Stdin = stdin
+	if err := root.Execute(); err != nil {
+		os.Stdin = old
+		t.Fatalf("first login: %v", err)
+	}
+	os.Stdin = old
+	stdin.Close()
+
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "first.example.com" {
+		t.Fatalf("first login default = %q", hosts.Default())
+	}
+
+	root = &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", "second.example.com", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--with-token", "--skip-validate"})
+	stdin, input, err = os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := input.WriteString("token-two\n"); err != nil {
+		t.Fatal(err)
+	}
+	input.Close()
+	os.Stdin = stdin
+	if err := root.Execute(); err != nil {
+		os.Stdin = old
+		t.Fatalf("second login: %v", err)
+	}
+	os.Stdin = old
+	stdin.Close()
+
+	hosts, err = config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "first.example.com" {
+		t.Fatalf("later login overrode default: %q", hosts.Default())
+	}
+	if _, ok := hosts.Get("second.example.com"); !ok {
+		t.Fatal("second host not saved")
+	}
+}
+
+func TestAuthStatusJSONExposesHostProvenance(t *testing.T) {
+	m := bindAuthTestManifest(t)
+	saveAuthHosts(t, "staging.example.com", "prod.example.com", "staging.example.com")
+	out, _, err := execRoot(t, m, "auth", "status", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Hostname string `json:"hostname"`
+		Source   string `json:"source"`
+		Default  string `json:"default"`
+		Hosts    []struct {
+			Hostname string `json:"hostname"`
+		} `json:"hosts"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if got.Hostname != "staging.example.com" || got.Source != "persisted" || got.Default != "staging.example.com" {
+		t.Fatalf("status = %#v\n%s", got, out)
+	}
+	if len(got.Hosts) != 2 {
+		t.Fatalf("hosts = %#v", got.Hosts)
+	}
+}

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -494,7 +494,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("## Workflow\n\n")
 	fmt.Fprintf(&b, "1. Search for candidates with `%s search \"<intent>\" --json`; use `--limit` when needed. Search is only candidate discovery.\n", cli)
 	fmt.Fprintf(&b, "2. Inspect the exact command with `%s commands show <path...> --json` before executing an unfamiliar command.\n", cli)
-	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --json` before execution. Host resolution is `--hostname`, then `$%s`, then a persisted default (`%s host default`), then `http.default_hostname`, then the unique host in `hosts.yml`. If more than one host is configured and none of those apply, stop and run `%s host default set <host>` or ask the user to authenticate.\n", cli, manifest.CLI.HostEnv, cli, cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "4. If a flag has `context`, inspect `%s auth context status -o json`. Explicit flags override the declared environment variable, which overrides the value stored for the selected host.\n", cli)
 		b.WriteString("5. Execute only after flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints are clear from `commands show`. When `mutation` is not `read`, preview with `--<dry_run.flag>` if `dry_run.mode` is `http_preview`; if preview is unavailable, obtain explicit user confirmation before execution.\n\n")
@@ -511,7 +511,9 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	fmt.Fprintf(&b, "- `%s commands --include-hidden --json`: include hidden generated commands.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands show <path...> --json`: source of truth for one command.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands schema --json`: catalog schema version, surfaces, and dry-run result shape.\n", cli)
-	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n\n", cli)
+	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n", cli)
+	fmt.Fprintf(&b, "- `%s auth status --json`: current host, resolution source, persisted default, and logged-in hosts.\n", cli)
+	fmt.Fprintf(&b, "- `%s host default`: show the persisted default host; `%s host default set <host>` / `unset` to change it.\n\n", cli, cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "- `%s auth context status -o json`: effective account-scoped context values for the selected host.\n\n", cli)
 	}
@@ -563,7 +565,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `path`: command path to pass to `commands show` or execute after the CLI name.\n")
 	b.WriteString("- `shortcuts`: root-level commands that execute the same operation with preset flag values.\n")
 	b.WriteString("- `http`: HTTP method and path template.\n")
-	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname`, `$%s`, and a persisted default (`host default`); when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, input modes, and help.\n")
 	b.WriteString("- `body`: request body requirement, media type, and optional `runtime_schema` preflight source, including its active-context prerequisites.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
@@ -577,7 +579,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("## Command Detail\n\n")
 	fmt.Fprintf(&b, "Run `%s commands show <path...> --json` before executing an unfamiliar command. This is the source of truth for flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints.\n\n", cli)
 	b.WriteString("## Schema\n\n")
-	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `headers`, `body`, `auth`, `output`).\n\n", cli)
+	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`, `host_source`, `headers`, `body`, `auth`, `output`).\n\n", cli)
 	b.WriteString("## Sensitive Flags\n\n")
 	b.WriteString("When a flag entry has `input_modes`, prefer safe modes over putting secrets directly in shell arguments.\n\n")
 	b.WriteString("- `flag`: pass the direct `--<flag>` value; keep this for compatibility or non-secret values.\n")
@@ -595,7 +597,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
 	b.WriteString("## Auth\n\n")
-	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --json` before execution. Host resolution is `--hostname`, then `$%s`, then a persisted default (`%s host default`), then `http.default_hostname`, then the unique host in `hosts.yml`. If more than one host is configured and none of those apply, stop and run `%s host default set <host>` or ask the user to authenticate.\n", cli, manifest.CLI.HostEnv, cli, cli)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
 		fmt.Fprintf(&b, "For browser-based OAuth login, run `%s auth login --device-auth --hostname <host> --provider <provider>`. The browser opens by default in an interactive terminal; use `--no-browser` for manual login. `auth_type: bearer` in `hosts.yml` is expected after login because API requests use the issued bearer token.\n", cli)
 	}

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -105,6 +105,8 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"error.code",
 		"exit 0",
 		"auth context status -o json",
+		"host default",
+		"auth status --json",
 	} {
 		if !strings.Contains(skill, want) {
 			t.Errorf("SKILL.md missing %q", want)
@@ -125,7 +127,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 
 	catalog := readFile(t, dir, "skills/acmectl/references/catalog.md")
-	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "body.runtime_schema", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero", "`mutation`", "`dry_run`", "catalog_schema_version", "surfaces", "other than `read`", "explicit user confirmation"} {
+	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "body.runtime_schema", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero", "`mutation`", "`dry_run`", "catalog_schema_version", "surfaces", "other than `read`", "explicit user confirmation", "host_source", "host default"} {
 		if !strings.Contains(catalog, want) {
 			t.Errorf("catalog.md missing %q", want)
 		}

--- a/pkg/config/hosts.go
+++ b/pkg/config/hosts.go
@@ -13,6 +13,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const defaultHostKey = "default"
+
 // https is the default and is stripped; http is an explicit downgrade and
 // is preserved so downstream BaseURL honors it.
 func NormalizeHostname(s string) string {
@@ -41,8 +43,9 @@ type HostEntry struct {
 }
 
 type Hosts struct {
-	entries map[string]HostEntry
-	path    string
+	defaultHost string
+	entries     map[string]HostEntry
+	path        string
 }
 
 func configDir() (string, error) {
@@ -85,18 +88,45 @@ func loadHostsPath(p string) (*Hosts, error) {
 		}
 		return nil, err
 	}
-	raw := map[string]HostEntry{}
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", p, err)
 	}
-	// One-time rekey: migrate any legacy keys that include scheme/slashes.
-	for k, v := range raw {
-		norm := NormalizeHostname(k)
-		if _, exists := h.entries[norm]; !exists || norm == k {
-			h.entries[norm] = v
+	mapping := mappingNode(&doc)
+	if mapping == nil {
+		return h, nil
+	}
+	for i := 0; i+1 < len(mapping.Content); i += 2 {
+		key := mapping.Content[i].Value
+		val := mapping.Content[i+1]
+		if key == defaultHostKey && val.Kind == yaml.ScalarNode {
+			h.defaultHost = NormalizeHostname(val.Value)
+			continue
+		}
+		var e HostEntry
+		if err := val.Decode(&e); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", p, err)
+		}
+		norm := NormalizeHostname(key)
+		if _, exists := h.entries[norm]; !exists || norm == key {
+			h.entries[norm] = e
 		}
 	}
 	return h, nil
+}
+
+func mappingNode(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	node := doc
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	return node
 }
 
 func (h *Hosts) Set(hostname string, e HostEntry) {
@@ -124,6 +154,23 @@ func (h *Hosts) Names() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// Default returns the persisted default hostname, or "" if none is set.
+// The value is a plain hostname and never carries credentials.
+func (h *Hosts) Default() string {
+	return h.defaultHost
+}
+
+// SetDefault stores hostname as the persisted default. It does not write
+// credentials into the default field.
+func (h *Hosts) SetDefault(hostname string) {
+	h.defaultHost = NormalizeHostname(hostname)
+}
+
+// ClearDefault removes the persisted default hostname.
+func (h *Hosts) ClearDefault() {
+	h.defaultHost = ""
 }
 
 func (h *Hosts) Save() error {
@@ -167,7 +214,7 @@ func (h *Hosts) saveAtomic() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(h.entries)
+	data, err := h.marshal()
 	if err != nil {
 		return err
 	}
@@ -193,4 +240,25 @@ func (h *Hosts) saveAtomic() error {
 		return err
 	}
 	return replaceFile(tmpPath, h.path)
+}
+
+func (h *Hosts) marshal() ([]byte, error) {
+	doc := &yaml.Node{Kind: yaml.MappingNode}
+	if h.defaultHost != "" {
+		doc.Content = append(doc.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: defaultHostKey},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: h.defaultHost},
+		)
+	}
+	for _, name := range h.Names() {
+		var entryNode yaml.Node
+		if err := entryNode.Encode(h.entries[name]); err != nil {
+			return nil, err
+		}
+		doc.Content = append(doc.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: name},
+			&entryNode,
+		)
+	}
+	return yaml.Marshal(doc)
 }

--- a/pkg/config/hosts_test.go
+++ b/pkg/config/hosts_test.go
@@ -1,10 +1,19 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func bindHostsTestManifest(t *testing.T) {
+	t.Helper()
+	Bind(&Manifest{CLI: CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"}})
+}
 
 func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
-	m := &Manifest{CLI: CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"}}
-	Bind(m)
+	bindHostsTestManifest(t)
 	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
 
 	hosts, err := LoadHosts()
@@ -38,5 +47,88 @@ func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
 	}
 	if entry.Contexts["workspace"] != "ws-1" {
 		t.Fatalf("contexts = %#v", entry.Contexts)
+	}
+}
+
+func TestHostsPersistedDefaultRoundTrip(t *testing.T) {
+	bindHostsTestManifest(t)
+	dir := t.TempDir()
+	t.Setenv("DEMO_CONFIG_DIR", dir)
+
+	hosts, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	hosts.Set("https://staging.example.com", HostEntry{AuthType: "bearer", OAuthToken: "secret-token"})
+	hosts.Set("https://prod.example.com", HostEntry{AuthType: "bearer", OAuthToken: "other-token"})
+	hosts.SetDefault("https://staging.example.com")
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "hosts.yml"))
+	if err != nil {
+		t.Fatalf("stat hosts.yml: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("hosts.yml mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "hosts.yml"))
+	if err != nil {
+		t.Fatalf("read hosts.yml: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, "default: staging.example.com") {
+		t.Fatalf("missing default field:\n%s", text)
+	}
+	if strings.Count(text, "secret-token") != 1 || strings.Contains(text, "default: secret-token") {
+		t.Fatalf("default field must not carry credentials:\n%s", text)
+	}
+
+	loaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts reload: %v", err)
+	}
+	if loaded.Default() != "staging.example.com" {
+		t.Fatalf("default = %q", loaded.Default())
+	}
+	if _, ok := loaded.Get("staging.example.com"); !ok {
+		t.Fatal("missing staging host")
+	}
+	loaded.ClearDefault()
+	if err := loaded.Save(); err != nil {
+		t.Fatalf("Save after clear: %v", err)
+	}
+	reloaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts after clear: %v", err)
+	}
+	if reloaded.Default() != "" {
+		t.Fatalf("default after clear = %q", reloaded.Default())
+	}
+	if _, ok := reloaded.Get("staging.example.com"); !ok {
+		t.Fatal("cleared default must not delete host credentials")
+	}
+}
+
+func TestHostsLoadLegacyFileWithoutDefault(t *testing.T) {
+	bindHostsTestManifest(t)
+	dir := t.TempDir()
+	t.Setenv("DEMO_CONFIG_DIR", dir)
+	if err := os.WriteFile(filepath.Join(dir, "hosts.yml"), []byte("api.example.com:\n  auth_type: bearer\n  oauth_token: token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	if loaded.Default() != "" {
+		t.Fatalf("default = %q, want empty", loaded.Default())
+	}
+	entry, ok := loaded.Get("api.example.com")
+	if !ok || entry.OAuthToken != "token" {
+		t.Fatalf("entry = %+v, found = %v", entry, ok)
 	}
 }

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -62,6 +62,9 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	authCmd := auth.NewCommand(m)
 	authCmd.GroupID = authGroupID
 	cmd.AddCommand(authCmd)
+	hostCmd := auth.NewHostCommand()
+	hostCmd.GroupID = authGroupID
+	cmd.AddCommand(hostCmd)
 	cmd.AddCommand(auth.NewHiddenLoginCommand(m))
 	cmd.AddCommand(commandsCmd(m))
 	cmd.AddCommand(searchCmd(m))

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -191,22 +191,25 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return UsageError(cmd, err)
 			}
 
-			var hostname string
+			var res HostResolution
 			var clientOpts ClientOptions
 			refreshAuth := !dryRun
 			if dryRun || (s.Security != nil && s.Security.Public) {
-				hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				res, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
 			} else {
-				hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				res, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
 			}
 			if err != nil {
 				return err
 			}
+			hostname := res.Hostname
+			noticeImplicitHost(cmd.ErrOrStderr(), res)
 
 			if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 				clientOpts.Debug = true
 			}
 			clientOpts.UserAgent = cmd.Root().Use
+			clientOpts.Hostname = hostname
 
 			output := operationOutput{}
 			if s.Output.Streaming != nil && format == "raw" && !waitPoll {
@@ -216,6 +219,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			}
 			result, err := invokeOperation(cmd.Context(), s, input, OperationOptions{
 				Hostname:    hostname,
+				HostSource:  res.Source,
 				Client:      clientOpts,
 				DryRun:      dryRun,
 				PaginateAll: paginateAll,

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -27,6 +27,7 @@ type ClientOptions struct {
 	Timeout     time.Duration
 	Headers     map[string]string
 	Debug       bool
+	Hostname    string
 	MaxRetries  int
 	UserAgent   string
 	Accept      string
@@ -76,7 +77,7 @@ func httpClient(opts ClientOptions, streaming bool) *http.Client {
 		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug, safeMethodsOnly: safeMethodsOnly}
 	}
 	if opts.Debug {
-		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming}
+		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming, hostname: opts.Hostname}
 	}
 	return &http.Client{
 		Timeout:       timeout,

--- a/pkg/runtime/context.go
+++ b/pkg/runtime/context.go
@@ -15,7 +15,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 	if !needsStoredContext(spec, *input) {
 		return resolveOperationContexts(spec, input, "")
 	}
-	hostname, err := resolveHost(cmd, spec.DefaultHostname)
+	res, err := resolveHost(cmd, spec.DefaultHostname)
 	if err != nil {
 		for _, param := range spec.Params {
 			if param.Context != "" && param.Required && contextNeedsStored(param, *input) {
@@ -24,7 +24,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 		}
 		return nil
 	}
-	return resolveOperationContexts(spec, input, hostname)
+	return resolveOperationContexts(spec, input, res.Hostname)
 }
 
 func needsStoredContext(spec CommandSpec, input OperationInput) bool {

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -16,6 +18,21 @@ import (
 // NewNotAuthenticatedError using the bound manifest.
 var ErrNotAuthenticated = errors.New("not authenticated")
 
+const (
+	HostSourceFlag           = "flag"
+	HostSourceEnv            = "env"
+	HostSourcePersisted      = "persisted"
+	HostSourceCodegenDefault = "codegen-default"
+	HostSourceUnique         = "unique"
+)
+
+// HostResolution is the selected hostname and how it was chosen.
+type HostResolution struct {
+	Hostname   string
+	Source     string
+	Configured int
+}
+
 // NewNotAuthenticatedError renders the "no host configured" message using
 // the bound manifest and wraps ErrNotAuthenticated so errors.Is still works.
 func NewNotAuthenticatedError() error {
@@ -24,34 +41,90 @@ func NewNotAuthenticatedError() error {
 }
 
 func ResolveHost(cmd *cobra.Command) (string, error) {
+	res, err := resolveHost(cmd, "")
+	return res.Hostname, err
+}
+
+// ResolveHostWithSource returns the hostname selected for cmd plus the
+// resolution source (`flag` / `env` / `persisted` / `codegen-default` / `unique`).
+func ResolveHostWithSource(cmd *cobra.Command) (HostResolution, error) {
 	return resolveHost(cmd, "")
 }
 
-func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
+func resolveHost(cmd *cobra.Command, defaultHostname string) (HostResolution, error) {
 	cli := config.Active().CLI
 	h, _ := cmd.Root().PersistentFlags().GetString("hostname")
-	if h == "" {
-		h = os.Getenv(cli.HostEnv)
-	}
 	if h != "" {
-		return config.NormalizeHostname(h), nil
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: HostSourceFlag}, nil
 	}
-	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
-		return defaultHostname, nil
+	if h = os.Getenv(cli.HostEnv); h != "" {
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: HostSourceEnv}, nil
 	}
+
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", err
+		return HostResolution{}, err
+	}
+	configured := len(hosts.Names())
+	if persisted := hosts.Default(); persisted != "" {
+		if _, ok := hosts.Get(persisted); ok {
+			return HostResolution{Hostname: persisted, Source: HostSourcePersisted, Configured: configured}, nil
+		}
+		fmt.Fprintf(os.Stderr, "warning: persisted default host %q is not configured; clearing it\n", persisted)
+		ctx := context.Background()
+		if cmd != nil && cmd.Context() != nil {
+			ctx = cmd.Context()
+		}
+		_ = config.MutateHosts(ctx, func(h *config.Hosts) error {
+			if cur := h.Default(); cur != "" {
+				if _, ok := h.Get(cur); !ok {
+					h.ClearDefault()
+				}
+			}
+			return nil
+		})
+	}
+	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
+		return HostResolution{Hostname: defaultHostname, Source: HostSourceCodegenDefault, Configured: configured}, nil
 	}
 	names := hosts.Names()
 	switch len(names) {
 	case 0:
-		return "", NewNotAuthenticatedError()
+		return HostResolution{}, NewNotAuthenticatedError()
 	case 1:
-		return names[0], nil
+		return HostResolution{Hostname: names[0], Source: HostSourceUnique, Configured: 1}, nil
 	default:
-		return "", fmt.Errorf("multiple hosts configured (%v); specify --hostname or $%s", names, cli.HostEnv)
+		return HostResolution{Configured: len(names)}, fmt.Errorf("multiple hosts configured (%v); specify --hostname or $%s, or run `%s host default set`", names, cli.HostEnv, cli.Name)
 	}
+}
+
+func implicitHostSource(source string) bool {
+	switch source {
+	case HostSourcePersisted, HostSourceCodegenDefault, HostSourceUnique:
+		return true
+	default:
+		return false
+	}
+}
+
+func implicitHostLabel(source string) string {
+	switch source {
+	case HostSourcePersisted:
+		return "persisted default"
+	case HostSourceCodegenDefault:
+		return "codegen default"
+	case HostSourceUnique:
+		return "unique host"
+	default:
+		return source
+	}
+}
+
+func noticeImplicitHost(w io.Writer, res HostResolution) {
+	if w == nil || res.Hostname == "" || res.Configured <= 1 || !implicitHostSource(res.Source) {
+		return
+	}
+	fmt.Fprintf(w, "host: %s (%s)\n", res.Hostname, implicitHostLabel(res.Source))
 }
 
 // LoadHostOptions resolves hostname and client options (including auth) for
@@ -59,96 +132,98 @@ func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
 // insecure when set; otherwise the host record's persisted Insecure value
 // applies.
 func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return loadHostOptions(cmd, "")
+	res, opts, err := loadHostOptions(cmd, "")
+	return res.Hostname, opts, err
 }
 
-func loadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+func loadHostOptions(cmd *cobra.Command, defaultHostname string) (HostResolution, ClientOptions, error) {
 	return loadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
 }
 
-func loadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
+func loadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
+	res, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
-	e, ok := hosts.Get(hostname)
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
-		return "", ClientOptions{}, notAuthenticatedToHost(hostname)
+		return HostResolution{}, ClientOptions{}, notAuthenticatedToHost(res.Hostname)
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		e, err = refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure)
+		e, err = refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure)
 		if err != nil {
-			return "", ClientOptions{}, err
+			return HostResolution{}, ClientOptions{}, err
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func TryLoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return tryLoadHostOptions(cmd, "")
+	res, opts, err := tryLoadHostOptions(cmd, "")
+	return res.Hostname, opts, err
 }
 
-func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (HostResolution, ClientOptions, error) {
 	return tryLoadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
 }
 
-func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
+func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
+	res, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return res, ClientOptions{}, nil
 	}
-	e, ok := hosts.Get(hostname)
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
 		opts := ClientOptions{}
 		if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 			opts.Insecure = true
 		}
-		return hostname, opts, nil
+		return res, opts, nil
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure); err == nil {
+		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure); err == nil {
 			e = refreshed
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return res, ClientOptions{}, nil
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func notAuthenticatedToHost(string) error {

--- a/pkg/runtime/ctx_test.go
+++ b/pkg/runtime/ctx_test.go
@@ -113,12 +113,15 @@ func TestLoadHostOptionsRefreshesExpiredOAuthToken(t *testing.T) {
 	root.PersistentFlags().String("hostname", srv.URL, "")
 	root.PersistentFlags().Bool("insecure", false, "")
 
-	hostname, opts, err := loadHostOptions(root, "")
+	res, opts, err := loadHostOptions(root, "")
 	if err != nil {
 		t.Fatalf("loadHostOptions: %v", err)
 	}
-	if hostname != config.NormalizeHostname(srv.URL) {
-		t.Fatalf("hostname = %q", hostname)
+	if res.Hostname != config.NormalizeHostname(srv.URL) {
+		t.Fatalf("hostname = %q", res.Hostname)
+	}
+	if res.Source != HostSourceFlag {
+		t.Fatalf("source = %q, want %q", res.Source, HostSourceFlag)
 	}
 	auth, ok := opts.Auth.(BearerAuth)
 	if !ok || auth.Token != "access-new" {

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -15,10 +15,15 @@ type debugTransport struct {
 	inner                http.RoundTripper
 	sensitiveQueryParams map[string]bool
 	streaming            bool
+	hostname             string
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
+	if d.hostname != "" {
+		fmt.Fprintf(os.Stderr, "> %s request host=%s\n\n", req.Method, d.hostname)
+	} else {
+		fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
+	}
 
 	start := time.Now()
 	resp, err := d.inner.RoundTrip(req)

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -151,3 +151,24 @@ func TestDebugTransport_DoesNotPeekStreamingResponse(t *testing.T) {
 		t.Fatalf("debug output unexpectedly dumped streaming body:\n%s", out)
 	}
 }
+
+func TestDebugTransport_LogsResolvedHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+	dt := &debugTransport{inner: http.DefaultTransport, hostname: "staging.example.com"}
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL, nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	resp.Body.Close()
+
+	out := readStderr(t, r)
+	if !strings.Contains(out, "> POST request host=staging.example.com") {
+		t.Fatalf("debug dump missing resolved host:\n%s", out)
+	}
+}

--- a/pkg/runtime/host_resolution_test.go
+++ b/pkg/runtime/host_resolution_test.go
@@ -1,0 +1,246 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func hostTestRoot(t *testing.T, hostnameDefault string) *cobra.Command {
+	t.Helper()
+	bindTestManifest(t, "demo", "DEMO_HOST")
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEMO_HOST", "")
+	root := &cobra.Command{Use: "demo"}
+	root.SetContext(context.Background())
+	root.PersistentFlags().String("hostname", hostnameDefault, "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	return root
+}
+
+func saveTestHosts(t *testing.T, defaultHost string, names ...string) {
+	t.Helper()
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	for _, name := range names {
+		hosts.Set(name, config.HostEntry{AuthType: "bearer", OAuthToken: "tok"})
+	}
+	if defaultHost != "" {
+		hosts.SetDefault(defaultHost)
+	}
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func TestResolveHost_OrderMatrix(t *testing.T) {
+	root := hostTestRoot(t, "")
+	saveTestHosts(t, "staging.example.com", "prod.example.com", "staging.example.com")
+
+	t.Run("flag over env persisted codegen", func(t *testing.T) {
+		t.Setenv("DEMO_HOST", "env.example.com")
+		if err := root.PersistentFlags().Set("hostname", "flag.example.com"); err != nil {
+			t.Fatal(err)
+		}
+		res, err := resolveHost(root, "codegen.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Hostname != "flag.example.com" || res.Source != HostSourceFlag {
+			t.Fatalf("got %+v", res)
+		}
+	})
+	t.Run("env over persisted codegen", func(t *testing.T) {
+		if err := root.PersistentFlags().Set("hostname", ""); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("DEMO_HOST", "env.example.com")
+		res, err := resolveHost(root, "codegen.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Hostname != "env.example.com" || res.Source != HostSourceEnv {
+			t.Fatalf("got %+v", res)
+		}
+	})
+	t.Run("persisted over codegen", func(t *testing.T) {
+		if err := root.PersistentFlags().Set("hostname", ""); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("DEMO_HOST", "")
+		res, err := resolveHost(root, "codegen.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Hostname != "staging.example.com" || res.Source != HostSourcePersisted {
+			t.Fatalf("got %+v", res)
+		}
+	})
+	t.Run("codegen over unique and multi-host error", func(t *testing.T) {
+		hosts, err := config.LoadHosts()
+		if err != nil {
+			t.Fatal(err)
+		}
+		hosts.ClearDefault()
+		if err := hosts.Save(); err != nil {
+			t.Fatal(err)
+		}
+		res, err := resolveHost(root, "codegen.example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Hostname != "codegen.example.com" || res.Source != HostSourceCodegenDefault {
+			t.Fatalf("got %+v", res)
+		}
+	})
+}
+
+func TestResolveHost_UniqueAndMultiHostError(t *testing.T) {
+	root := hostTestRoot(t, "")
+	saveTestHosts(t, "", "only.example.com")
+	res, err := resolveHost(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Hostname != "only.example.com" || res.Source != HostSourceUnique {
+		t.Fatalf("got %+v", res)
+	}
+
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hosts.Set("other.example.com", config.HostEntry{AuthType: "bearer", OAuthToken: "tok"})
+	if err := hosts.Save(); err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolveHost(root, "")
+	if err == nil {
+		t.Fatal("expected multi-host error")
+	}
+	if !strings.Contains(err.Error(), "host default set") || !strings.Contains(err.Error(), "DEMO_HOST") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResolveHost_StalePersistedDefaultFallsThrough(t *testing.T) {
+	root := hostTestRoot(t, "")
+	saveTestHosts(t, "gone.example.com", "prod.example.com")
+
+	stderr := captureStderr(t)
+	res, err := resolveHost(root, "codegen.example.com")
+	out := readStderr(t, stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Hostname != "codegen.example.com" || res.Source != HostSourceCodegenDefault {
+		t.Fatalf("stale default must fall through, got %+v", res)
+	}
+	if !strings.Contains(out, `warning: persisted default host "gone.example.com" is not configured; clearing it`) {
+		t.Fatalf("missing stale warning:\n%s", out)
+	}
+	reloaded, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Default() != "" {
+		t.Fatalf("stale default not cleared: %q", reloaded.Default())
+	}
+}
+
+func TestResolveHost_StalePersistedDefaultDoesNotPickSubstitute(t *testing.T) {
+	root := hostTestRoot(t, "")
+	saveTestHosts(t, "gone.example.com", "a.example.com", "b.example.com")
+	stderr := captureStderr(t)
+	res, err := resolveHost(root, "")
+	_ = readStderr(t, stderr)
+	if err == nil {
+		t.Fatalf("expected multi-host error, got %+v", res)
+	}
+	if res.Hostname != "" {
+		t.Fatalf("must not pick a substitute host, got %q", res.Hostname)
+	}
+	if !strings.Contains(err.Error(), "host default set") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestNoticeImplicitHost_TriggerConditions(t *testing.T) {
+	var buf bytes.Buffer
+	noticeImplicitHost(&buf, HostResolution{Hostname: "staging.example.com", Source: HostSourcePersisted, Configured: 2})
+	if !strings.Contains(buf.String(), "host: staging.example.com (persisted default)") {
+		t.Fatalf("persisted notice = %q", buf.String())
+	}
+
+	buf.Reset()
+	noticeImplicitHost(&buf, HostResolution{Hostname: "codegen.example.com", Source: HostSourceCodegenDefault, Configured: 2})
+	if !strings.Contains(buf.String(), "host: codegen.example.com (codegen default)") {
+		t.Fatalf("codegen notice = %q", buf.String())
+	}
+
+	buf.Reset()
+	noticeImplicitHost(&buf, HostResolution{Hostname: "only.example.com", Source: HostSourceUnique, Configured: 1})
+	if buf.Len() != 0 {
+		t.Fatalf("unique single-host must be silent, got %q", buf.String())
+	}
+
+	buf.Reset()
+	noticeImplicitHost(&buf, HostResolution{Hostname: "flag.example.com", Source: HostSourceFlag, Configured: 2})
+	if buf.Len() != 0 {
+		t.Fatalf("explicit flag must be silent, got %q", buf.String())
+	}
+
+	buf.Reset()
+	noticeImplicitHost(&buf, HostResolution{Hostname: "env.example.com", Source: HostSourceEnv, Configured: 2})
+	if buf.Len() != 0 {
+		t.Fatalf("explicit env must be silent, got %q", buf.String())
+	}
+}
+
+func TestWriteDryRun_IncludesHostProvenance(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeDryRun(DryRunRequest{
+		Method:     "GET",
+		URL:        "https://example.com/x",
+		Hostname:   "example.com",
+		HostSource: HostSourcePersisted,
+	}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"hostname": "example.com"`) || !strings.Contains(buf.String(), `"host_source": "persisted"`) {
+		t.Fatalf("dry-run JSON missing provenance:\n%s", buf.String())
+	}
+}
+
+func TestResolveHost_NothingPersistedMatchesPriorErrorPlusHostDefaultSet(t *testing.T) {
+	root := hostTestRoot(t, "")
+	saveTestHosts(t, "", "a.example.com", "b.example.com")
+	_, err := resolveHost(root, "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "multiple hosts configured") || !strings.Contains(err.Error(), "host default set") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestResolveHost_UsesBoundHostEnvSource(t *testing.T) {
+	bindTestManifest(t, "myapp", "MYAPP_HOST")
+	t.Setenv("MYAPP_HOST", "example.internal")
+	root := &cobra.Command{Use: "myapp"}
+	root.PersistentFlags().String("hostname", "", "")
+	res, err := resolveHost(root, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Hostname != "example.internal" || res.Source != HostSourceEnv {
+		t.Fatalf("got %+v", res)
+	}
+}

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -21,6 +21,7 @@ type OperationInput struct {
 
 type OperationOptions struct {
 	Hostname    string
+	HostSource  string
 	Client      ClientOptions
 	DryRun      bool
 	PaginateAll bool
@@ -40,12 +41,14 @@ const (
 )
 
 type DryRunRequest struct {
-	Method  string            `json:"method"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Body    any               `json:"body"`
-	Auth    DryRunAuth        `json:"auth"`
-	Output  CatalogOutput     `json:"output"`
+	Method     string            `json:"method"`
+	URL        string            `json:"url"`
+	Hostname   string            `json:"hostname,omitempty"`
+	HostSource string            `json:"host_source,omitempty"`
+	Headers    map[string]string `json:"headers"`
+	Body       any               `json:"body"`
+	Auth       DryRunAuth        `json:"auth"`
+	Output     CatalogOutput     `json:"output"`
 }
 
 type DryRunAuth struct {
@@ -69,7 +72,7 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		return OperationResult{}, err
 	}
 	if opts.DryRun {
-		out, err := buildDryRunRequest(ctx, s, opts.Hostname, path, body, clientOpts)
+		out, err := buildDryRunRequest(ctx, s, opts.Hostname, opts.HostSource, path, body, clientOpts)
 		if err != nil {
 			return OperationResult{}, err
 		}
@@ -290,17 +293,19 @@ func hasFormDataParams(params []ParamSpec) bool {
 	return false
 }
 
-func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path string, body any, opts ClientOptions) (DryRunRequest, error) {
+func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, hostSource, path string, body any, opts ClientOptions) (DryRunRequest, error) {
 	req, bodyBytes, _, err := resolveRequest(ctx, hostname, s.Method, path, body, opts)
 	if err != nil {
 		return DryRunRequest{}, err
 	}
 	return DryRunRequest{
-		Method:  req.Method,
-		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams),
-		Headers: redactedDryRunHeaders(req.Header),
-		Body:    redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
-		Auth:    dryRunAuthForSpec(s),
+		Method:     req.Method,
+		URL:        redactDebugURL(req.URL, opts.sensitiveQueryParams),
+		Hostname:   hostname,
+		HostSource: hostSource,
+		Headers:    redactedDryRunHeaders(req.Header),
+		Body:       redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
+		Auth:       dryRunAuthForSpec(s),
 		Output: CatalogOutput{
 			ListPath:          s.Output.ListPath,
 			DefaultColumns:    append([]string(nil), s.Output.DefaultColumns...),

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -167,24 +167,28 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 			return fail(UsageError(cmd, err))
 		}
 
-		var hostname string
+		var res HostResolution
 		var clientOpts ClientOptions
 		if step.Operation.Security != nil && step.Operation.Security.Public {
-			hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			res, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		} else {
-			hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			res, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		}
 		if err != nil {
 			return fail(err)
 		}
+		hostname := res.Hostname
+		noticeImplicitHost(cmd.ErrOrStderr(), res)
 		if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 			clientOpts.Debug = true
 		}
 		clientOpts.UserAgent = cmd.Root().Use
+		clientOpts.Hostname = hostname
 
 		opResult, err := InvokeOperation(cmd.Context(), step.Operation, input, OperationOptions{
-			Hostname: hostname,
-			Client:   clientOpts,
+			Hostname:   hostname,
+			HostSource: res.Source,
+			Client:     clientOpts,
 		})
 		if err != nil {
 			return fail(err)


### PR DESCRIPTION
## Summary
Implements #125: persist a user-selected default host for generated CLIs.

- Non-secret `default` hostname in `hosts.yml` (0600; never stores credentials in the field)
- Resolution order: `--hostname` > `$_HOST` > persisted default > codegen `default_hostname` > unique host > error pointing at `host default set`
- Commands: `host default` / `host default set <host>` / `host default unset`
- `auth login` elects the new host only when no default is set (first-login-wins)
- Stale persisted default: ignore + clear + stderr warning; never pick a substitute
- Implicit-host stderr notice when source is persisted/codegen-default/unique and more than one host is configured
- Dry-run JSON and debug dump include resolved host / source
- Docs invariant 7, cli-usage, contracts, and generated Skill guidance updated

Rebased on latest `main` and squashed to a single commit. Local `go build ./...` and focused tests passed (`pkg/config`, `pkg/runtime`, `internal/auth`, `pkg/lathe`, `internal/codegen/render`).

Closes #125
