### PR TITLE
feat(output): support table column labels in overlays

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -338,6 +338,27 @@ body before the target request. External `$ref` loading is disabled.
 schemas from the API spec remain discovery metadata; they are not runtime
 validators.
 
+### Table Columns
+
+Override the generated table columns for one command when schema-derived
+columns do not surface the operator-facing identity or status fields:
+
+```yaml
+commands:
+  list-resources:
+    output:
+      default_columns: [resourceId, displayName, status]
+      column_labels:
+        resourceId: Resource ID
+        displayName: Name
+```
+
+The paths are ordered, dot-separated JSON fields. The override is compiled
+into the generated command and affects table output only; JSON, YAML, and raw
+responses remain unchanged. `column_labels` changes only the displayed header;
+it does not transform values. Unlabeled columns retain the default uppercase
+header.
+
 ### Stream Collection
 
 ```yaml

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -17,7 +17,13 @@
 # Leave the file empty ({} / no "commands:" key) if you do not want to override
 # anything; the generated layer passes through verbatim.
 
-commands: {}
+commands:
+  list-resources:
+    output:
+      default_columns: [resourceId, displayName, status]
+      column_labels:
+        resourceId: Resource ID
+        displayName: Name
 # Example:
 # defaults:
 #   pagination:

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -353,6 +353,18 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 		if err := validateArguments(spec, override.Params); err != nil {
 			return fmt.Errorf("command %q: %w", spec.Use, err)
 		}
+		if override.Output != nil {
+			if err := validateDefaultColumnsOverride(override.Output.DefaultColumns); err != nil {
+				return fmt.Errorf("command %q output: %w", spec.Use, err)
+			}
+			columns := spec.Output.DefaultColumns
+			if len(override.Output.DefaultColumns) > 0 {
+				columns = override.Output.DefaultColumns
+			}
+			if err := validateColumnLabelsOverride(columns, override.Output.ColumnLabels); err != nil {
+				return fmt.Errorf("command %q output: %w", spec.Use, err)
+			}
+		}
 		if override.Output != nil && override.Output.Streaming != nil {
 			if err := validateStreamingOverride(spec, *override.Output.Streaming); err != nil {
 				return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
@@ -602,6 +614,47 @@ func validArgumentName(name string) bool {
 	return true
 }
 
+func validateDefaultColumnsOverride(columns []string) error {
+	seen := map[string]bool{}
+	for i, column := range columns {
+		if column == "" || strings.TrimSpace(column) != column {
+			return fmt.Errorf("default_columns[%d] must be a non-empty trimmed path", i)
+		}
+		for _, part := range strings.Split(column, ".") {
+			if strings.TrimSpace(part) == "" {
+				return fmt.Errorf("default_columns[%d] contains an empty path segment", i)
+			}
+		}
+		if seen[column] {
+			return fmt.Errorf("default column %q is duplicated", column)
+		}
+		seen[column] = true
+	}
+	return nil
+}
+
+func validateColumnLabelsOverride(columns []string, labels map[string]string) error {
+	known := make(map[string]bool, len(columns))
+	for _, column := range columns {
+		known[column] = true
+	}
+	keys := make([]string, 0, len(labels))
+	for path := range labels {
+		keys = append(keys, path)
+	}
+	sort.Strings(keys)
+	for _, path := range keys {
+		label := labels[path]
+		if !known[path] {
+			return fmt.Errorf("column label %q does not match a default column", path)
+		}
+		if label == "" || strings.TrimSpace(label) != label || strings.ContainsAny(label, "\t\v\f\r\n") {
+			return fmt.Errorf("column label %q must be non-empty, trimmed, and single-line", path)
+		}
+	}
+	return nil
+}
+
 func validateStreamingOverride(spec runtime.CommandSpec, stream overlay.StreamingOverride) error {
 	if spec.Output.Streaming == nil {
 		return fmt.Errorf("operation is not declared as streaming")
@@ -808,6 +861,12 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 	if override.Context != nil && override.Context.SetOnSuccess != nil {
 		set := override.Context.SetOnSuccess
 		spec.SetContext = &runtime.ContextSetHint{Name: set.Name, Param: set.FromParam}
+	}
+	if override.Output != nil && len(override.Output.DefaultColumns) > 0 {
+		spec.Output.DefaultColumns = append([]string(nil), override.Output.DefaultColumns...)
+	}
+	if override.Output != nil && len(override.Output.ColumnLabels) > 0 {
+		spec.Output.ColumnLabels = copyStringMap(override.Output.ColumnLabels)
 	}
 	if override.Output != nil && override.Output.Streaming != nil {
 		stream := override.Output.Streaming
@@ -1291,6 +1350,9 @@ func outputHintsLiteral(hints runtime.OutputHints) string {
 	b.WriteString("runtime.OutputHints{")
 	writeStringField(&b, "ListPath", hints.ListPath)
 	writeStringSliceField(&b, "DefaultColumns", hints.DefaultColumns)
+	if len(hints.ColumnLabels) > 0 {
+		fmt.Fprintf(&b, "ColumnLabels: %s,", stringMapLiteral(hints.ColumnLabels))
+	}
 	writeStringField(&b, "ResponseMediaType", hints.ResponseMediaType)
 	if hints.Pagination != nil {
 		fmt.Fprintf(&b, "Pagination: %s,", paginationHintLiteral(hints.Pagination))
@@ -1385,7 +1447,7 @@ func knownErrorsLiteral(errors []runtime.KnownError) string {
 }
 
 func outputHintsSet(hints runtime.OutputHints) bool {
-	return hints.ListPath != "" || len(hints.DefaultColumns) > 0 || hints.ResponseMediaType != "" || hints.Pagination != nil || hints.Streaming != nil
+	return hints.ListPath != "" || len(hints.DefaultColumns) > 0 || len(hints.ColumnLabels) > 0 || hints.ResponseMediaType != "" || hints.Pagination != nil || hints.Streaming != nil
 }
 
 func writeStringField(b *strings.Builder, name, value string) {
@@ -1614,7 +1676,7 @@ var Specs = []runtime.CommandSpec{
 				{{- end}}
 			},
 			{{- end}}
-		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
+		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ColumnLabels $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
 		Output: {{outputHintsLiteral $op.Output}},
 		{{- end}}
 		{{- if $op.Security}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -60,7 +60,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	chdirWithGoMod(t)
 
 	specs := []runtime.CommandSpec{
-		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/api/v1/addon", Params: []runtime.ParamSpec{{Name: "workspace_id", Flag: "workspace-id", In: runtime.InQuery, GoType: "string"}}, RequestBody: &runtime.RequestBody{Required: true, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}},
+		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/api/v1/addon", Params: []runtime.ParamSpec{{Name: "workspace_id", Flag: "workspace-id", In: runtime.InQuery, GoType: "string"}}, RequestBody: &runtime.RequestBody{Required: true, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}, Output: runtime.OutputHints{DefaultColumns: []string{"id"}}},
 		{Group: "Addon", Use: "untouched", Short: "untouched short", Method: "GET", PathTpl: "/api/v1/x"},
 	}
 	overrides := map[string]overlay.Override{
@@ -83,6 +83,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing addon name"}},
 			Params:        map[string]overlay.ParamOverride{"workspace_id": {Context: "workspace"}},
 			Context:       &overlay.ContextOverride{SetOnSuccess: &overlay.ContextSetOnSuccess{Name: "workspace", FromParam: "workspace_id"}},
+			Output:        &overlay.OutputOverride{DefaultColumns: []string{"name"}, ColumnLabels: map[string]string{"name": "Addon"}},
 		},
 	}
 
@@ -112,6 +113,8 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`Cause: "missing addon name"`,
 		`Context: "workspace"`,
 		`SetContext: &runtime.ContextSetHint{Name: "workspace", Param: "workspace_id"}`,
+		`DefaultColumns: []string{"name"}`,
+		`ColumnLabels: map[string]string{"name": "Addon"}`,
 		`"untouched short"`,
 		`generatedSchemaVersion`,
 		`func Mount(root *cobra.Command) error`,
@@ -757,6 +760,59 @@ func TestMergeOverlayModule_StreamPolicy(t *testing.T) {
 	bad[0].Output.Streaming = nil
 	if err := ValidateOverlayModule(bad, mod); err == nil || !strings.Contains(err.Error(), "not declared as streaming") {
 		t.Fatalf("validation error = %v", err)
+	}
+}
+
+func TestMergeOverlayModule_OutputColumns(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group: "Resources", Use: "list", Method: "GET", PathTpl: "/resources",
+		Output: runtime.OutputHints{ListPath: "items", DefaultColumns: []string{"id", "category"}},
+	}}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"list": {Output: &overlay.OutputOverride{
+			DefaultColumns: []string{"resourceId", "displayName"},
+			ColumnLabels:   map[string]string{"resourceId": "Resource ID", "displayName": "Name"},
+		}},
+	}}
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		t.Fatalf("ValidateOverlayModule: %v", err)
+	}
+	merged := MergeOverlayModule(specs, mod)
+	if got := strings.Join(merged[0].Output.DefaultColumns, ","); got != "resourceId,displayName" {
+		t.Fatalf("default columns = %q", got)
+	}
+	if got := merged[0].Output.ColumnLabels["resourceId"]; got != "Resource ID" {
+		t.Fatalf("column label = %q", got)
+	}
+	if got := strings.Join(specs[0].Output.DefaultColumns, ","); got != "id,category" {
+		t.Fatalf("source default columns = %q", got)
+	}
+
+	for _, columns := range [][]string{{"displayName", "displayName"}, {"status..phase"}, {" name"}} {
+		bad := overlay.Module{Commands: map[string]overlay.Override{
+			"list": {Output: &overlay.OutputOverride{DefaultColumns: columns}},
+		}}
+		if err := ValidateOverlayModule(specs, bad); err == nil {
+			t.Fatalf("ValidateOverlayModule accepted columns %#v", columns)
+		}
+	}
+
+	for _, labels := range []map[string]string{
+		{"unknown": "Unknown"},
+		{"resourceId": ""},
+		{"resourceId": " Resource ID"},
+		{"resourceId": "Resource\tID"},
+		{"resourceId": "Resource\nID"},
+	} {
+		bad := overlay.Module{Commands: map[string]overlay.Override{
+			"list": {Output: &overlay.OutputOverride{
+				DefaultColumns: []string{"resourceId", "displayName"},
+				ColumnLabels:   labels,
+			}},
+		}}
+		if err := ValidateOverlayModule(specs, bad); err == nil {
+			t.Fatalf("ValidateOverlayModule accepted labels %#v", labels)
+		}
 	}
 }
 

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -50,7 +50,9 @@ type RuntimeSchemaOverride struct {
 }
 
 type OutputOverride struct {
-	Streaming *StreamingOverride `yaml:"streaming"`
+	DefaultColumns []string           `yaml:"default_columns"`
+	ColumnLabels   map[string]string  `yaml:"column_labels"`
+	Streaming      *StreamingOverride `yaml:"streaming"`
 }
 
 type StreamingOverride struct {

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -122,6 +122,10 @@ commands:
         response_path: input_schema
         params:
           user_id: ${params.user_id}
+    output:
+      default_columns: [name, status.phase]
+      column_labels:
+        status.phase: Status
     params:
       status:
         flag: user-status
@@ -179,6 +183,12 @@ commands:
 	}
 	if cu.Body == nil || cu.Body.RuntimeSchema == nil || cu.Body.RuntimeSchema.OperationID != "describeUser" || cu.Body.RuntimeSchema.ResponsePath != "input_schema" || cu.Body.RuntimeSchema.Params["user_id"] != "${params.user_id}" {
 		t.Errorf("runtime schema = %#v", cu.Body)
+	}
+	if cu.Output == nil || len(cu.Output.DefaultColumns) != 2 || cu.Output.DefaultColumns[0] != "name" || cu.Output.DefaultColumns[1] != "status.phase" {
+		t.Errorf("output = %#v", cu.Output)
+	}
+	if cu.Output.ColumnLabels["status.phase"] != "Status" {
+		t.Errorf("column labels = %#v", cu.Output.ColumnLabels)
 	}
 	sp := cu.Params["status"]
 	if sp.Flag != "user-status" {

--- a/pkg/runtime/formatter_test.go
+++ b/pkg/runtime/formatter_test.go
@@ -74,6 +74,31 @@ func TestFormatOutput_TableUsesNestedListPath(t *testing.T) {
 	}
 }
 
+func TestFormatOutput_TableUsesConfiguredColumnLabels(t *testing.T) {
+	var buf bytes.Buffer
+	data := []byte(`{"items":[{"resourceId":"r1","createdAt":"2026-08-28","status":"active","details":{"owner":{"profile":{"contact":{"display name":"Alice Smith","user-name":"alice"}}}}}]}`)
+	err := FormatOutput(data, "table", &buf, OutputHints{
+		ListPath:       "items",
+		DefaultColumns: []string{"resourceId", "createdAt", "status", "details.owner.profile.contact.display name", "details.owner.profile.contact.user-name"},
+		ColumnLabels: map[string]string{
+			"resourceId": "Resource ID",
+			"createdAt":  "Created at",
+			"status":     "Status",
+			"details.owner.profile.contact.display name": "Display name",
+			"details.owner.profile.contact.user-name":    "User",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	for _, want := range []string{"Resource ID", "Created at", "Status", "Display name", "User", "r1", "2026-08-28", "active", "Alice Smith", "alice"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("table output missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestRegisterFormatter(t *testing.T) {
 	RegisterFormatter("custom", rawFormatter{})
 	defer delete(formatters, "custom")

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -144,6 +144,7 @@ func (s *AdditionalPropertiesSpec) UnmarshalJSON(data []byte) error {
 type OutputHints struct {
 	ListPath          string
 	DefaultColumns    []string
+	ColumnLabels      map[string]string `json:",omitempty"`
 	ResponseMediaType string
 	Pagination        *PaginationHint
 	Streaming         *StreamingHint

--- a/pkg/runtime/table.go
+++ b/pkg/runtime/table.go
@@ -40,7 +40,7 @@ func renderTable(data []byte, w io.Writer, hints OutputHints) error {
 	if len(cols) == 0 {
 		return renderJSON(data, w)
 	}
-	return writeTable(cols, rows, w)
+	return writeTable(cols, rows, hints.ColumnLabels, w)
 }
 
 // chooseColumns prefers codegen-supplied DefaultColumns when available,
@@ -50,14 +50,13 @@ func chooseColumns(rows []map[string]any, hints OutputHints) []string {
 	if len(hints.DefaultColumns) == 0 {
 		return pickColumns(rows)
 	}
-	pathSet := map[string]struct{}{}
-	for _, r := range rows {
-		collectPaths(r, "", 4, pathSet)
-	}
 	var picked []string
 	for _, c := range hints.DefaultColumns {
-		if _, ok := pathSet[c]; ok {
-			picked = append(picked, c)
+		for _, r := range rows {
+			if _, ok := tableValue(r, c); ok {
+				picked = append(picked, c)
+				break
+			}
 		}
 	}
 	if len(picked) == 0 {
@@ -175,19 +174,34 @@ func collectPaths(v any, prefix string, maxDepth int, out map[string]struct{}) {
 }
 
 func lookupPath(row map[string]any, path string) string {
-	parts := strings.Split(path, ".")
-	var cur any = row
-	for _, p := range parts {
-		m, ok := cur.(map[string]any)
+	v, ok := tableValue(row, path)
+	if !ok {
+		return ""
+	}
+	return stringify(v)
+}
+
+func tableValue(row map[string]any, path string) (any, bool) {
+	var v any = row
+	for _, part := range strings.Split(path, ".") {
+		m, ok := v.(map[string]any)
 		if !ok {
-			return ""
+			return nil, false
 		}
-		cur, ok = m[p]
+		v, ok = m[part]
 		if !ok {
-			return ""
+			return nil, false
 		}
 	}
-	return stringify(cur)
+	if v == nil {
+		return nil, false
+	}
+	switch v.(type) {
+	case map[string]any, []any:
+		return nil, false
+	default:
+		return v, true
+	}
 }
 
 func stringify(v any) string {
@@ -208,13 +222,13 @@ func stringify(v any) string {
 	}
 }
 
-func writeTable(cols []string, rows []map[string]any, w io.Writer) error {
+func writeTable(cols []string, rows []map[string]any, labels map[string]string, w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	for i, c := range cols {
 		if i > 0 {
 			fmt.Fprint(tw, "\t")
 		}
-		fmt.Fprint(tw, columnHeader(c))
+		fmt.Fprint(tw, columnHeader(c, labels))
 	}
 	fmt.Fprintln(tw)
 	for _, r := range rows {
@@ -229,7 +243,10 @@ func writeTable(cols []string, rows []map[string]any, w io.Writer) error {
 	return tw.Flush()
 }
 
-func columnHeader(path string) string {
+func columnHeader(path string, labels map[string]string) string {
+	if label := labels[path]; label != "" {
+		return label
+	}
 	if i := strings.LastIndexByte(path, '.'); i >= 0 {
 		return strings.ToUpper(path[i+1:])
 	}


### PR DESCRIPTION
## Summary

- Add `output.default_columns` and `output.column_labels` to command overlays.
- Compile table labels into runtime output hints while preserving JSON, YAML, and raw output.
- Support deep dot-separated fields, ordinary spaces, and hyphens while rejecting table control characters.

## Verification

- `go test ./pkg/runtime -run 'TestFormatOutput_(TableUsesNestedListPath|TableUsesConfiguredColumnLabels)$' -count=1`
- `go test ./internal/codegen/render -run 'TestRenderModule_AppliesOverlay|TestMergeOverlayModule_OutputColumns' -count=1`
- `go test ./internal/overlay -run TestLoadDir_ParsesExtendedFields -count=1`
- `make check`
- `go test -race ./...`

## Compatibility

- Generated `CommandSpec` literals may include the optional `OutputHints.ColumnLabels` field.
- `runtime.SchemaVersion` remains 11 because existing generated modules remain compatible.
- Catalog schema and JSON, YAML, and raw output are unchanged; only table rendering uses labels.
- CLI usage documentation and the overlay example are updated.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.