### PR TITLE
feat(runtime): add a persistent host selection to generated CLIs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,8 +157,10 @@ but it is outside Lathe's generated capability contract.
    syntax or file locations.
 6. Generated output is static Go and Skill data. Building or running a generated
    CLI does not invoke codegen or require spec tooling.
-7. Host selection is per invocation. Active account contexts are stored under a
-   selected host; they do not create an ambient global host.
+7. Host selection is per invocation. An operator may mark one host in
+   `hosts.yml` as selected; the mark is overridable per invocation and the
+   resolved host is always reportable with its source. Active account contexts
+   are stored under a selected host.
 8. API commands, workflow steps, catalog entries, generated Skills, and verify
    checks must describe the same compiled command surface.
 9. Generated files are outputs. Change specs, `cli.yaml`, or overlays, then

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -113,6 +113,21 @@ rejects an empty field, or checks the raw response body when no field is set.
 With neither an assertion nor display paths, any successful response is
 accepted, including non-JSON.
 
+### Host Selection
+
+Host resolution order is `--hostname`, `$ACMECTL_HOST`, the selected host,
+`http.default_hostname`, then the single logged-in host. With several hosts and
+none of the above, the command fails and lists them.
+
+```sh
+bin/acmectl auth use api.acme.com
+```
+
+`auth use` marks the host `selected: true` in `hosts.yml`, as does the first
+`auth login`. When the host is chosen implicitly and more than one is logged
+in, the CLI prints `current host: <name>` on stderr; explicit selection is
+silent.
+
 ### Active Contexts
 
 Account-scoped defaults are opt-in:
@@ -415,7 +430,7 @@ bin/acmectl __lathe verify --json
 bin/acmectl __lathe verify --json
 bin/acmectl search "create user" --json
 bin/acmectl commands show users create --json
-bin/acmectl auth status --hostname api.acme.com
+bin/acmectl auth status -o json
 bin/acmectl users create --set email=alice@example.com --dry-run
 bin/acmectl users create --set email=alice@example.com -o json
 ```

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -30,8 +30,8 @@ the contract from the running CLI:
 
 `commands schema --json` reports `catalog_schema_version`, the committed
 `surfaces`, and `dry_run.result`. `dry_run.result=http_preview` means a
-preview prints the resolved HTTP request JSON (`method`, `url`, `headers`,
-`body`, `auth`, `output`).
+preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`,
+`host_source`, `headers`, `body`, `auth`, `output`).
 
 Catalog entries have two kinds:
 
@@ -88,6 +88,13 @@ errors are excluded.
 | `canceled` | 130 |
 
 A configured stream pause is a successful terminal outcome and exits `0`.
+
+## Host provenance
+
+`auth status -o json` reports `hostname`, `source`, `selected`, and `hosts`;
+dry-run output carries `hostname` and `host_source`. `source` is `flag`, `env`,
+`selected`, `codegen-default`, or `unique`. The stderr `current host` notice is
+for operators, not a machine contract.
 
 ## Durable inputs
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -32,7 +32,7 @@ func NewCommand(m *config.Manifest) *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(newLogin(m), newStatus(), newLogout())
+	cmd.AddCommand(newLogin(m), newStatus(), newLogout(), newUse())
 	if len(m.Contexts) > 0 {
 		cmd.AddCommand(newContextCommand(m))
 	}
@@ -466,6 +466,7 @@ func newLogin(m *config.Manifest) *cobra.Command {
 				}
 			}
 
+			elected := false
 			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
 				current, _ := hosts.Get(hostname)
 				contexts := maps.Clone(current.Contexts)
@@ -476,12 +477,20 @@ func newLogin(m *config.Manifest) *cobra.Command {
 					contexts[name] = value
 				}
 				entry.Contexts = contexts
+				entry.Selected = current.Selected
 				hosts.Set(hostname, entry)
+				if hosts.Selected() == "" {
+					hosts.Select(hostname)
+					elected = true
+				}
 				return nil
 			}); err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "✓ Logged in to %s\n", hostname)
+			fmt.Fprintf(cmd.ErrOrStderr(), "✓ Logged in to %s\n", hostname)
+			if elected {
+				fmt.Fprintf(cmd.ErrOrStderr(), "✓ Now using %s\n", hostname)
+			}
 			return nil
 		},
 	}
@@ -498,12 +507,28 @@ func newLogin(m *config.Manifest) *cobra.Command {
 	return cmd
 }
 
