### PR TITLE
fix(runtime): substitute null for skipped steps in composite output.from

### DIFF
--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -204,10 +204,10 @@ func executeWorkflow(cmd *cobra.Command, spec WorkflowSpec, vals map[string]any)
 	if strings.TrimSpace(spec.OutputFrom) == "" {
 		return result, nil, nil
 	}
-	value, err := evalWorkflowValue(spec.OutputFrom, state)
+	value, err := evalWorkflowOutputValue(spec.OutputFrom, state)
 	if err != nil {
-		// Referencing a skipped step degrades to the step summary rather than
-		// failing the command.
+		// A bare reference to a skipped step degrades to the step summary
+		// rather than failing the command.
 		if errors.Is(err, errStepSkipped) {
 			return result, nil, nil
 		}
@@ -391,6 +391,56 @@ func evalWorkflowValue(expr string, state workflowState) (any, error) {
 		return workflowRefValue(strings.TrimSpace(trimmed[2:len(trimmed)-1]), state)
 	}
 	return evalWorkflowString(expr, state)
+}
+
+// evalWorkflowOutputValue evaluates output.from expressions. A bare reference
+// to a skipped step still propagates errStepSkipped (the caller degrades to the
+// step summary). A composite expression substitutes null for skipped references
+// so the remaining step data survives.
+func evalWorkflowOutputValue(expr string, state workflowState) (any, error) {
+	trimmed := strings.TrimSpace(expr)
+	if strings.HasPrefix(trimmed, "${") && strings.HasSuffix(trimmed, "}") && strings.Count(trimmed, "${") == 1 {
+		return workflowRefValue(strings.TrimSpace(trimmed[2:len(trimmed)-1]), state)
+	}
+	return evalWorkflowOutputString(expr, state)
+}
+
+// evalWorkflowOutputString is like evalWorkflowString but substitutes "null"
+// for references to skipped steps instead of propagating errStepSkipped. This
+// lets a JSON-literal output.from like '{"a":${steps.x},"b":${steps.y}}'
+// produce '{"a":<data>,"b":null}' when y is skipped, rather than discarding
+// the entire aggregate.
+func evalWorkflowOutputString(expr string, state workflowState) (string, error) {
+	if !strings.Contains(expr, "${") {
+		return expr, nil
+	}
+	var out strings.Builder
+	rest := expr
+	for {
+		start := strings.Index(rest, "${")
+		if start < 0 {
+			out.WriteString(rest)
+			return out.String(), nil
+		}
+		out.WriteString(rest[:start])
+		after := rest[start+2:]
+		end := strings.Index(after, "}")
+		if end < 0 {
+			return "", fmt.Errorf("unterminated reference in %q", expr)
+		}
+		ref := strings.TrimSpace(after[:end])
+		value, err := workflowRefValue(ref, state)
+		if err != nil {
+			if errors.Is(err, errStepSkipped) {
+				out.WriteString("null")
+				rest = after[end+1:]
+				continue
+			}
+			return "", err
+		}
+		out.WriteString(workflowString(value))
+		rest = after[end+1:]
+	}
 }
 
 func workflowRefValue(ref string, state workflowState) (any, error) {

--- a/pkg/runtime/workflow_test.go
+++ b/pkg/runtime/workflow_test.go
@@ -709,3 +709,102 @@ func TestBuildWorkflows_PreservesNumericReferenceSemantics(t *testing.T) {
 		t.Fatalf("paths = %#v, want %#v", paths, want)
 	}
 }
+
+func TestBuildWorkflows_CompositeOutputNullsSkippedStep(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/pod":
+			_, _ = w.Write([]byte(`{"name":"web-0","node":""}`))
+		case "/events":
+			_, _ = w.Write([]byte(`{"items":[{"reason":"FailedScheduling"}]}`))
+		case "/neighbors":
+			_, _ = w.Write([]byte(`{"items":[]}`))
+		}
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use: "diag",
+		Params: []ParamSpec{
+			{Name: "kind", Flag: "kind", In: InInput, GoType: "string"},
+		},
+		Steps: []WorkflowStepSpec{
+			{ID: "pod", Operation: publicGetSpec("get-pod", "/pod")},
+			{ID: "events", Operation: publicGetSpec("list-events", "/events")},
+			{
+				ID:        "neighbors",
+				Operation: publicGetSpec("list-neighbors", "/neighbors"),
+				When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"has-node"}}},
+			},
+		},
+		OutputFrom: `{"pod":${steps.pod},"events":${steps.events},"neighbors":${steps.neighbors}}`,
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+
+	root.SetArgs([]string{"--hostname", srv.URL, "diag", "--kind", "no-node"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	raw := strings.TrimSpace(stdout.String())
+	// The output is a JSON-encoded string (composite output.from produces a
+	// string value that json.Marshal wraps in quotes).
+	var outer string
+	if err := json.Unmarshal([]byte(raw), &outer); err != nil {
+		t.Fatalf("outer unmarshal: %v (raw = %s)", err, raw)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(outer), &result); err != nil {
+		t.Fatalf("inner unmarshal: %v (outer = %s)", err, outer)
+	}
+	if result["pod"] == nil {
+		t.Fatal("pod should not be nil")
+	}
+	if result["events"] == nil {
+		t.Fatal("events should not be nil")
+	}
+	if result["neighbors"] != nil {
+		t.Fatalf("neighbors should be null, got %v", result["neighbors"])
+	}
+}
+
+func TestBuildWorkflows_BareOutputFromSkippedStepStillDegrades(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	var stdout bytes.Buffer
+	root := newWorkflowRoot(&stdout)
+	if err := BuildWorkflows(root, []WorkflowSpec{{
+		Use:    "deploy",
+		Params: []ParamSpec{{Name: "kind", Flag: "kind", In: InInput, GoType: "string"}},
+		Steps: []WorkflowStepSpec{{
+			ID:        "gpu",
+			Operation: publicGetSpec("gpu", "/gpu"),
+			When:      []WorkflowCondition{{Value: "${input.kind}", Operator: "in", Values: []string{"gpu"}}},
+		}},
+		OutputFrom: "${steps.gpu}",
+	}}); err != nil {
+		t.Fatalf("BuildWorkflows: %v", err)
+	}
+	root.SetArgs([]string{"--hostname", srv.URL, "deploy", "--kind", "cpu"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	summary := decodeWorkflowSummary(t, stdout.String())
+	if summary.Status != "ok" || len(summary.Steps) != 1 || summary.Steps[0].Status != "skipped" {
+		t.Fatalf("summary = %#v", summary)
+	}
+}


### PR DESCRIPTION
## Summary

- A composite `output.from` like `'{"a":${steps.x},"b":${steps.y}}'` now
  substitutes `null` for references to skipped steps instead of discarding
  the entire aggregate into the step summary.
- Bare references (`output.from: ${steps.x}`) still degrade to the step
  summary when the step is skipped — no behavior change there.

**Motivation:** a pod-diagnosis workflow aggregates get-pod + list-events +
list-pods-by-node. The node-neighbors step is guarded with `when` (Pending
pods have no `spec.nodeName`). Without this fix, skipping neighbors discards
the pod and events data too — the user gets only `{"status":"ok","steps":[...]}`.

## Test plan

- [x] `TestBuildWorkflows_CompositeOutputNullsSkippedStep` — composite output with one skipped step produces `null` for that key, preserves others
- [x] `TestBuildWorkflows_BareOutputFromSkippedStepStillDegrades` — bare reference still returns step summary (regression guard)
- [x] Full test suite passes (`go test ./...`)