### PR TITLE
feat(runtime): persist a user-selected default host for generated CLIs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ order. `generated.MountModules` remains a compatibility alias.
 | `internal/latheskill` | distribution | Embeds Lathe's own Agent Skill. |
 | `pkg/config` | runtime | Loads the embedded manifest and persists per-host credentials and active contexts. |
 | `pkg/runtime` | runtime | Builds operation/workflow commands, catalog data, requests, auth, body handling, pagination, streaming, polling, output, and stable errors. |
-| `internal/auth` | runtime | Implements `auth login`, `logout`, `status`, and context commands. |
+| `internal/auth` | runtime | Implements `auth login`, `logout`, `status`, `host default`, and context commands. |
 | `pkg/lathe` | runtime | Provides the generated-CLI entrypoint, framework commands, version/update support, and `__lathe verify`. |
 
 `internal/**` is implementation-only. `pkg/**` is linked by downstream generated
@@ -157,8 +157,10 @@ but it is outside Lathe's generated capability contract.
    syntax or file locations.
 6. Generated output is static Go and Skill data. Building or running a generated
    CLI does not invoke codegen or require spec tooling.
-7. Host selection is per invocation. Active account contexts are stored under a
-   selected host; they do not create an ambient global host.
+7. Host selection is per invocation by default. A user may explicitly elect a
+   persisted default host; when elected, it is always visible together with its
+   resolution source and always overridable per invocation. Active account
+   contexts are stored under a selected host.
 8. API commands, workflow steps, catalog entries, generated Skills, and verify
    checks must describe the same compiled command surface.
 9. Generated files are outputs. Change specs, `cli.yaml`, or overlays, then

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -436,9 +436,14 @@ Rules:
    `--<flag>-stdin` for sensitive values.
 8. Branch on structured `error.code` and process exit status, not error prose.
 
-Framework commands such as `auth`, `commands`, `completion`, `search`,
+Framework commands such as `auth`, `host`, `commands`, `completion`, `search`,
 `skill`, `update`, and `__lathe` are documented by `--help`; generated API
 operations and workflows are documented by the runtime catalog.
+
+A persisted default host is optional. Resolve with `--hostname`, then the
+configured host environment variable, then `host default`, then codegen
+`default_hostname`, then the unique host in `hosts.yml`. `auth status --json`
+and `--dry-run` expose the resolved host and its source.
 
 ## Examples
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -30,8 +30,8 @@ the contract from the running CLI:
 
 `commands schema --json` reports `catalog_schema_version`, the committed
 `surfaces`, and `dry_run.result`. `dry_run.result=http_preview` means a