+type authStatus struct {
+	Hostname string           `json:"hostname,omitempty"`
+	Source   string           `json:"source,omitempty"`
+	Selected string           `json:"selected,omitempty"`
+	Hosts    []authStatusHost `json:"hosts"`
+}
+
+type authStatusHost struct {
+	Hostname string `json:"hostname"`
+	User     string `json:"user,omitempty"`
+	Auth     string `json:"auth"`
+}
+
 func newStatus() *cobra.Command {
 	return &cobra.Command{
 		Use:   "status",
 		Short: "View authentication status",
 		Args:  runtime.UsageArgs(cobra.NoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateContextOutput(cmd); err != nil {
+				return err
+			}
 			hostname := rootString(cmd, "hostname")
 			hosts, err := config.LoadHosts()
 			if err != nil {
@@ -514,16 +539,35 @@ func newStatus() *cobra.Command {
 				return runtime.NewNotAuthenticatedError()
 			}
 			if hostname != "" {
-				e, ok := hosts.Get(hostname)
-				if !ok {
+				if _, ok := hosts.Get(hostname); !ok {
 					return runtime.NewNotAuthenticatedError()
 				}
-				printStatus(hostname, e)
-				return nil
+				names = []string{config.NormalizeHostname(hostname)}
+			}
+			res, _ := runtime.ResolveHostWithSource(cmd)
+			selected := hosts.Selected()
+
+			out := authStatus{
+				Hostname: res.Hostname,
+				Source:   res.Source,
+				Selected: selected,
+				Hosts:    make([]authStatusHost, 0, len(names)),
 			}
 			for _, n := range names {
 				e, _ := hosts.Get(n)
-				printStatus(n, e)
+				out.Hosts = append(out.Hosts, authStatusHost{Hostname: n, User: e.User, Auth: authTypeLabel(e)})
+			}
+
+			if format := rootString(cmd, "output"); format == "json" || format == "yaml" {
+				return writeContextOutput(cmd, out, runtime.OutputHints{
+					ListPath:       "hosts",
+					DefaultColumns: []string{"hostname", "user", "auth"},
+				})
+			}
+			w := cmd.OutOrStdout()
+			for _, n := range names {
+				e, _ := hosts.Get(n)
+				printStatus(w, n, e, n == selected)
 			}
 			return nil
 		},
@@ -563,7 +607,7 @@ func newLogout() *cobra.Command {
 			}); err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "✓ Logged out of %s\n", hostname)
+			fmt.Fprintf(cmd.ErrOrStderr(), "✓ Logged out of %s\n", hostname)
 			return nil
 		},
 	}
@@ -749,23 +793,30 @@ func validateContextOutput(cmd *cobra.Command) error {
 	}
 }
 
-func printStatus(hostname string, e config.HostEntry) {
+func authTypeLabel(e config.HostEntry) string {
+	if e.AuthType == "" {
+		return "bearer"
+	}
+	return e.AuthType
+}
+
+func printStatus(w io.Writer, hostname string, e config.HostEntry, selected bool) {
 	user := e.User
 	if user == "" {
 		user = fmt.Sprintf("(unknown — run `%s auth login` to validate)", config.Active().CLI.Name)
 	}
-	authLabel := e.AuthType
-	if authLabel == "" {
-		authLabel = "bearer"
+	marker := ""
+	if selected {
+		marker = " (selected)"
 	}
 	credential := maskedCredential(e)
-	fmt.Fprintf(os.Stdout, "%s\n  ✓ Logged in as %s\n  ✓ Auth: %s\n  ✓ Credential: %s\n", hostname, user, authLabel, credential)
+	fmt.Fprintf(w, "%s%s\n  ✓ Logged in as %s\n  ✓ Auth: %s\n  ✓ Credential: %s\n", hostname, marker, user, authTypeLabel(e), credential)
 	if e.LoginType != "" {
 		loginLabel := e.LoginType
 		if e.LoginProvider != "" {
 			loginLabel += " (" + e.LoginProvider + ")"
 		}
-		fmt.Fprintf(os.Stdout, "  ✓ Login: %s\n", loginLabel)
+		fmt.Fprintf(w, "  ✓ Login: %s\n", loginLabel)
 	}
 }
 

--- a/internal/auth/use.go
+++ b/internal/auth/use.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+func newUse() *cobra.Command {
+	return &cobra.Command{
+		Use:   "use <host>",
+		Short: "Select the host later commands use by default",
+		Long: "Select the host later commands use by default.\n\n" +
+			"The selection is recorded against the logged-in host and is always overridden\n" +
+			"by --hostname or the host environment variable. Logging out of the selected\n" +
+			"host releases it.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				return nil
+			}
+			return runtime.NewError(runtime.CodeUsage, runtime.ExitUsage,
+				"host is required",
+				fmt.Sprintf("run `%s <host>`", cmd.CommandPath()),
+				nil)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hostname := config.NormalizeHostname(args[0])
+			if hostname == "" {
+				return runtime.UsageError(cmd, fmt.Errorf("host is required"))
+			}
+			if err := config.MutateHosts(cmd.Context(), func(hosts *config.Hosts) error {
+				if _, ok := hosts.Get(hostname); !ok {
+					names := hosts.Names()
+					if len(names) == 0 {
+						return runtime.NewNotAuthenticatedError()
+					}
+					cli := config.Active().CLI.Name
+					return runtime.NewError(runtime.CodeUsage, runtime.ExitUsage,
+						fmt.Sprintf("host %q is not logged in", hostname),
+						fmt.Sprintf("run `%s auth login --hostname %s`, or choose from: %s", cli, hostname, strings.Join(names, ", ")),
+						nil)
+				}
+				hosts.Select(hostname)
+				return nil
+			}); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "✓ Now using %s\n", hostname)
+			return nil
+		},
+	}
+}

--- a/internal/auth/use_test.go
+++ b/internal/auth/use_test.go
@@ -1,0 +1,119 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func newAuthRoot(m *config.Manifest, hostname string) *cobra.Command {
+	root := &cobra.Command{Use: "demo"}
+	root.SetContext(context.Background())
+	root.PersistentFlags().String("hostname", hostname, "")
+	root.PersistentFlags().String("output", "table", "")
+	root.PersistentFlags().Bool("insecure", false, "")
+	root.AddCommand(NewCommand(m))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	return root
+}
+
+func selectedHost(t *testing.T) string {
+	t.Helper()
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	return hosts.Selected()
+}
+
+func TestFirstLoginSelectsTheHostAndLaterOnesDoNot(t *testing.T) {
+	m := &config.Manifest{
+		CLI:  config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"},
+		Auth: config.AuthInfo{DefaultType: "apikey", APIKeyHeader: "X-Auth-Token"},
+	}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+
+	login := func(hostname string) string {
+		t.Helper()
+		stdin, input, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := input.WriteString("secret\n"); err != nil {
+			t.Fatal(err)
+		}
+		if err := input.Close(); err != nil {
+			t.Fatal(err)
+		}
+		oldStdin := os.Stdin
+		os.Stdin = stdin
+		defer func() {
+			_ = stdin.Close()
+			os.Stdin = oldStdin
+		}()
+
+		root := newAuthRoot(m, hostname)
+		var stderr bytes.Buffer
+		root.SetErr(&stderr)
+		root.SetArgs([]string{"auth", "login", "--with-token"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("login %s: %v", hostname, err)
+		}
+		return stderr.String()
+	}
+
+	if out := login("first.example.com"); !strings.Contains(out, "Now using first.example.com") {
+		t.Fatalf("stderr = %q, want the first login to announce the selection", out)
+	}
+	if got := selectedHost(t); got != "first.example.com" {
+		t.Fatalf("selected = %q, want the first login", got)
+	}
+	login("second.example.com")
+	if got := selectedHost(t); got != "first.example.com" {
+		t.Fatalf("selected = %q, want the first login to stand", got)
+	}
+	if out := login("first.example.com"); strings.Contains(out, "Now using") {
+		t.Fatalf("stderr = %q, want a re-login not to re-elect", out)
+	}
+
+	root := newAuthRoot(m, "")
+	root.SetArgs([]string{"auth", "use", "https://second.example.com"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("auth use: %v", err)
+	}
+	if got := selectedHost(t); got != "second.example.com" {
+		t.Errorf("selected = %q, want the explicit switch", got)
+	}
+}
+
+func TestAuthUseRejectsAHostThatIsNotLoggedIn(t *testing.T) {
+	m := &config.Manifest{CLI: config.CLIInfo{Name: "demo", ConfigDir: "demo", ConfigDirEnv: "DEMO_CONFIG_DIR", HostEnv: "DEMO_HOST"}}
+	config.Bind(m)
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	hosts.Set("a.example.com", config.HostEntry{AuthType: "bearer"})
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	root := newAuthRoot(m, "")
+	root.SetArgs([]string{"auth", "use", "missing.example.com"})
+	err = root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not logged in") {
+		t.Fatalf("err = %v, want a not-logged-in refusal", err)
+	}
+	if got := selectedHost(t); got != "" {
+		t.Errorf("selected = %q, want the selection untouched", got)
+	}
+}

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -494,7 +494,7 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	b.WriteString("## Workflow\n\n")
 	fmt.Fprintf(&b, "1. Search for candidates with `%s search \"<intent>\" --json`; use `--limit` when needed. Search is only candidate discovery.\n", cli)
 	fmt.Fprintf(&b, "2. Inspect the exact command with `%s commands show <path...> --json` before executing an unfamiliar command.\n", cli)
-	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "3. If the command detail has `auth.required=true`, run `%s auth status -o json` before execution and read `hostname` and `source`. Host resolution order: `--hostname` > `$%s` > the selected host (`%s auth use <host>`) > `http.default_hostname` > the single host in `hosts.yml`. If none applies, stop and ask the user to authenticate or select a host.\n", cli, manifest.CLI.HostEnv, cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "4. If a flag has `context`, inspect `%s auth context status -o json`. Explicit flags override the declared environment variable, which overrides the value stored for the selected host.\n", cli)
 		b.WriteString("5. Execute only after flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints are clear from `commands show`. When `mutation` is not `read`, preview with `--<dry_run.flag>` if `dry_run.mode` is `http_preview`; if preview is unavailable, obtain explicit user confirmation before execution.\n\n")
@@ -511,7 +511,8 @@ func renderSkillMD(manifest *config.Manifest, refs []moduleRef) string {
 	fmt.Fprintf(&b, "- `%s commands --include-hidden --json`: include hidden generated commands.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands show <path...> --json`: source of truth for one command.\n", cli)
 	fmt.Fprintf(&b, "- `%s commands schema --json`: catalog schema version, surfaces, and dry-run result shape.\n", cli)
-	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n\n", cli)
+	fmt.Fprintf(&b, "- `%s search \"<intent>\" --json`: ranked candidate commands.\n", cli)
+	fmt.Fprintf(&b, "- `%s auth status -o json`: resolved `hostname`, its `source`, the `selected` host, and every logged-in host.\n\n", cli)
 	if len(manifest.Contexts) > 0 {
 		fmt.Fprintf(&b, "- `%s auth context status -o json`: effective account-scoped context values for the selected host.\n\n", cli)
 	}
@@ -563,7 +564,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("- `path`: command path to pass to `commands show` or execute after the CLI name.\n")
 	b.WriteString("- `shortcuts`: root-level commands that execute the same operation with preset flag values.\n")
 	b.WriteString("- `http`: HTTP method and path template.\n")
-	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host selected after explicit `--hostname` and `$%s`; when present it is used before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "- `http.default_hostname`: optional source-level host used after `--hostname`, `$%s`, and the host selected with `auth use`, and before the single-host fallback from `hosts.yml`.\n", manifest.CLI.HostEnv)
 	b.WriteString("- `flags`: CLI flags, parameter location, type, required state, defaults, enum values, format, input modes, and help.\n")
 	b.WriteString("- `body`: request body requirement, media type, and optional `runtime_schema` preflight source, including its active-context prerequisites.\n")
 	b.WriteString("- `auth`: whether auth is required and which scopes are declared.\n")