-preview prints the resolved HTTP request JSON (`method`, `url`, `headers`,
-`body`, `auth`, `output`).
+preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`,
+`host_source`, `headers`, `body`, `auth`, `output`).
 
 Catalog entries have two kinds:
 
@@ -49,8 +49,9 @@ operations are classified from the request template (`query` / `mutation`),
 not from HTTP POST. Other methods stay `unknown` unless the template proves
 otherwise.
 
-Framework commands such as `auth`, `commands`, `search`, `skill`, `update`, and
-`__lathe` are discovered through `--help`; they are not operation entries.
+Framework commands such as `auth`, `host`, `commands`, `search`, `skill`,
+`update`, and `__lathe` are discovered through `--help`; they are not
+operation entries.
 `catalog.cli.capabilities` reports compiled first-party capabilities such as
 `skill.bundle` and `workflow.dsl`.
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -466,6 +466,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 			}
 
+			elected := false
 			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
 				current, _ := hosts.Get(hostname)
 				contexts := maps.Clone(current.Contexts)
@@ -477,11 +478,18 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 				entry.Contexts = contexts
 				hosts.Set(hostname, entry)
+				if hosts.Default() == "" {
+					hosts.SetDefault(hostname)
+					elected = true
+				}
 				return nil
 			}); err != nil {
 				return err
 			}
 			fmt.Fprintf(os.Stderr, "✓ Logged in to %s\n", hostname)
+			if elected {
+				fmt.Fprintf(os.Stderr, "✓ Set %s as the default host (no default was set)\n", hostname)
+			}
 			return nil
 		},
 	}
@@ -498,13 +506,30 @@ func newLogin(m *config.Manifest) *cobra.Command {
 	return cmd
 }
 
+type statusReport struct {
+	Hostname string       `json:"hostname,omitempty"`
+	Source   string       `json:"source,omitempty"`
+	Default  string       `json:"default,omitempty"`
+	Hosts    []statusHost `json:"hosts"`
+}
+
+type statusHost struct {
+	Hostname string `json:"hostname"`
+	User     string `json:"user,omitempty"`
+	Auth     string `json:"auth"`
+}
+
 func newStatus() *cobra.Command {
-	return &cobra.Command{
+	var jsonOut bool
+	cmd := &cobra.Command{
 		Use:   "status",
 		Short: "View authentication status",
 		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostname := rootString(cmd, "hostname")
+			// Resolve first: a stale persisted default is cleared here, so the
+			// hosts snapshot below already reflects it.
+			res, _ := runtime.ResolveHostWithSource(cmd)
 			hosts, err := config.LoadHosts()
 			if err != nil {
 				return err
@@ -514,13 +539,41 @@ func newStatus() *cobra.Command {
 				return runtime.NewNotAuthenticatedError()
 			}
 			if hostname != "" {
-				e, ok := hosts.Get(hostname)
-				if !ok {
+				if _, ok := hosts.Get(hostname); !ok {
 					return runtime.NewNotAuthenticatedError()
 				}
-				printStatus(hostname, e)
-				return nil
+				names = []string{config.NormalizeHostname(hostname)}
 			}
+			if jsonOut {
+				out := statusReport{
+					Hostname: res.Hostname,
+					Source:   res.Source,
+					Default:  hosts.Default(),
+					Hosts:    make([]statusHost, 0, len(names)),
+				}
+				for _, n := range names {
+					e, _ := hosts.Get(n)
+					item := statusHost{Hostname: n, User: e.User, Auth: e.AuthType}
+					if item.Auth == "" {
+						item.Auth = "bearer"
+					}
+					out.Hosts = append(out.Hosts, item)
+				}
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(out)
+			}
+			if res.Hostname != "" {
+				fmt.Fprintf(os.Stdout, "Current host: %s (%s)\n", res.Hostname, res.Source)
+			} else {
+				fmt.Fprintln(os.Stdout, "Current host: (none)")
+			}
+			if d := hosts.Default(); d != "" {
+				fmt.Fprintf(os.Stdout, "Default host: %s\n", d)
+			} else {
+				fmt.Fprintln(os.Stdout, "Default host: (none)")
+			}
+			fmt.Fprintln(os.Stdout)
 			for _, n := range names {
 				e, _ := hosts.Get(n)
 				printStatus(n, e)
@@ -528,6 +581,8 @@ func newStatus() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Emit status as JSON")
+	return cmd
 }
 
 func newLogout() *cobra.Command {

--- a/internal/auth/host.go
+++ b/internal/auth/host.go
@@ -1,0 +1,98 @@
+package auth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+// NewHostCommand is the top-level `host` command for the persisted default host.
+func NewHostCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "host",
+		Short: "Manage configured hosts",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newHostDefault())
+	return cmd
+}
+
+func newHostDefault() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "default",
+		Short: "Show the persisted default host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			hosts, err := config.LoadHosts()
+			if err != nil {
+				return err
+			}
+			if d := hosts.Default(); d != "" {
+				fmt.Fprintln(cmd.OutOrStdout(), d)
+			} else {
+				fmt.Fprintln(cmd.OutOrStdout(), "No default host is set")
+			}
+			return nil
+		},
+	}
+	cmd.AddCommand(newHostDefaultSet(), newHostDefaultUnset())
+	return cmd
+}
+
+func newHostDefaultSet() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <host>",
+		Short: "Persist a default host among logged-in hosts",
+		Args:  runtime.UsageArgs(cobra.ExactArgs(1)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := config.NormalizeHostname(args[0])
+			if hostname == "" {
+				return runtime.UsageError(cmd, fmt.Errorf("host is required"))
+			}
+			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
+				if _, ok := hosts.Get(hostname); !ok {
+					names := hosts.Names()
+					if len(names) == 0 {
+						return runtime.NewNotAuthenticatedError()
+					}
+					return runtime.NewError(runtime.CodeUsage, runtime.ExitUsage,
+						fmt.Sprintf("host %q is not logged in", hostname),
+						fmt.Sprintf("run `%s auth login --hostname %s` or choose from: %s", config.Active().CLI.Name, hostname, strings.Join(names, ", ")),
+						nil)
+				}
+				hosts.SetDefault(hostname)
+				return nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "✓ Default host set to %s\n", hostname)
+			return nil
+		},
+	}
+}
+
+func newHostDefaultUnset() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unset",
+		Short: "Clear the persisted default host",
+		Args:  runtime.UsageArgs(cobra.NoArgs),
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
+				hosts.ClearDefault()
+				return nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintln(os.Stderr, "✓ Default host unset")
+			return nil
+		},
+	}
+}

--- a/internal/auth/host_test.go
+++ b/internal/auth/host_test.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func bindHostTestManifest(t *testing.T) *config.Manifest {
+	t.Helper()
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEMO_HOST", "")
+	return m
+}
+
+func saveTestHosts(t *testing.T, defaultHost string, names ...string) {
+	t.Helper()
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range names {
+		hosts.Set(name, config.HostEntry{AuthType: "bearer", OAuthToken: "tok", User: "octo"})
+	}
+	if defaultHost != "" {
+		hosts.SetDefault(defaultHost)
+	}
+	if err := hosts.Save(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func execAuthRoot(t *testing.T, m *config.Manifest, args ...string) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	root := &cobra.Command{Use: "demo"}
+	root.SetOut(&out)
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.AddCommand(NewHostCommand())
+	root.SetArgs(args)
+	err := root.Execute()
+	return out.String(), err
+}
+
+func loginWithToken(t *testing.T, m *config.Manifest, hostname, token string) {
+	t.Helper()
+	stdin, input, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := input.WriteString(token + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := input.Close(); err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = stdin
+	defer func() {
+		_ = stdin.Close()
+		os.Stdin = oldStdin
+	}()
+
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", hostname, "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetArgs([]string{"auth", "login", "--with-token", "--skip-validate"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("login %s: %v", hostname, err)
+	}
+}
+
+func TestHostDefaultSetShowUnset(t *testing.T) {
+	m := bindHostTestManifest(t)
+	saveTestHosts(t, "", "prod.example.com", "staging.example.com")
+
+	out, err := execAuthRoot(t, m, "host", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No default host is set") {
+		t.Fatalf("default = %q", out)
+	}
+
+	if _, err := execAuthRoot(t, m, "host", "default", "set", "staging.example.com"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	out, err = execAuthRoot(t, m, "host", "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(out) != "staging.example.com" {
+		t.Fatalf("default after set = %q", out)
+	}
+
+	if _, err := execAuthRoot(t, m, "host", "default", "set", "missing.example.com"); err == nil {
+		t.Fatal("set unknown host succeeded")
+	}
+
+	if _, err := execAuthRoot(t, m, "host", "default", "unset"); err != nil {
+		t.Fatalf("unset: %v", err)
+	}
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "" {
+		t.Fatalf("default after unset = %q", hosts.Default())
+	}
+}
+
+func TestAuthLoginElectsDefaultOnlyWhenUnset(t *testing.T) {
+	m := bindHostTestManifest(t)
+
+	loginWithToken(t, m, "first.example.com", "token-one")
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "first.example.com" {
+		t.Fatalf("first login default = %q", hosts.Default())
+	}
+
+	loginWithToken(t, m, "second.example.com", "token-two")
+	hosts, err = config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hosts.Default() != "first.example.com" {
+		t.Fatalf("later login overrode default: %q", hosts.Default())
+	}
+	if _, ok := hosts.Get("second.example.com"); !ok {
+		t.Fatal("second host not saved")
+	}
+}
+
+func TestAuthStatusJSONExposesHostProvenance(t *testing.T) {
+	m := bindHostTestManifest(t)
+	saveTestHosts(t, "staging.example.com", "prod.example.com", "staging.example.com")
+
+	out, err := execAuthRoot(t, m, "auth", "status", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		Hostname string `json:"hostname"`
+		Source   string `json:"source"`
+		Default  string `json:"default"`
+		Hosts    []struct {
+			Hostname string `json:"hostname"`
+			Auth     string `json:"auth"`
+		} `json:"hosts"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if got.Hostname != "staging.example.com" || got.Source != "persisted" || got.Default != "staging.example.com" {
+		t.Fatalf("status = %#v\n%s", got, out)
+	}
+	if len(got.Hosts) != 2 {
+		t.Fatalf("hosts = %#v", got.Hosts)
+	}
+}

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -229,6 +229,7 @@ var reservedRootCommands = map[string]bool{
 	"commands":   true,
 	"completion": true,
 	"help":       true,
+	"host":       true,
 	"login":      true,
 	"search":     true,
 	"skill":      true,

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -1044,7 +1044,7 @@ func TestValidateModuleNames(t *testing.T) {
 	if err := ValidateModuleNames([]string{"pets", "billing"}); err != nil {
 		t.Fatalf("distinct module names should pass: %v", err)
 	}
-	for _, reserved := range []string{"__lathe", "auth", "commands", "completion", "help", "login", "search", "skill", "update"} {
+	for _, reserved := range []string{"__lathe", "auth", "commands", "completion", "help", "host", "login", "search", "skill", "update"} {
 		err := ValidateModuleNames([]string{"pets", reserved})
 		if err == nil || !strings.Contains(err.Error(), "reserved root command") {
 			t.Fatalf("module name %q should be rejected, got %v", reserved, err)

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -494,7 +494,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("## Workflow\n\n")
 	fmt.Fprintf(&b, "1. Search for candidates with `%s search \"<intent>\" --json`; use `--limit` when needed. Search is only candidate discovery.\n", cli)
 	fmt.Fprintf(&b, "2. Inspect the exact command with `%s commands show <path...> --json` before executing an unfamiliar command.\n", cli)
-	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --json` before execution. Host resolution: `--hostname` > `$%s` > persisted default (`%s host default`) > `http.default_hostname` > unique host in `hosts.yml`; if multiple hosts are configured and none apply, run `%s host default set <host>` or ask the user to authenticate.\n", cli, manifest.CLI.HostEnv, cli, cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "4. If a flag has `context`, inspect `%s auth context status -o json`. Explicit flags override the declared environment variable, which overrides the value stored for the selected host.\n", cli)
 		b.WriteString("5. Execute only after flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints are clear from `commands show`. When `mutation` is not `read`, preview with `--<dry_run.flag>` if `dry_run.mode` is `http_preview`; if preview is unavailable, obtain explicit user confirmation before execution.\n\n")
@@ -511,7 +511,9 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	fmt.Fprintf(&b, "- `%s commands --include-hidden --json`: include hidden generated commands.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands show <path...> --json`: source of truth for one command.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands schema --json`: catalog schema version, surfaces, and dry-run result shape.\n", cli)
-	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n\n", cli)
+	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n", cli)
+	fmt.Fprintf(&b, "- `%s auth status --json`: resolved host, its resolution source, the persisted default, and logged-in hosts.\n", cli)
+	fmt.Fprintf(&b, "- `%s host default`: show the persisted default host; `%s host default set <host>` / `unset` to change it.\n\n", cli, cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "- `%s auth context status -o json`: effective account-scoped context values for the selected host.\n\n", cli)
 	}
@@ -563,7 +565,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `path`: command path to pass to `commands show` or execute after the CLI name.\n")
 	b.WriteString("- `shortcuts`: root-level commands that execute the same operation with preset flag values.\n")
 	b.WriteString("- `http`: HTTP method and path template.\n")
-	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after `--hostname`, `$%s`, and a persisted default (`host default`); when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, input modes, and help.\n")
 	b.WriteString("- `body`: request body requirement, media type, and optional `runtime_schema` preflight source, including its active-context prerequisites.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
@@ -577,7 +579,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("## Command Detail\n\n")
 	fmt.Fprintf(&b, "Run `%s commands show <path...> --json` before executing an unfamiliar command. This is the source of truth for flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints.\n\n", cli)
 	b.WriteString("## Schema\n\n")
-	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `headers`, `body`, `auth`, `output`).\n\n", cli)
+	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`, `host_source`, `headers`, `body`, `auth`, `output`).\n\n", cli)
 	b.WriteString("## Sensitive Flags\n\n")
 	b.WriteString("When a flag entry has `input_modes`, prefer safe modes over putting secrets directly in shell arguments.\n\n")
 	b.WriteString("- `flag`: pass the direct `--<flag>` value; keep this for compatibility or non-secret values.\n")
@@ -595,7 +597,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
 	b.WriteString("## Auth\n\n")
-	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --json` before execution. Host resolution: `--hostname` > `$%s` > persisted default (`%s host default`) > `http.default_hostname` > unique host in `hosts.yml`; if multiple hosts are configured and none apply, run `%s host default set <host>` or ask the user to authenticate.\n", cli, manifest.CLI.HostEnv, cli, cli)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
 		fmt.Fprintf(&b, "For browser-based OAuth login, run `%s auth login --device-auth --hostname <host> --provider <provider>`. The browser opens by default in an interactive terminal; use `--no-browser` for manual login. `auth_type: bearer` in `hosts.yml` is expected after login because API requests use the issued bearer token.\n", cli)
 	}

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -105,6 +105,8 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"error.code",
 		"exit 0",
 		"auth context status -o json",
+		"host default",
+		"auth status --json",
 	} {
 		if !strings.Contains(skill, want) {
 			t.Errorf("SKILL.md missing %q", want)
@@ -125,7 +127,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 	}
 
 	catalog := readFile(t, dir, "skills/acmectl/references/catalog.md")
-	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "body.runtime_schema", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero", "`mutation`", "`dry_run`", "catalog_schema_version", "surfaces", "other than `read`", "explicit user confirmation"} {
+	for _, want := range []string{"## Search", "## Full Catalog", "## Command Detail", "## Sensitive Flags", "## Schema", "input_modes", "body.runtime_schema", "--<flag>-env", "--<flag>-file", "--<flag>-stdin", "--set-str", "-o json", "error.http", "pause exits zero", "`mutation`", "`dry_run`", "catalog_schema_version", "surfaces", "other than `read`", "explicit user confirmation", "host_source", "host default"} {
 		if !strings.Contains(catalog, want) {
 			t.Errorf("catalog.md missing %q", want)
 		}

--- a/pkg/config/hosts.go
+++ b/pkg/config/hosts.go
@@ -41,8 +41,9 @@ type HostEntry struct {
 }
 
 type Hosts struct {
-	entries map[string]HostEntry
-	path    string
+	defaultHost string
+	entries     map[string]HostEntry
+	path        string
 }
 
 func configDir() (string, error) {
@@ -85,15 +86,27 @@ func loadHostsPath(p string) (*Hosts, error) {
 		}
 		return nil, err
 	}
-	raw := map[string]HostEntry{}
+	raw := map[string]yaml.Node{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", p, err)
 	}
 	// One-time rekey: migrate any legacy keys that include scheme/slashes.
-	for k, v := range raw {
+	for k, n := range raw {
+		if k == "default" && n.Kind == yaml.ScalarNode {
+			var d string
+			if err := n.Decode(&d); err != nil {
+				return nil, fmt.Errorf("parse %s: %w", p, err)
+			}
+			h.defaultHost = NormalizeHostname(d)
+			continue
+		}
+		var e HostEntry
+		if err := n.Decode(&e); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", p, err)
+		}
 		norm := NormalizeHostname(k)
 		if _, exists := h.entries[norm]; !exists || norm == k {
-			h.entries[norm] = v
+			h.entries[norm] = e
 		}
 	}
 	return h, nil
@@ -124,6 +137,18 @@ func (h *Hosts) Names() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func (h *Hosts) Default() string {
+	return h.defaultHost
+}
+
+func (h *Hosts) SetDefault(hostname string) {
+	h.defaultHost = NormalizeHostname(hostname)
+}
+
+func (h *Hosts) ClearDefault() {
+	h.defaultHost = ""
 }
 
 func (h *Hosts) Save() error {
@@ -167,7 +192,7 @@ func (h *Hosts) saveAtomic() error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(h.entries)
+	data, err := h.marshal()
 	if err != nil {
 		return err
 	}
@@ -193,4 +218,17 @@ func (h *Hosts) saveAtomic() error {
 		return err
 	}
 	return replaceFile(tmpPath, h.path)
+}
+
+// marshal keeps the flat hosts.yml shape: the default host is a reserved
+// scalar key alongside the per-host entries, never a credential.
+func (h *Hosts) marshal() ([]byte, error) {
+	raw := make(map[string]any, len(h.entries)+1)
+	for k, v := range h.entries {
+		raw[k] = v
+	}
+	if h.defaultHost != "" {
+		raw["default"] = h.defaultHost
+	}
+	return yaml.Marshal(raw)
 }

--- a/pkg/config/hosts_test.go
+++ b/pkg/config/hosts_test.go
@@ -1,11 +1,22 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func bindHostsTestManifest(t *testing.T) string {
+	t.Helper()
+	Bind(&Manifest{CLI: CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"}})
+	dir := t.TempDir()
+	t.Setenv("DEMO_CONFIG_DIR", dir)
+	return dir
+}
 
 func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
-	m := &Manifest{CLI: CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"}}
-	Bind(m)
-	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	bindHostsTestManifest(t)
 
 	hosts, err := LoadHosts()
 	if err != nil {
@@ -38,5 +49,116 @@ func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
 	}
 	if entry.Contexts["workspace"] != "ws-1" {
 		t.Fatalf("contexts = %#v", entry.Contexts)
+	}
+}
+
+func TestHostsPersistedDefaultRoundTrip(t *testing.T) {
+	dir := bindHostsTestManifest(t)
+
+	hosts, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	hosts.Set("https://staging.example.com", HostEntry{AuthType: "bearer", OAuthToken: "secret-token"})
+	hosts.Set("https://prod.example.com", HostEntry{AuthType: "bearer", OAuthToken: "other-token"})
+	hosts.SetDefault("https://staging.example.com")
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "hosts.yml"))
+	if err != nil {
+		t.Fatalf("stat hosts.yml: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("hosts.yml mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "hosts.yml"))
+	if err != nil {
+		t.Fatalf("read hosts.yml: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, "default: staging.example.com") {
+		t.Fatalf("missing default field:\n%s", text)
+	}
+	if strings.Count(text, "secret-token") != 1 {
+		t.Fatalf("default field must not carry credentials:\n%s", text)
+	}
+
+	loaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts reload: %v", err)
+	}
+	if loaded.Default() != "staging.example.com" {
+		t.Fatalf("default = %q", loaded.Default())
+	}
+	if _, ok := loaded.Get("staging.example.com"); !ok {
+		t.Fatal("missing staging host")
+	}
+
+	loaded.ClearDefault()
+	if err := loaded.Save(); err != nil {
+		t.Fatalf("Save after clear: %v", err)
+	}
+	reloaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts after clear: %v", err)
+	}
+	if reloaded.Default() != "" {
+		t.Fatalf("default after clear = %q", reloaded.Default())
+	}
+	if _, ok := reloaded.Get("staging.example.com"); !ok {
+		t.Fatal("cleared default must not delete host credentials")
+	}
+}
+
+func TestHostsWithoutDefaultKeepsLegacyFileShape(t *testing.T) {
+	dir := bindHostsTestManifest(t)
+
+	hosts, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	hosts.Set("api.example.com", HostEntry{AuthType: "bearer", OAuthToken: "token"})
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "hosts.yml"))
+	if err != nil {
+		t.Fatalf("read hosts.yml: %v", err)
+	}
+	if strings.Contains(string(raw), "default:") {
+		t.Fatalf("no default must be written when unset:\n%s", raw)
+	}
+}
+
+func TestHostsLoadLegacyFileWithoutDefault(t *testing.T) {
+	dir := bindHostsTestManifest(t)
+	if err := os.WriteFile(filepath.Join(dir, "hosts.yml"), []byte("api.example.com:\n  auth_type: bearer\n  oauth_token: token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	if loaded.Default() != "" {
+		t.Fatalf("default = %q, want empty", loaded.Default())
+	}
+	entry, ok := loaded.Get("api.example.com")
+	if !ok || entry.OAuthToken != "token" {
+		t.Fatalf("entry = %+v, found = %v", entry, ok)
+	}
+}
+
+func TestHostsLoadRejectsNonMappingFile(t *testing.T) {
+	dir := bindHostsTestManifest(t)
+	if err := os.WriteFile(filepath.Join(dir, "hosts.yml"), []byte("- not\n- a\n- mapping\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadHosts(); err == nil {
+		t.Fatal("corrupt hosts.yml must fail to parse, not load as empty")
 	}
 }

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -62,6 +62,9 @@ func NewApp(m *config.Manifest) *cobra.Command {
 	authCmd := auth.NewCommand(m)
 	authCmd.GroupID = authGroupID
 	cmd.AddCommand(authCmd)
+	hostCmd := auth.NewHostCommand()
+	hostCmd.GroupID = authGroupID
+	cmd.AddCommand(hostCmd)
 	cmd.AddCommand(auth.NewHiddenLoginCommand(m))
 	cmd.AddCommand(commandsCmd(m))
 	cmd.AddCommand(searchCmd(m))

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -191,22 +191,24 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return UsageError(cmd, err)
 			}
 
-			var hostname string
+			var res HostResolution
 			var clientOpts ClientOptions
 			refreshAuth := !dryRun
 			if dryRun || (s.Security != nil && s.Security.Public) {
-				hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				res, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
 			} else {
-				hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				res, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
 			}
 			if err != nil {
 				return err
 			}
+			noticeImplicitHost(cmd.ErrOrStderr(), res)
 
 			if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 				clientOpts.Debug = true
 			}
 			clientOpts.UserAgent = cmd.Root().Use
+			clientOpts.Hostname = res.Hostname
 
 			output := operationOutput{}
 			if s.Output.Streaming != nil && format == "raw" && !waitPoll {
@@ -215,7 +217,8 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				output.live = cmd.OutOrStdout()
 			}
 			result, err := invokeOperation(cmd.Context(), s, input, OperationOptions{
-				Hostname:    hostname,
+				Hostname:    res.Hostname,
+				HostSource:  res.Source,
 				Client:      clientOpts,
 				DryRun:      dryRun,
 				PaginateAll: paginateAll,

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -27,6 +27,7 @@ type ClientOptions struct {
 	Timeout     time.Duration
 	Headers     map[string]string
 	Debug       bool
+	Hostname    string
 	MaxRetries  int
 	UserAgent   string
 	Accept      string
@@ -76,7 +77,7 @@ func httpClient(opts ClientOptions, streaming bool) *http.Client {
 		transport = &retryTransport{inner: transport, maxRetries: maxRetries, debug: opts.Debug, safeMethodsOnly: safeMethodsOnly}
 	}
 	if opts.Debug {
-		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming}
+		transport = &debugTransport{inner: transport, sensitiveQueryParams: opts.sensitiveQueryParams, streaming: streaming, hostname: opts.Hostname}
 	}
 	return &http.Client{
 		Timeout:       timeout,

--- a/pkg/runtime/context.go
+++ b/pkg/runtime/context.go
@@ -15,7 +15,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 	if !needsStoredContext(spec, *input) {
 		return resolveOperationContexts(spec, input, "")
 	}
-	hostname, err := resolveHost(cmd, spec.DefaultHostname)
+	res, err := resolveHost(cmd, spec.DefaultHostname)
 	if err != nil {
 		for _, param := range spec.Params {
 			if param.Context != "" && param.Required && contextNeedsStored(param, *input) {
@@ -24,7 +24,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 		}
 		return nil
 	}
-	return resolveOperationContexts(spec, input, hostname)
+	return resolveOperationContexts(spec, input, res.Hostname)
 }
 
 func needsStoredContext(spec CommandSpec, input OperationInput) bool {

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -24,34 +26,96 @@ func NewNotAuthenticatedError() error {
 }
 
 func ResolveHost(cmd *cobra.Command) (string, error) {
+	res, err := resolveHost(cmd, "")
+	return res.Hostname, err
+}
+
+// HostResolution is the selected hostname, how it was chosen, and how many
+// hosts are configured (0 when resolution did not consult hosts.yml).
+type HostResolution struct {
+	Hostname   string
+	Source     string
+	Configured int
+}
+
+const (
+	hostSourceFlag           = "flag"
+	hostSourceEnv            = "env"
+	hostSourcePersisted      = "persisted"
+	hostSourceCodegenDefault = "codegen-default"
+	hostSourceUnique         = "unique"
+)
+
+// ResolveHostWithSource returns the hostname selected for cmd plus its
+// resolution source, for status and dry-run provenance.
+func ResolveHostWithSource(cmd *cobra.Command) (HostResolution, error) {
 	return resolveHost(cmd, "")
 }
 
-func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
+func resolveHost(cmd *cobra.Command, defaultHostname string) (HostResolution, error) {
 	cli := config.Active().CLI
-	h, _ := cmd.Root().PersistentFlags().GetString("hostname")
-	if h == "" {
-		h = os.Getenv(cli.HostEnv)
+	if h, _ := cmd.Root().PersistentFlags().GetString("hostname"); h != "" {
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: hostSourceFlag}, nil
 	}
-	if h != "" {
-		return config.NormalizeHostname(h), nil
-	}
-	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
-		return defaultHostname, nil
+	if h := os.Getenv(cli.HostEnv); h != "" {
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: hostSourceEnv}, nil
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", err
+		return HostResolution{}, err
+	}
+	configured := len(hosts.Names())
+	if persisted := hosts.Default(); persisted != "" {
+		if _, ok := hosts.Get(persisted); ok {
+			return HostResolution{Hostname: persisted, Source: hostSourcePersisted, Configured: configured}, nil
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning: persisted default host %q is not configured; clearing it\n", persisted)
+		_ = config.MutateHosts(cmd.Context(), func(h *config.Hosts) error {
+			if h.Default() == persisted {
+				h.ClearDefault()
+			}
+			return nil
+		})
+	}
+	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
+		return HostResolution{Hostname: defaultHostname, Source: hostSourceCodegenDefault, Configured: configured}, nil
 	}
 	names := hosts.Names()
 	switch len(names) {
 	case 0:
-		return "", NewNotAuthenticatedError()
+		return HostResolution{}, NewNotAuthenticatedError()
 	case 1:
-		return names[0], nil
+		return HostResolution{Hostname: names[0], Source: hostSourceUnique, Configured: 1}, nil
 	default:
-		return "", fmt.Errorf("multiple hosts configured (%v); specify --hostname or $%s", names, cli.HostEnv)
+		return HostResolution{Configured: len(names)}, NewError(
+			CodeGeneral,
+			ExitGeneral,
+			fmt.Sprintf("multiple hosts configured (%s)", strings.Join(names, ", ")),
+			fmt.Sprintf("specify --hostname or $%s, or run `%s host default set <host>`", cli.HostEnv, cli.Name),
+			nil,
+		)
 	}
+}
+
+// noticeImplicitHost announces the selected host when it was chosen
+// implicitly (persisted / codegen default / unique) and a wrong-host choice
+// is possible because more than one host is configured.
+func noticeImplicitHost(w io.Writer, res HostResolution) {
+	if w == nil || res.Hostname == "" || res.Configured <= 1 {
+		return
+	}
+	var label string
+	switch res.Source {
+	case hostSourcePersisted:
+		label = "persisted default"
+	case hostSourceCodegenDefault:
+		label = "codegen default"
+	case hostSourceUnique:
+		label = "unique host"
+	default:
+		return
+	}
+	fmt.Fprintf(w, "host: %s (%s)\n", res.Hostname, label)
 }
 
 // LoadHostOptions resolves hostname and client options (including auth) for
@@ -59,96 +123,98 @@ func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
 // insecure when set; otherwise the host record's persisted Insecure value
 // applies.
 func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return loadHostOptions(cmd, "")
+	res, opts, err := loadHostOptions(cmd, "")
+	return res.Hostname, opts, err
 }
 
-func loadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+func loadHostOptions(cmd *cobra.Command, defaultHostname string) (HostResolution, ClientOptions, error) {
 	return loadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
 }
 
-func loadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
+func loadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
+	res, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
-	e, ok := hosts.Get(hostname)
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
-		return "", ClientOptions{}, notAuthenticatedToHost(hostname)
+		return HostResolution{}, ClientOptions{}, notAuthenticatedToHost(res.Hostname)
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		e, err = refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure)
+		e, err = refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure)
 		if err != nil {
-			return "", ClientOptions{}, err
+			return HostResolution{}, ClientOptions{}, err
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func TryLoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return tryLoadHostOptions(cmd, "")
+	res, opts, err := tryLoadHostOptions(cmd, "")
+	return res.Hostname, opts, err
 }
 
-func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
+func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (HostResolution, ClientOptions, error) {
 	return tryLoadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
 }
 
-func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
+func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
+	res, err := resolveHost(cmd, defaultHostname)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return res, ClientOptions{}, nil
 	}
-	e, ok := hosts.Get(hostname)
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
 		opts := ClientOptions{}
 		if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 			opts.Insecure = true
 		}
-		return hostname, opts, nil
+		return res, opts, nil
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure); err == nil {
+		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure); err == nil {
 			e = refreshed
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return res, ClientOptions{}, nil
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func notAuthenticatedToHost(string) error {

--- a/pkg/runtime/ctx_test.go
+++ b/pkg/runtime/ctx_test.go
@@ -113,12 +113,15 @@ func TestLoadHostOptionsRefreshesExpiredOAuthToken(t *testing.T) {
 	root.PersistentFlags().String("hostname", srv.URL, "")
 	root.PersistentFlags().Bool("insecure", false, "")
 
-	hostname, opts, err := loadHostOptions(root, "")
+	res, opts, err := loadHostOptions(root, "")
 	if err != nil {
 		t.Fatalf("loadHostOptions: %v", err)
 	}
-	if hostname != config.NormalizeHostname(srv.URL) {
-		t.Fatalf("hostname = %q", hostname)
+	if res.Hostname != config.NormalizeHostname(srv.URL) {
+		t.Fatalf("hostname = %q", res.Hostname)
+	}
+	if res.Source != hostSourceFlag {
+		t.Fatalf("source = %q, want %q", res.Source, hostSourceFlag)
 	}
 	auth, ok := opts.Auth.(BearerAuth)
 	if !ok || auth.Token != "access-new" {

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -15,10 +15,15 @@ type debugTransport struct {
 	inner                http.RoundTripper
 	sensitiveQueryParams map[string]bool
 	streaming            bool
+	hostname             string
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
+	if d.hostname != "" {
+		fmt.Fprintf(os.Stderr, "> %s request host=%s\n\n", req.Method, d.hostname)
+	} else {
+		fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
+	}
 
 	start := time.Now()
 	resp, err := d.inner.RoundTrip(req)

--- a/pkg/runtime/debug_test.go
+++ b/pkg/runtime/debug_test.go
@@ -151,3 +151,24 @@ func TestDebugTransport_DoesNotPeekStreamingResponse(t *testing.T) {
 		t.Fatalf("debug output unexpectedly dumped streaming body:\n%s", out)
 	}
 }
+
+func TestDebugTransport_LogsResolvedHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	r := captureStderr(t)
+	dt := &debugTransport{inner: http.DefaultTransport, hostname: "staging.example.com"}
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", srv.URL, nil)
+	resp, err := dt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	out := readStderr(t, r)
+	if !strings.Contains(out, "> POST request host=staging.example.com") {
+		t.Fatalf("debug dump missing resolved host:\n%s", out)
+	}
+}

--- a/pkg/runtime/host_resolution_test.go
+++ b/pkg/runtime/host_resolution_test.go
@@ -1,0 +1,201 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func hostResolutionRoot(t *testing.T) *cobra.Command {
+	t.Helper()
+	bindTestManifest(t, "demo", "DEMO_HOST")
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	t.Setenv("DEMO_HOST", "")
+	root := &cobra.Command{Use: "demo"}
+	root.SetContext(context.Background())
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	return root
+}
+
+func saveHosts(t *testing.T, defaultHost string, names ...string) {
+	t.Helper()
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	for _, name := range names {
+		hosts.Set(name, config.HostEntry{AuthType: "bearer", OAuthToken: "tok"})
+	}
+	if defaultHost != "" {
+		hosts.SetDefault(defaultHost)
+	}
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func TestResolveHostOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		flag       string
+		env        string
+		persisted  string
+		hosts      []string
+		codegen    string
+		wantHost   string
+		wantSource string
+		wantErr    string
+	}{
+		{"flag beats env persisted codegen", "flag.example.com", "env.example.com", "staging.example.com", []string{"prod.example.com", "staging.example.com"}, "codegen.example.com", "flag.example.com", hostSourceFlag, ""},
+		{"env beats persisted codegen", "", "env.example.com", "staging.example.com", []string{"prod.example.com", "staging.example.com"}, "codegen.example.com", "env.example.com", hostSourceEnv, ""},
+		{"persisted beats codegen", "", "", "staging.example.com", []string{"prod.example.com", "staging.example.com"}, "codegen.example.com", "staging.example.com", hostSourcePersisted, ""},
+		{"codegen beats unique and multi-host error", "", "", "", []string{"a.example.com", "b.example.com"}, "codegen.example.com", "codegen.example.com", hostSourceCodegenDefault, ""},
+		{"unique host", "", "", "", []string{"only.example.com"}, "", "only.example.com", hostSourceUnique, ""},
+		{"multi-host error points at host default set", "", "", "", []string{"a.example.com", "b.example.com"}, "", "", "", "multiple hosts configured"},
+		{"no hosts is not authenticated", "", "", "", nil, "", "", "", "not logged in"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := hostResolutionRoot(t)
+			saveHosts(t, tt.persisted, tt.hosts...)
+			if tt.flag != "" {
+				if err := root.PersistentFlags().Set("hostname", tt.flag); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.env != "" {
+				t.Setenv("DEMO_HOST", tt.env)
+			}
+			res, err := resolveHost(root, tt.codegen)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Hostname != tt.wantHost || res.Source != tt.wantSource {
+				t.Fatalf("got %+v, want %q via %q", res, tt.wantHost, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestResolveHostMultiHostErrorIsActionable(t *testing.T) {
+	root := hostResolutionRoot(t)
+	saveHosts(t, "", "a.example.com", "b.example.com")
+
+	_, err := resolveHost(root, "")
+	if err == nil {
+		t.Fatal("expected multi-host error")
+	}
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("multi-host error must be structured so the guidance survives rendering, got %T", err)
+	}
+	if le.Code != CodeGeneral || le.ExitCode != ExitGeneral {
+		t.Fatalf("code = %q exit = %d, want %q/%d (unchanged from today)", le.Code, le.ExitCode, CodeGeneral, ExitGeneral)
+	}
+	if !strings.Contains(le.Message, "a.example.com") || !strings.Contains(le.Message, "b.example.com") {
+		t.Fatalf("message must list configured hosts: %q", le.Message)
+	}
+	if !strings.Contains(le.Hint, "host default set") || !strings.Contains(le.Hint, "DEMO_HOST") {
+		t.Fatalf("hint = %q", le.Hint)
+	}
+}
+
+func TestResolveHostStalePersistedDefault(t *testing.T) {
+	root := hostResolutionRoot(t)
+	saveHosts(t, "gone.example.com", "prod.example.com")
+
+	stderr := captureStderr(t)
+	res, err := resolveHost(root, "codegen.example.com")
+	out := readStderr(t, stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Hostname != "codegen.example.com" || res.Source != hostSourceCodegenDefault {
+		t.Fatalf("stale default must fall through, got %+v", res)
+	}
+	if !strings.Contains(out, `warning: persisted default host "gone.example.com" is not configured; clearing it`) {
+		t.Fatalf("missing stale warning:\n%s", out)
+	}
+	reloaded, err := config.LoadHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.Default() != "" {
+		t.Fatalf("stale default not cleared: %q", reloaded.Default())
+	}
+}
+
+func TestResolveHostStaleDefaultDoesNotPickSubstitute(t *testing.T) {
+	root := hostResolutionRoot(t)
+	saveHosts(t, "gone.example.com", "a.example.com", "b.example.com")
+
+	stderr := captureStderr(t)
+	res, err := resolveHost(root, "")
+	_ = readStderr(t, stderr)
+	if err == nil {
+		t.Fatalf("expected multi-host error, got %+v", res)
+	}
+	if res.Hostname != "" {
+		t.Fatalf("must not pick a substitute host, got %q", res.Hostname)
+	}
+	if !strings.Contains(err.Error(), "multiple hosts configured") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestNoticeImplicitHost(t *testing.T) {
+	tests := []struct {
+		name string
+		res  HostResolution
+		want string
+	}{
+		{"persisted with multiple hosts", HostResolution{Hostname: "staging.example.com", Source: hostSourcePersisted, Configured: 2}, "host: staging.example.com (persisted default)"},
+		{"codegen default with multiple hosts", HostResolution{Hostname: "codegen.example.com", Source: hostSourceCodegenDefault, Configured: 2}, "host: codegen.example.com (codegen default)"},
+		{"unique single host is silent", HostResolution{Hostname: "only.example.com", Source: hostSourceUnique, Configured: 1}, ""},
+		{"explicit flag is silent", HostResolution{Hostname: "flag.example.com", Source: hostSourceFlag, Configured: 2}, ""},
+		{"explicit env is silent", HostResolution{Hostname: "env.example.com", Source: hostSourceEnv, Configured: 2}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			noticeImplicitHost(&buf, tt.res)
+			if tt.want == "" {
+				if buf.Len() != 0 {
+					t.Fatalf("notice = %q, want silent", buf.String())
+				}
+				return
+			}
+			if !strings.Contains(buf.String(), tt.want) {
+				t.Fatalf("notice = %q, want %q", buf.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestWriteDryRunIncludesHostProvenance(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeDryRun(DryRunRequest{
+		Method:     "GET",
+		URL:        "https://example.com/x",
+		Hostname:   "example.com",
+		HostSource: hostSourcePersisted,
+	}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), `"hostname": "example.com"`) || !strings.Contains(buf.String(), `"host_source": "persisted"`) {
+		t.Fatalf("dry-run JSON missing provenance:\n%s", buf.String())
+	}
+}

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -21,6 +21,7 @@ type OperationInput struct {
 
 type OperationOptions struct {
 	Hostname    string
+	HostSource  string
 	Client      ClientOptions
 	DryRun      bool
 	PaginateAll bool
@@ -40,12 +41,14 @@ const (
 )
 
 type DryRunRequest struct {
-	Method  string            `json:"method"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Body    any               `json:"body"`
-	Auth    DryRunAuth        `json:"auth"`
-	Output  CatalogOutput     `json:"output"`
+	Method     string            `json:"method"`
+	URL        string            `json:"url"`
+	Hostname   string            `json:"hostname,omitempty"`
+	HostSource string            `json:"host_source,omitempty"`
+	Headers    map[string]string `json:"headers"`
+	Body       any               `json:"body"`
+	Auth       DryRunAuth        `json:"auth"`
+	Output     CatalogOutput     `json:"output"`
 }
 
 type DryRunAuth struct {
@@ -69,7 +72,7 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		return OperationResult{}, err
 	}
 	if opts.DryRun {
-		out, err := buildDryRunRequest(ctx, s, opts.Hostname, path, body, clientOpts)
+		out, err := buildDryRunRequest(ctx, s, opts.Hostname, opts.HostSource, path, body, clientOpts)
 		if err != nil {
 			return OperationResult{}, err
 		}
@@ -290,17 +293,19 @@ func hasFormDataParams(params []ParamSpec) bool {
 	return false
 }
 
-func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path string, body any, opts ClientOptions) (DryRunRequest, error) {
+func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, hostSource, path string, body any, opts ClientOptions) (DryRunRequest, error) {
 	req, bodyBytes, _, err := resolveRequest(ctx, hostname, s.Method, path, body, opts)
 	if err != nil {
 		return DryRunRequest{}, err
 	}
 	return DryRunRequest{
-		Method:  req.Method,
-		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams),
-		Headers: redactedDryRunHeaders(req.Header),
-		Body:    redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
-		Auth:    dryRunAuthForSpec(s),
+		Method:     req.Method,
+		URL:        redactDebugURL(req.URL, opts.sensitiveQueryParams),
+		Hostname:   hostname,
+		HostSource: hostSource,
+		Headers:    redactedDryRunHeaders(req.Header),
+		Body:       redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
+		Auth:       dryRunAuthForSpec(s),
 		Output: CatalogOutput{
 			ListPath:          s.Output.ListPath,
 			DefaultColumns:    append([]string(nil), s.Output.DefaultColumns...),

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -167,24 +167,27 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 			return fail(UsageError(cmd, err))
 		}
 
-		var hostname string
+		var res HostResolution
 		var clientOpts ClientOptions
 		if step.Operation.Security != nil && step.Operation.Security.Public {
-			hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			res, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		} else {
-			hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			res, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
 		}
 		if err != nil {
 			return fail(err)
 		}
+		noticeImplicitHost(cmd.ErrOrStderr(), res)
 		if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 			clientOpts.Debug = true
 		}
 		clientOpts.UserAgent = cmd.Root().Use
+		clientOpts.Hostname = res.Hostname
 
 		opResult, err := InvokeOperation(cmd.Context(), step.Operation, input, OperationOptions{
-			Hostname: hostname,
-			Client:   clientOpts,
+			Hostname:   res.Hostname,
+			HostSource: res.Source,
+			Client:     clientOpts,
 		})
 		if err != nil {
 			return fail(err)


### PR DESCRIPTION
## Summary

Implements #125. Alternative implementation to #158 with a smaller diff (1007 vs 1606 changed lines) and three correctness differences called out below.

A non-secret `default` key in `hosts.yml` (0600, never a credential) records the elected host. Resolution order: `--hostname` > `$<CLI>_HOST` > persisted default > codegen `default_hostname` > unique configured host > error.

- Commands: `host default` / `host default set <host>` / `host default unset`
- `auth login` elects the new host only when no default is set (first-login-wins); later logins never override
- Stale persisted default: stderr warning + clear + fall through; never picks a substitute
- Implicit selection (persisted / codegen default / unique) prints a stderr host notice when more than one host is configured; explicit `--hostname`/`$<CLI>_HOST` stays silent
- `auth status --json`, dry-run JSON (`hostname` / `host_source`), and the debug dump (`host=`) expose the resolved host and its source
- Docs: architecture invariant 7, cli-usage, contracts, generated Skill guidance

## Differences from #158

1. **Multi-host error is actually visible.** The base `ClassifyError` (`pkg/runtime/errors.go:125`) renders any plain error as `command failed / check local configuration and retry` and hides the prose (asserted in `errors_test.go`). #158 updated the error text, but users would never see it. Here the error is a structured `LatheError` with a visible message and hint (see the rendered example at the bottom). The code/exit stay `general`/1, so the only rendered-behavior change is the one the issue requests.
2. **`host` added to `reservedRootCommands`.** Without this, a module named `host` passes codegen validation but fails runtime mounting, and the whole generated CLI exits with `generated CLI failed to start` on every invocation.
3. **Corrupt `hosts.yml` still fails to parse.** Loading via `map[string]yaml.Node` preserves the old loud parse error for a non-mapping top level instead of silently loading zero credentials.

## Verification

- `make check` (gofmt, go vet, golangci-lint, `go test ./...`) on the final diff
- `go test -race ./pkg/config/ ./pkg/runtime/ ./internal/auth/ ./pkg/lathe/ ./internal/codegen/render/`
- End-to-end smoke with a regenerated petstore example: first-login election, later-login non-override, `host default` show/set/unset, `auth status --json` provenance, dry-run `hostname`/`host_source`, implicit-host stderr notice, env override, stale-default clear + fall-through, debug `host=` line, multi-host error rendering (exit 1), unknown-host `host default set` (exit 2)

## User-visible wording (for review)

- `✓ Set %s as the default host (no default was set)` — login election, stderr
- `No default host is set` — `host default` when unset, stdout
- `✓ Default host set to %s` / `✓ Default host unset` — stderr
- `warning: persisted default host %q is not configured; clearing it` — stderr
- `host: %s (persisted default|codegen default|unique host)` — implicit notice, stderr
- `Current host: %s (%s)` / `Default host: %s` — `auth status` text header

Rendered errors, as shown in the smoke run:

```text
Error: multiple hosts configured (prod.example.com, staging.example.com)
Hint: specify --hostname or $PETSTORE_HOST, or run `petstore host default set <host>`

Error: host "missing.example.com" is not logged in
Hint: run `petstore auth login --hostname missing.example.com` or choose from: prod.example.com, staging.example.com
```

Closes #125