@@ -577,7 +578,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("## Command Detail\n\n")
 	fmt.Fprintf(&b, "Run `%s commands show <path...> --json` before executing an unfamiliar command. This is the source of truth for flags, body, auth, HTTP path, `mutation`, `dry_run`, and output hints.\n\n", cli)
 	b.WriteString("## Schema\n\n")
-	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `headers`, `body`, `auth`, `output`).\n\n", cli)
+	fmt.Fprintf(&b, "Run `%s commands schema --json` to read `catalog_schema_version`, `surfaces`, and `dry_run.result` before parsing catalog JSON with durable tooling. `dry_run.result=http_preview` means a preview prints the resolved HTTP request JSON (`method`, `url`, `hostname`, `host_source`, `headers`, `body`, `auth`, `output`).\n\n", cli)
 	b.WriteString("## Sensitive Flags\n\n")
 	b.WriteString("When a flag entry has `input_modes`, prefer safe modes over putting secrets directly in shell arguments.\n\n")
 	b.WriteString("- `flag`: pass the direct `--<flag>` value; keep this for compatibility or non-secret values.\n")
@@ -595,7 +596,7 @@ func renderCatalogReference(manifest *config.Manifest) string {
 	b.WriteString("Use `-o json` for machine-readable command output. Other supported formats are `table`, `yaml`, and `raw`. For collected streams, choose one mode: JSON or YAML for one document, `--stream` in the default output mode when `output.streaming.policy.live` is present, or raw for wire events.\n\n")
 	b.WriteString("On a non-zero exit with JSON or YAML output, read `error.code`, `error.message`, and `error.hint`; optional `error.http` contains only `status`. A configured pause exits zero and is represented by the field mapping in its stream collection policy.\n\n")
 	b.WriteString("## Auth\n\n")
-	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status --hostname <host>` before execution. Use `http.default_hostname` when present unless the user provides `--hostname` or `$%s`; if no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv)
+	fmt.Fprintf(&b, "If command detail returns `auth.required=true`, run `%s auth status -o json` before execution and read `hostname` and `source`. Host resolution order: `--hostname` > `$%s` > the selected host (`%s auth use <host>`) > `http.default_hostname` > the single host in `hosts.yml`. When more than one host is logged in and the host was chosen implicitly, the CLI also prints a `current host: <name>` line on stderr; read provenance from `auth status`, not from that line. If no matching host is logged in, stop and ask the user to authenticate.\n", cli, manifest.CLI.HostEnv, cli)
 	if manifest.Auth.Login != nil && manifest.Auth.Login.Type == config.AuthLoginOAuthDevice {
 		fmt.Fprintf(&b, "For browser-based OAuth login, run `%s auth login --device-auth --hostname <host> --provider <provider>`. The browser opens by default in an interactive terminal; use `--no-browser` for manual login. `auth_type: bearer` in `hosts.yml` is expected after login because API requests use the issued bearer token.\n", cli)
 	}

--- a/pkg/config/hosts.go
+++ b/pkg/config/hosts.go
@@ -37,6 +37,7 @@ type HostEntry struct {
 	BasicUser         string            `yaml:"basic_user,omitempty"`
 	BasicPassword     string            `yaml:"basic_password,omitempty"`
 	Insecure          bool              `yaml:"insecure,omitempty"`
+	Selected          bool              `yaml:"selected,omitempty"`
 	Contexts          map[string]string `yaml:"contexts,omitempty"`
 }
 
@@ -126,6 +127,23 @@ func (h *Hosts) Names() []string {
 	return out
 }
 
+func (h *Hosts) Selected() string {
+	for _, name := range h.Names() {
+		if h.entries[name].Selected {
+			return name
+		}
+	}
+	return ""
+}
+
+func (h *Hosts) Select(hostname string) {
+	k := NormalizeHostname(hostname)
+	for name, e := range h.entries {
+		e.Selected = name == k
+		h.entries[name] = e
+	}
+}
+
 func (h *Hosts) Save() error {
 	return h.saveAtomic()
 }
@@ -163,15 +181,19 @@ func MutateHosts(ctx context.Context, mutate func(*Hosts) error) error {
 }
 
 func (h *Hosts) saveAtomic() error {
-	dir := filepath.Dir(h.path)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
 	data, err := yaml.Marshal(h.entries)
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(dir, ".hosts-*.tmp")
+	return writeFileAtomic(h.path, data)
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
 	if err != nil {
 		return err
 	}
@@ -192,5 +214,5 @@ func (h *Hosts) saveAtomic() error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	return replaceFile(tmpPath, h.path)
+	return replaceFile(tmpPath, path)
 }

--- a/pkg/config/hosts_test.go
+++ b/pkg/config/hosts_test.go
@@ -11,6 +11,8 @@ func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadHosts: %v", err)
 	}
+	hosts.Set("other.example.com", HostEntry{AuthType: "bearer"})
+	hosts.Select("other.example.com")
 	hosts.Set("https://api.example.com", HostEntry{
 		AuthType:          "bearer",
 		LoginType:         AuthLoginOAuthDevice,
@@ -21,6 +23,7 @@ func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
 		OAuthExpiresAt:    1790000000,
 		Contexts:          map[string]string{"workspace": "ws-1"},
 	})
+	hosts.Select("https://api.example.com")
 	if err := hosts.Save(); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -38,5 +41,8 @@ func TestHostsRoundTripOAuthLoginFields(t *testing.T) {
 	}
 	if entry.Contexts["workspace"] != "ws-1" {
 		t.Fatalf("contexts = %#v", entry.Contexts)
+	}
+	if got := loaded.Selected(); got != "api.example.com" {
+		t.Fatalf("Selected = %q, want the last selection to be the only one", got)
 	}
 }

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -191,16 +191,20 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				return UsageError(cmd, err)
 			}
 
-			var hostname string
+			var host HostResolution
 			var clientOpts ClientOptions
 			refreshAuth := !dryRun
 			if dryRun || (s.Security != nil && s.Security.Public) {
-				hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				host, clientOpts, err = tryLoadHostOptions(cmd, s.DefaultHostname, refreshAuth)
 			} else {
-				hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, s.DefaultHostname, refreshAuth)
+				host, clientOpts, err = loadHostOptions(cmd, s.DefaultHostname, refreshAuth)
 			}
 			if err != nil {
 				return err
+			}
+			if !dryRun {
+				var reporter hostReporter
+				reporter.noticeImplicitHost(cmd.ErrOrStderr(), host)
 			}
 
 			if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
@@ -215,7 +219,8 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				output.live = cmd.OutOrStdout()
 			}
 			result, err := invokeOperation(cmd.Context(), s, input, OperationOptions{
-				Hostname:    hostname,
+				Hostname:    host.Hostname,
+				HostSource:  host.Source,
 				Client:      clientOpts,
 				DryRun:      dryRun,
 				PaginateAll: paginateAll,

--- a/pkg/runtime/context.go
+++ b/pkg/runtime/context.go
@@ -15,7 +15,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 	if !needsStoredContext(spec, *input) {
 		return resolveOperationContexts(spec, input, "")
 	}
-	hostname, err := resolveHost(cmd, spec.DefaultHostname)
+	res, err := resolveHost(cmd, spec.DefaultHostname)
 	if err != nil {
 		for _, param := range spec.Params {
 			if param.Context != "" && param.Required && contextNeedsStored(param, *input) {
@@ -24,7 +24,7 @@ func resolveCommandContexts(cmd *cobra.Command, spec CommandSpec, input *Operati
 		}
 		return nil
 	}
-	return resolveOperationContexts(spec, input, hostname)
+	return resolveOperationContexts(spec, input, res.Hostname)
 }
 
 func needsStoredContext(spec CommandSpec, input OperationInput) bool {

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -3,7 +3,9 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +18,20 @@ import (
 // NewNotAuthenticatedError using the bound manifest.
 var ErrNotAuthenticated = errors.New("not authenticated")
 
+const (
+	HostSourceFlag           = "flag"
+	HostSourceEnv            = "env"
+	HostSourceSelected       = "selected"
+	HostSourceCodegenDefault = "codegen-default"
+	HostSourceUnique         = "unique"
+)
+
+type HostResolution struct {
+	Hostname  string
+	Source    string
+	Ambiguous bool
+}
+
 // NewNotAuthenticatedError renders the "no host configured" message using
 // the bound manifest and wraps ErrNotAuthenticated so errors.Is still works.
 func NewNotAuthenticatedError() error {
@@ -24,34 +40,75 @@ func NewNotAuthenticatedError() error {
 }
 
 func ResolveHost(cmd *cobra.Command) (string, error) {
+	res, err := resolveHost(cmd, "")
+	return res.Hostname, err
+}
+
+func ResolveHostWithSource(cmd *cobra.Command) (HostResolution, error) {
 	return resolveHost(cmd, "")
 }
 
-func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
-	cli := config.Active().CLI
-	h, _ := cmd.Root().PersistentFlags().GetString("hostname")
-	if h == "" {
-		h = os.Getenv(cli.HostEnv)
-	}
-	if h != "" {
-		return config.NormalizeHostname(h), nil
-	}
-	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
-		return defaultHostname, nil
-	}
+func resolveHost(cmd *cobra.Command, defaultHostname string) (HostResolution, error) {
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", err
+		return HostResolution{}, err
 	}
+	return resolveHostFrom(cmd, hosts, defaultHostname)
+}
+
+func resolveHostFrom(cmd *cobra.Command, hosts *config.Hosts, defaultHostname string) (HostResolution, error) {
+	cli := config.Active().CLI
+	if h, _ := cmd.Root().PersistentFlags().GetString("hostname"); h != "" {
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: HostSourceFlag}, nil
+	}
+	if h := os.Getenv(cli.HostEnv); h != "" {
+		return HostResolution{Hostname: config.NormalizeHostname(h), Source: HostSourceEnv}, nil
+	}
+	return resolveConfiguredHost(hosts, defaultHostname)
+}
+
+func resolveConfiguredHost(hosts *config.Hosts, defaultHostname string) (HostResolution, error) {
 	names := hosts.Names()
+	ambiguous := len(names) > 1
+	if selected := hosts.Selected(); selected != "" {
+		return HostResolution{Hostname: selected, Source: HostSourceSelected, Ambiguous: ambiguous}, nil
+	}
+	if defaultHostname = config.NormalizeHostname(defaultHostname); defaultHostname != "" {
+		return HostResolution{Hostname: defaultHostname, Source: HostSourceCodegenDefault, Ambiguous: ambiguous}, nil
+	}
 	switch len(names) {
 	case 0:
-		return "", NewNotAuthenticatedError()
+		return HostResolution{}, NewNotAuthenticatedError()
 	case 1:
-		return names[0], nil
+		return HostResolution{Hostname: names[0], Source: HostSourceUnique}, nil
 	default:
-		return "", fmt.Errorf("multiple hosts configured (%v); specify --hostname or $%s", names, cli.HostEnv)
+		cli := config.Active().CLI
+		return HostResolution{}, NewError(
+			CodeGeneral,
+			ExitGeneral,
+			fmt.Sprintf("multiple hosts configured (%s)", strings.Join(names, ", ")),
+			fmt.Sprintf("select one with `%s auth use <host>`, or pass --hostname or $%s", cli.Name, cli.HostEnv),
+			nil,
+		)
 	}
+}
+
+type hostReporter struct {
+	noticed map[string]bool
+}
+
+func (r *hostReporter) noticeImplicitHost(w io.Writer, res HostResolution) {
+	if w == nil || !res.Ambiguous || res.Hostname == "" {
+		return
+	}
+	if r.noticed == nil {
+		r.noticed = map[string]bool{}
+	}
+	if r.noticed[res.Hostname] {
+		return
+	}
+	r.noticed[res.Hostname] = true
+	fmt.Fprintf(w, "current host: %s\n", res.Hostname)
 }
 
 // LoadHostOptions resolves hostname and client options (including auth) for
@@ -59,96 +116,90 @@ func resolveHost(cmd *cobra.Command, defaultHostname string) (string, error) {
 // insecure when set; otherwise the host record's persisted Insecure value
 // applies.
 func LoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return loadHostOptions(cmd, "")
+	res, opts, err := loadHostOptions(cmd, "", true)
+	return res.Hostname, opts, err
 }
 
-func loadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
-	return loadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
-}
-
-func loadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
-	if err != nil {
-		return "", ClientOptions{}, err
-	}
+func loadHostOptions(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return "", ClientOptions{}, err
+		return HostResolution{}, ClientOptions{}, err
 	}
-	e, ok := hosts.Get(hostname)
+	res, err := resolveHostFrom(cmd, hosts, defaultHostname)
+	if err != nil {
+		return HostResolution{}, ClientOptions{}, err
+	}
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
-		return "", ClientOptions{}, notAuthenticatedToHost(hostname)
+		return res, ClientOptions{}, notAuthenticatedToHost(res.Hostname)
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		e, err = refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure)
+		e, err = refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure)
 		if err != nil {
-			return "", ClientOptions{}, err
+			return res, ClientOptions{}, err
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return "", ClientOptions{}, err
+		return res, ClientOptions{}, err
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func TryLoadHostOptions(cmd *cobra.Command) (string, ClientOptions, error) {
-	return tryLoadHostOptions(cmd, "")
+	res, opts, err := tryLoadHostOptions(cmd, "", true)
+	return res.Hostname, opts, err
 }
 
-func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string) (string, ClientOptions, error) {
-	return tryLoadHostOptionsMaybeRefresh(cmd, defaultHostname, true)
-}
-
-func tryLoadHostOptionsMaybeRefresh(cmd *cobra.Command, defaultHostname string, refresh bool) (string, ClientOptions, error) {
-	hostname, err := resolveHost(cmd, defaultHostname)
-	if err != nil {
-		return "", ClientOptions{}, err
-	}
+func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string, refresh bool) (HostResolution, ClientOptions, error) {
 	hosts, err := config.LoadHosts()
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return HostResolution{}, ClientOptions{}, err
 	}
-	e, ok := hosts.Get(hostname)
+	res, err := resolveHostFrom(cmd, hosts, defaultHostname)
+	if err != nil {
+		return HostResolution{}, ClientOptions{}, err
+	}
+	e, ok := hosts.Get(res.Hostname)
 	if !ok {
 		opts := ClientOptions{}
 		if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 			opts.Insecure = true
 		}
-		return hostname, opts, nil
+		return res, opts, nil
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
 		insecure = true
 	}
 	if refresh {
-		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), hostname, e, insecure); err == nil {
+		if refreshed, err := refreshHostAuthIfNeeded(cmd.Context(), res.Hostname, e, insecure); err == nil {
 			e = refreshed
 		}
 	}
 	auth, err := NewAuthFromHost(e)
 	if err != nil {
-		return hostname, ClientOptions{}, nil
+		return res, ClientOptions{}, nil
 	}
 	opts := ClientOptions{
 		Auth:     auth,
 		Insecure: insecure,
 	}
 	if refresh && canRefreshHostAuth(e) {
-		opts.RefreshAuth = refreshAuthFunc(hostname, insecure, e.OAuthToken)
+		opts.RefreshAuth = refreshAuthFunc(res.Hostname, insecure, e.OAuthToken)
 	}
-	return hostname, opts, nil
+	return res, opts, nil
 }
 
 func notAuthenticatedToHost(string) error {

--- a/pkg/runtime/ctx_test.go
+++ b/pkg/runtime/ctx_test.go
@@ -113,12 +113,12 @@ func TestLoadHostOptionsRefreshesExpiredOAuthToken(t *testing.T) {
 	root.PersistentFlags().String("hostname", srv.URL, "")
 	root.PersistentFlags().Bool("insecure", false, "")
 
-	hostname, opts, err := loadHostOptions(root, "")
+	host, opts, err := loadHostOptions(root, "", true)
 	if err != nil {
 		t.Fatalf("loadHostOptions: %v", err)
 	}
-	if hostname != config.NormalizeHostname(srv.URL) {
-		t.Fatalf("hostname = %q", hostname)
+	if host.Hostname != config.NormalizeHostname(srv.URL) {
+		t.Fatalf("hostname = %q", host.Hostname)
 	}
 	auth, ok := opts.Auth.(BearerAuth)
 	if !ok || auth.Token != "access-new" {

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -18,7 +18,7 @@ type debugTransport struct {
 }
 
 func (d *debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Fprintf(os.Stderr, "> %s request\n\n", req.Method)
+	fmt.Fprintf(os.Stderr, "> %s request host=%s\n\n", req.Method, req.URL.Host)
 
 	start := time.Now()
 	resp, err := d.inner.RoundTrip(req)

--- a/pkg/runtime/host_resolution_test.go
+++ b/pkg/runtime/host_resolution_test.go
@@ -1,0 +1,115 @@
+package runtime
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func hostsWith(t *testing.T, selected string, names ...string) *config.Hosts {
+	t.Helper()
+	t.Setenv("DEMO_CONFIG_DIR", t.TempDir())
+	hosts, err := config.LoadHosts()
+	if err != nil {
+		t.Fatalf("LoadHosts: %v", err)
+	}
+	for _, n := range names {
+		hosts.Set(n, config.HostEntry{AuthType: "bearer", OAuthToken: "t"})
+	}
+	if selected != "" {
+		hosts.Select(selected)
+	}
+	return hosts
+}
+
+func TestResolveConfiguredHost_Order(t *testing.T) {
+	bindTestManifest(t, "demo", "DEMO_HOST")
+
+	tests := []struct {
+		name           string
+		configured     []string
+		selected       string
+		codegenDefault string
+		wantHost       string
+		wantSource     string
+		wantAmbiguous  bool
+		wantErr        bool
+	}{
+		{
+			name:       "selection wins over codegen default",
+			configured: []string{"a.example.com", "b.example.com"},
+			selected:   "b.example.com", codegenDefault: "a.example.com",
+			wantHost: "b.example.com", wantSource: HostSourceSelected, wantAmbiguous: true,
+		},
+		{
+			name:           "codegen default applies when nothing is selected",
+			configured:     []string{"a.example.com", "b.example.com"},
+			codegenDefault: "a.example.com",
+			wantHost:       "a.example.com", wantSource: HostSourceCodegenDefault, wantAmbiguous: true,
+		},
+		{
+			name:       "single host needs no selection and raises no notice",
+			configured: []string{"a.example.com"},
+			wantHost:   "a.example.com", wantSource: HostSourceUnique,
+		},
+		{
+			name:       "several hosts and nothing to pick is an error",
+			configured: []string{"a.example.com", "b.example.com"},
+			wantErr:    true,
+		},
+		{
+			name:    "no hosts at all is not authenticated",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hosts := hostsWith(t, tt.selected, tt.configured...)
+			res, err := resolveConfiguredHost(hosts, tt.codegenDefault)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if res.Hostname != tt.wantHost {
+				t.Errorf("hostname = %q, want %q", res.Hostname, tt.wantHost)
+			}
+			if !tt.wantErr && res.Source != tt.wantSource {
+				t.Errorf("source = %q, want %q", res.Source, tt.wantSource)
+			}
+			if res.Ambiguous != tt.wantAmbiguous {
+				t.Errorf("ambiguous = %v, want %v", res.Ambiguous, tt.wantAmbiguous)
+			}
+		})
+	}
+}
+
+func TestResolveConfiguredHost_MultipleHostErrorStaysVisible(t *testing.T) {
+	bindTestManifest(t, "demo", "DEMO_HOST")
+	hosts := hostsWith(t, "", "a.example.com", "b.example.com")
+
+	_, err := resolveConfiguredHost(hosts, "")
+	le := ClassifyError(err)
+	if !strings.Contains(le.Message, "a.example.com") || !strings.Contains(le.Message, "b.example.com") {
+		t.Errorf("message = %q, want the configured hosts", le.Message)
+	}
+	if !strings.Contains(le.Hint, "demo auth use") {
+		t.Errorf("hint = %q, want a pointer at `demo auth use`", le.Hint)
+	}
+	if le.ExitCode != ExitGeneral {
+		t.Errorf("exit = %d, want %d", le.ExitCode, ExitGeneral)
+	}
+}
+
+func TestHostReporterNoticesAnAmbiguousHostOnce(t *testing.T) {
+	bindTestManifest(t, "demo", "DEMO_HOST")
+	var buf bytes.Buffer
+	var r hostReporter
+
+	r.noticeImplicitHost(&buf, HostResolution{Hostname: "b.example.com", Source: HostSourceSelected, Ambiguous: true})
+	r.noticeImplicitHost(&buf, HostResolution{Hostname: "b.example.com", Source: HostSourceSelected, Ambiguous: true})
+	if got := buf.String(); got != "current host: b.example.com\n" {
+		t.Errorf("output = %q, want one notice", got)
+	}
+}

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -21,6 +21,7 @@ type OperationInput struct {
 
 type OperationOptions struct {
 	Hostname    string
+	HostSource  string
 	Client      ClientOptions
 	DryRun      bool
 	PaginateAll bool
@@ -40,12 +41,14 @@ const (
 )
 
 type DryRunRequest struct {
-	Method  string            `json:"method"`
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Body    any               `json:"body"`
-	Auth    DryRunAuth        `json:"auth"`
-	Output  CatalogOutput     `json:"output"`
+	Method     string            `json:"method"`
+	URL        string            `json:"url"`
+	Hostname   string            `json:"hostname,omitempty"`
+	HostSource string            `json:"host_source,omitempty"`
+	Headers    map[string]string `json:"headers"`
+	Body       any               `json:"body"`
+	Auth       DryRunAuth        `json:"auth"`
+	Output     CatalogOutput     `json:"output"`
 }
 
 type DryRunAuth struct {
@@ -69,7 +72,7 @@ func invokeOperation(ctx context.Context, s CommandSpec, input OperationInput, o
 		return OperationResult{}, err
 	}
 	if opts.DryRun {
-		out, err := buildDryRunRequest(ctx, s, opts.Hostname, path, body, clientOpts)
+		out, err := buildDryRunRequest(ctx, s, opts.Hostname, opts.HostSource, path, body, clientOpts)
 		if err != nil {
 			return OperationResult{}, err
 		}
@@ -290,17 +293,19 @@ func hasFormDataParams(params []ParamSpec) bool {
 	return false
 }
 
-func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, path string, body any, opts ClientOptions) (DryRunRequest, error) {
+func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, hostSource, path string, body any, opts ClientOptions) (DryRunRequest, error) {
 	req, bodyBytes, _, err := resolveRequest(ctx, hostname, s.Method, path, body, opts)
 	if err != nil {
 		return DryRunRequest{}, err
 	}
 	return DryRunRequest{
-		Method:  req.Method,
-		URL:     redactDebugURL(req.URL, opts.sensitiveQueryParams),
-		Headers: redactedDryRunHeaders(req.Header),
-		Body:    redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
-		Auth:    dryRunAuthForSpec(s),
+		Method:     req.Method,
+		URL:        redactDebugURL(req.URL, opts.sensitiveQueryParams),
+		Hostname:   hostname,
+		HostSource: hostSource,
+		Headers:    redactedDryRunHeaders(req.Header),
+		Body:       redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
+		Auth:       dryRunAuthForSpec(s),
 		Output: CatalogOutput{
 			ListPath:          s.Output.ListPath,
 			DefaultColumns:    append([]string(nil), s.Output.DefaultColumns...),

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -123,6 +123,7 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 		skipped: map[string]bool{},
 	}
 	result := WorkflowResult{Status: "ok", Steps: make([]WorkflowStepResult, 0, len(spec.Steps))}
+	var reporter hostReporter
 	for _, step := range spec.Steps {
 		stepResult := WorkflowStepResult{ID: step.ID, Status: "ok"}
 		fail := func(err error) (WorkflowResult, []byte, error) {
@@ -167,24 +168,26 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 			return fail(UsageError(cmd, err))
 		}
 
-		var hostname string
+		var host HostResolution
 		var clientOpts ClientOptions
 		if step.Operation.Security != nil && step.Operation.Security.Public {
-			hostname, clientOpts, err = tryLoadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			host, clientOpts, err = tryLoadHostOptions(cmd, step.Operation.DefaultHostname, true)
 		} else {
-			hostname, clientOpts, err = loadHostOptionsMaybeRefresh(cmd, step.Operation.DefaultHostname, true)
+			host, clientOpts, err = loadHostOptions(cmd, step.Operation.DefaultHostname, true)
 		}
 		if err != nil {
 			return fail(err)
 		}
+		reporter.noticeImplicitHost(cmd.ErrOrStderr(), host)
 		if v, err := cmd.Root().PersistentFlags().GetBool("debug"); err == nil && v {
 			clientOpts.Debug = true
 		}
 		clientOpts.UserAgent = cmd.Root().Use
 
 		opResult, err := InvokeOperation(cmd.Context(), step.Operation, input, OperationOptions{
-			Hostname: hostname,
-			Client:   clientOpts,
+			Hostname:   host.Hostname,
+			HostSource: host.Source,
+			Client:     clientOpts,
 		})
 		if err != nil {
 			return fail(err)


### PR DESCRIPTION
## Summary

Implements #125. Operators with several hosts logged in had to pass `--hostname` or export `$<CLI>_HOST` in every new shell; a generated CLI can now record one host as selected and use it until it changes.

- `auth use <host>` records the selection; the first `auth login` marks the host it authenticated, later logins leave an existing selection alone, and `auth logout` removes the host and its marker together.
- Resolution order: `--hostname` > `$<CLI>_HOST` > the selected host > `http.default_hostname` > the single logged-in host > an error listing the configured hosts.
- The selection is a `selected: true` field on the host record in `hosts.yml`, not a reserved top-level key. It therefore cannot collide with a real hostname, cannot outlive the credentials it points at, and needs no new file.
- When the host is chosen implicitly and more than one is logged in, the CLI prints `current host: <name>` on stderr before sending. Explicit `--hostname` / env selection stays silent.
- `auth status` reports `hostname`, `source`, and `selected` through the existing `-o` flag; dry-run output carries `hostname` and `host_source`; the `--debug` dump names the host actually dialed.

No new top-level command, so `reservedRootCommands` is unchanged and specs with a `host` module keep generating.

## Verification

```
make check
go test -race ./...
```

End-to-end against a regenerated `examples/petstore` under an isolated `PETSTORE_CONFIG_DIR`: first-login election, later-login non-override, re-login to the selected host not re-electing, `auth use` switching and refusing a host that is not logged in, the implicit-host stderr notice firing only with more than one host, `--hostname` and `$PETSTORE_HOST` staying silent, dry-run `hostname`/`host_source`, `--debug` host line, the multiple-hosts error and its exit code, `auth logout` releasing the selection, and `__lathe verify --json` reporting `ok: true`.

## Compatibility

- With nothing selected, resolution is unchanged.
- `hosts.yml` gains an optional `selected` boolean on a host record. `yaml.v3` ignores unknown fields, so an older binary reading a newer file is unaffected, and a newer binary reading an older file simply has no selection. No migration.
- `auth status` gains `-o json|yaml` support and a `(selected)` marker in its default output; `--hostname` now prints the normalized hostname.
- Dry-run JSON gains `hostname` and `host_source`. `catalog_schema_version` stays at 18: that bump is itself unreleased since v0.6.0 (which shipped 17), so this change folds into it rather than adding a second one.
- `docs/architecture.md` invariant 7, `docs/cli-usage.md`, `docs/contracts.md`, and the generated Skill guidance are updated in the same change-set.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.

Closes #125