### PR TITLE
feat(output): support declarative column formats

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -347,17 +347,30 @@ columns do not surface the operator-facing identity or status fields:
 commands:
   list-resources:
     output:
-      default_columns: [resourceId, displayName, status]
+      default_columns: [resourceId, displayName, status, spendMicro]
       column_labels:
         resourceId: Resource ID
         displayName: Name
+      column_formats:
+        spendMicro:
+          kind: currency
+          currency: USD
+          source_scale: 6
+          grouping: true
+          min_fraction_digits: 2
+          max_fraction_digits: 6
 ```
 
 The paths are ordered, dot-separated JSON fields. The override is compiled
 into the generated command and affects table output only; JSON, YAML, and raw
 responses remain unchanged. `column_labels` changes only the displayed header;
 it does not transform values. Unlabeled columns retain the default uppercase
-header.
+header. `column_formats` transforms table values only. Currency formats treat
+the source as a fixed-point integer, move the decimal point left by
+`source_scale`, and retain every non-zero fractional digit through
+`max_fraction_digits`. The maximum must be at least the source scale, so
+configured output never rounds away source precision. USD uses `$`; other
+three-letter currency codes remain explicit.
 
 ### Stream Collection
 

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -20,10 +20,18 @@
 commands:
   list-resources:
     output:
-      default_columns: [resourceId, displayName, status]
+      default_columns: [resourceId, displayName, status, spendMicro]
       column_labels:
         resourceId: Resource ID
         displayName: Name
+      column_formats:
+        spendMicro:
+          kind: currency
+          currency: USD
+          source_scale: 6
+          grouping: true
+          min_fraction_digits: 2
+          max_fraction_digits: 6
 # Example:
 # defaults:
 #   pagination:

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -364,6 +364,9 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 			if err := validateColumnLabelsOverride(columns, override.Output.ColumnLabels); err != nil {
 				return fmt.Errorf("command %q output: %w", spec.Use, err)
 			}
+			if err := validateColumnFormatsOverride(columns, override.Output.ColumnFormats); err != nil {
+				return fmt.Errorf("command %q output: %w", spec.Use, err)
+			}
 		}
 		if override.Output != nil && override.Output.Streaming != nil {
 			if err := validateStreamingOverride(spec, *override.Output.Streaming); err != nil {
@@ -655,6 +658,55 @@ func validateColumnLabelsOverride(columns []string, labels map[string]string) er
 	return nil
 }
 
+func validateColumnFormatsOverride(columns []string, formats map[string]overlay.ColumnFormatOverride) error {
+	known := make(map[string]bool, len(columns))
+	for _, column := range columns {
+		known[column] = true
+	}
+	paths := make([]string, 0, len(formats))
+	for path := range formats {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		format := formats[path]
+		if !known[path] {
+			return fmt.Errorf("column format %q does not match a default column", path)
+		}
+		if format.Kind != "currency" {
+			return fmt.Errorf("column format %q kind must be currency", path)
+		}
+		if !validCurrencyCode(format.Currency) {
+			return fmt.Errorf("column format %q currency must be a three-letter uppercase code", path)
+		}
+		if format.SourceScale < 0 || format.SourceScale > 18 {
+			return fmt.Errorf("column format %q source_scale must be between 0 and 18", path)
+		}
+		if format.MinFractionDigits < 0 || format.MinFractionDigits > 18 {
+			return fmt.Errorf("column format %q min_fraction_digits must be between 0 and 18", path)
+		}
+		if format.MaxFractionDigits < format.MinFractionDigits || format.MaxFractionDigits > 18 {
+			return fmt.Errorf("column format %q max_fraction_digits must be between min_fraction_digits and 18", path)
+		}
+		if format.MaxFractionDigits < format.SourceScale {
+			return fmt.Errorf("column format %q max_fraction_digits must be at least source_scale", path)
+		}
+	}
+	return nil
+}
+
+func validCurrencyCode(value string) bool {
+	if len(value) != 3 {
+		return false
+	}
+	for _, r := range value {
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+	return true
+}
+
 func validateStreamingOverride(spec runtime.CommandSpec, stream overlay.StreamingOverride) error {
 	if spec.Output.Streaming == nil {
 		return fmt.Errorf("operation is not declared as streaming")
@@ -867,6 +919,19 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 	}
 	if override.Output != nil && len(override.Output.ColumnLabels) > 0 {
 		spec.Output.ColumnLabels = copyStringMap(override.Output.ColumnLabels)
+	}
+	if override.Output != nil && len(override.Output.ColumnFormats) > 0 {
+		spec.Output.ColumnFormats = make(map[string]runtime.ColumnFormat, len(override.Output.ColumnFormats))
+		for path, format := range override.Output.ColumnFormats {
+			spec.Output.ColumnFormats[path] = runtime.ColumnFormat{
+				Kind:              format.Kind,
+				Currency:          format.Currency,
+				SourceScale:       format.SourceScale,
+				Grouping:          format.Grouping,
+				MinFractionDigits: format.MinFractionDigits,
+				MaxFractionDigits: format.MaxFractionDigits,
+			}
+		}
 	}
 	if override.Output != nil && override.Output.Streaming != nil {
 		stream := override.Output.Streaming
@@ -1123,6 +1188,38 @@ func stringMapLiteral(values map[string]string) string {
 	return b.String()
 }
 
+func columnFormatMapLiteral(values map[string]runtime.ColumnFormat) string {
+	if len(values) == 0 {
+		return "nil"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("map[string]runtime.ColumnFormat{")
+	for _, key := range keys {
+		format := values[key]
+		fmt.Fprintf(&b, "%q: runtime.ColumnFormat{", key)
+		writeStringField(&b, "Kind", format.Kind)
+		writeStringField(&b, "Currency", format.Currency)
+		if format.SourceScale != 0 {
+			fmt.Fprintf(&b, "SourceScale: %d,", format.SourceScale)
+		}
+		writeBoolField(&b, "Grouping", format.Grouping)
+		if format.MinFractionDigits != 0 {
+			fmt.Fprintf(&b, "MinFractionDigits: %d,", format.MinFractionDigits)
+		}
+		if format.MaxFractionDigits != 0 {
+			fmt.Fprintf(&b, "MaxFractionDigits: %d,", format.MaxFractionDigits)
+		}
+		b.WriteString("},")
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
 func workflowSpecLiteral(spec runtime.WorkflowSpec) string {
 	var b strings.Builder
 	b.WriteString("runtime.WorkflowSpec{")
@@ -1353,6 +1450,9 @@ func outputHintsLiteral(hints runtime.OutputHints) string {
 	if len(hints.ColumnLabels) > 0 {
 		fmt.Fprintf(&b, "ColumnLabels: %s,", stringMapLiteral(hints.ColumnLabels))
 	}
+	if len(hints.ColumnFormats) > 0 {
+		fmt.Fprintf(&b, "ColumnFormats: %s,", columnFormatMapLiteral(hints.ColumnFormats))
+	}
 	writeStringField(&b, "ResponseMediaType", hints.ResponseMediaType)
 	if hints.Pagination != nil {
 		fmt.Fprintf(&b, "Pagination: %s,", paginationHintLiteral(hints.Pagination))
@@ -1447,7 +1547,7 @@ func knownErrorsLiteral(errors []runtime.KnownError) string {
 }
 
 func outputHintsSet(hints runtime.OutputHints) bool {
-	return hints.ListPath != "" || len(hints.DefaultColumns) > 0 || len(hints.ColumnLabels) > 0 || hints.ResponseMediaType != "" || hints.Pagination != nil || hints.Streaming != nil
+	return hints.ListPath != "" || len(hints.DefaultColumns) > 0 || len(hints.ColumnLabels) > 0 || len(hints.ColumnFormats) > 0 || hints.ResponseMediaType != "" || hints.Pagination != nil || hints.Streaming != nil
 }
 
 func writeStringField(b *strings.Builder, name, value string) {
@@ -1676,7 +1776,7 @@ var Specs = []runtime.CommandSpec{
 				{{- end}}
 			},
 			{{- end}}
-		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ColumnLabels $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
+		{{- if or $op.Output.ListPath $op.Output.DefaultColumns $op.Output.ColumnLabels $op.Output.ColumnFormats $op.Output.ResponseMediaType $op.Output.Pagination $op.Output.Streaming}}
 		Output: {{outputHintsLiteral $op.Output}},
 		{{- end}}
 		{{- if $op.Security}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -83,7 +83,13 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing addon name"}},
 			Params:        map[string]overlay.ParamOverride{"workspace_id": {Context: "workspace"}},
 			Context:       &overlay.ContextOverride{SetOnSuccess: &overlay.ContextSetOnSuccess{Name: "workspace", FromParam: "workspace_id"}},
-			Output:        &overlay.OutputOverride{DefaultColumns: []string{"name"}, ColumnLabels: map[string]string{"name": "Addon"}},
+			Output: &overlay.OutputOverride{
+				DefaultColumns: []string{"name", "spendMicro"},
+				ColumnLabels:   map[string]string{"name": "Addon"},
+				ColumnFormats: map[string]overlay.ColumnFormatOverride{
+					"spendMicro": {Kind: "currency", Currency: "USD", SourceScale: 6, Grouping: true, MinFractionDigits: 2, MaxFractionDigits: 6},
+				},
+			},
 		},
 	}
 
@@ -113,8 +119,9 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`Cause: "missing addon name"`,
 		`Context: "workspace"`,
 		`SetContext: &runtime.ContextSetHint{Name: "workspace", Param: "workspace_id"}`,
-		`DefaultColumns: []string{"name"}`,
+		`DefaultColumns: []string{"name", "spendMicro"}`,
 		`ColumnLabels: map[string]string{"name": "Addon"}`,
+		`ColumnFormats: map[string]runtime.ColumnFormat{"spendMicro": runtime.ColumnFormat{Kind: "currency", Currency: "USD", SourceScale: 6, Grouping: true, MinFractionDigits: 2, MaxFractionDigits: 6}}`,
 		`"untouched short"`,
 		`generatedSchemaVersion`,
 		`func Mount(root *cobra.Command) error`,
@@ -770,19 +777,26 @@ func TestMergeOverlayModule_OutputColumns(t *testing.T) {
 	}}
 	mod := overlay.Module{Commands: map[string]overlay.Override{
 		"list": {Output: &overlay.OutputOverride{
-			DefaultColumns: []string{"resourceId", "displayName"},
+			DefaultColumns: []string{"resourceId", "displayName", "spendMicro"},
 			ColumnLabels:   map[string]string{"resourceId": "Resource ID", "displayName": "Name"},
+			ColumnFormats: map[string]overlay.ColumnFormatOverride{
+				"spendMicro": {Kind: "currency", Currency: "USD", SourceScale: 6, Grouping: true, MinFractionDigits: 2, MaxFractionDigits: 6},
+			},
 		}},
 	}}
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		t.Fatalf("ValidateOverlayModule: %v", err)
 	}
 	merged := MergeOverlayModule(specs, mod)
-	if got := strings.Join(merged[0].Output.DefaultColumns, ","); got != "resourceId,displayName" {
+	if got := strings.Join(merged[0].Output.DefaultColumns, ","); got != "resourceId,displayName,spendMicro" {
 		t.Fatalf("default columns = %q", got)
 	}
 	if got := merged[0].Output.ColumnLabels["resourceId"]; got != "Resource ID" {
 		t.Fatalf("column label = %q", got)
+	}
+	format := merged[0].Output.ColumnFormats["spendMicro"]
+	if format.Kind != "currency" || format.Currency != "USD" || format.SourceScale != 6 || !format.Grouping || format.MinFractionDigits != 2 || format.MaxFractionDigits != 6 {
+		t.Fatalf("column format = %#v", format)
 	}
 	if got := strings.Join(specs[0].Output.DefaultColumns, ","); got != "id,category" {
 		t.Fatalf("source default columns = %q", got)
@@ -812,6 +826,25 @@ func TestMergeOverlayModule_OutputColumns(t *testing.T) {
 		}}
 		if err := ValidateOverlayModule(specs, bad); err == nil {
 			t.Fatalf("ValidateOverlayModule accepted labels %#v", labels)
+		}
+	}
+
+	for _, formats := range []map[string]overlay.ColumnFormatOverride{
+		{"unknown": {Kind: "currency", Currency: "USD", MaxFractionDigits: 2}},
+		{"resourceId": {Kind: "number", Currency: "USD", MaxFractionDigits: 2}},
+		{"resourceId": {Kind: "currency", Currency: "usd", MaxFractionDigits: 2}},
+		{"resourceId": {Kind: "currency", Currency: "USD", SourceScale: -1, MaxFractionDigits: 2}},
+		{"resourceId": {Kind: "currency", Currency: "USD", SourceScale: 6, MinFractionDigits: 2, MaxFractionDigits: 5}},
+		{"resourceId": {Kind: "currency", Currency: "USD", MinFractionDigits: 3, MaxFractionDigits: 2}},
+	} {
+		bad := overlay.Module{Commands: map[string]overlay.Override{
+			"list": {Output: &overlay.OutputOverride{
+				DefaultColumns: []string{"resourceId", "displayName"},
+				ColumnFormats:  formats,
+			}},
+		}}
+		if err := ValidateOverlayModule(specs, bad); err == nil {
+			t.Fatalf("ValidateOverlayModule accepted formats %#v", formats)
 		}
 	}
 }

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -50,9 +50,19 @@ type RuntimeSchemaOverride struct {
 }
 
 type OutputOverride struct {
-	DefaultColumns []string           `yaml:"default_columns"`
-	ColumnLabels   map[string]string  `yaml:"column_labels"`
-	Streaming      *StreamingOverride `yaml:"streaming"`
+	DefaultColumns []string                        `yaml:"default_columns"`
+	ColumnLabels   map[string]string               `yaml:"column_labels"`
+	ColumnFormats  map[string]ColumnFormatOverride `yaml:"column_formats"`
+	Streaming      *StreamingOverride              `yaml:"streaming"`
+}
+
+type ColumnFormatOverride struct {
+	Kind              string `yaml:"kind"`
+	Currency          string `yaml:"currency"`
+	SourceScale       int    `yaml:"source_scale"`
+	Grouping          bool   `yaml:"grouping"`
+	MinFractionDigits int    `yaml:"min_fraction_digits"`
+	MaxFractionDigits int    `yaml:"max_fraction_digits"`
 }
 
 type StreamingOverride struct {

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -123,9 +123,17 @@ commands:
         params:
           user_id: ${params.user_id}
     output:
-      default_columns: [name, status.phase]
+      default_columns: [name, spendMicro, status.phase]
       column_labels:
         status.phase: Status
+      column_formats:
+        spendMicro:
+          kind: currency
+          currency: USD
+          source_scale: 6
+          grouping: true
+          min_fraction_digits: 2
+          max_fraction_digits: 6
     params:
       status:
         flag: user-status
@@ -184,11 +192,15 @@ commands:
 	if cu.Body == nil || cu.Body.RuntimeSchema == nil || cu.Body.RuntimeSchema.OperationID != "describeUser" || cu.Body.RuntimeSchema.ResponsePath != "input_schema" || cu.Body.RuntimeSchema.Params["user_id"] != "${params.user_id}" {
 		t.Errorf("runtime schema = %#v", cu.Body)
 	}
-	if cu.Output == nil || len(cu.Output.DefaultColumns) != 2 || cu.Output.DefaultColumns[0] != "name" || cu.Output.DefaultColumns[1] != "status.phase" {
+	if cu.Output == nil || len(cu.Output.DefaultColumns) != 3 || cu.Output.DefaultColumns[0] != "name" || cu.Output.DefaultColumns[1] != "spendMicro" || cu.Output.DefaultColumns[2] != "status.phase" {
 		t.Errorf("output = %#v", cu.Output)
 	}
 	if cu.Output.ColumnLabels["status.phase"] != "Status" {
 		t.Errorf("column labels = %#v", cu.Output.ColumnLabels)
+	}
+	format := cu.Output.ColumnFormats["spendMicro"]
+	if format.Kind != "currency" || format.Currency != "USD" || format.SourceScale != 6 || !format.Grouping || format.MinFractionDigits != 2 || format.MaxFractionDigits != 6 {
+		t.Errorf("column format = %#v", format)
 	}
 	sp := cu.Params["status"]
 	if sp.Flag != "user-status" {

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lathe-cli/lathe/pkg/config"
 )
 
-const CatalogSchemaVersion = 18
+const CatalogSchemaVersion = 19
 const DefaultSearchLimit = 20
 
 const (
@@ -204,11 +204,13 @@ type CatalogContextSet struct {
 }
 
 type CatalogOutput struct {
-	ListPath          string             `json:"list_path,omitempty"`
-	DefaultColumns    []string           `json:"default_columns,omitempty"`
-	ResponseMediaType string             `json:"response_media_type,omitempty"`
-	Pagination        *CatalogPagination `json:"pagination,omitempty"`
-	Streaming         *CatalogStreaming  `json:"streaming,omitempty"`
+	ListPath          string                  `json:"list_path,omitempty"`
+	DefaultColumns    []string                `json:"default_columns,omitempty"`
+	ColumnLabels      map[string]string       `json:"column_labels,omitempty"`
+	ColumnFormats     map[string]ColumnFormat `json:"column_formats,omitempty"`
+	ResponseMediaType string                  `json:"response_media_type,omitempty"`
+	Pagination        *CatalogPagination      `json:"pagination,omitempty"`
+	Streaming         *CatalogStreaming       `json:"streaming,omitempty"`
 }
 
 type CatalogPagination struct {
@@ -430,6 +432,8 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 		Output: CatalogOutput{
 			ListPath:          spec.Output.ListPath,
 			DefaultColumns:    append([]string(nil), spec.Output.DefaultColumns...),
+			ColumnLabels:      copyStringMap(spec.Output.ColumnLabels),
+			ColumnFormats:     copyColumnFormats(spec.Output.ColumnFormats),
 			ResponseMediaType: spec.Output.ResponseMediaType,
 			Pagination:        catalogPagination(spec.Output.Pagination),
 			Streaming:         catalogStreaming(spec.Output.Streaming),
@@ -533,6 +537,8 @@ func catalogWorkflowCommand(spec WorkflowSpec, path []string) CatalogCommand {
 		Output: CatalogOutput{
 			ListPath:          spec.Output.ListPath,
 			DefaultColumns:    append([]string(nil), spec.Output.DefaultColumns...),
+			ColumnLabels:      copyStringMap(spec.Output.ColumnLabels),
+			ColumnFormats:     copyColumnFormats(spec.Output.ColumnFormats),
 			ResponseMediaType: spec.Output.ResponseMediaType,
 			Pagination:        catalogPagination(spec.Output.Pagination),
 			Streaming:         catalogStreaming(spec.Output.Streaming),
@@ -612,6 +618,17 @@ func copyStringMap(in map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func copyColumnFormats(in map[string]ColumnFormat) map[string]ColumnFormat {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]ColumnFormat, len(in))
 	for key, value := range in {
 		out[key] = value
 	}

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -50,8 +50,12 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 				},
 			},
 			Output: OutputHints{
-				ListPath:          "data.items",
-				DefaultColumns:    []string{"id", "name"},
+				ListPath:       "data.items",
+				DefaultColumns: []string{"id", "name"},
+				ColumnLabels:   map[string]string{"id": "ID"},
+				ColumnFormats: map[string]ColumnFormat{
+					"id": {Kind: "currency", Currency: "USD", SourceScale: 6, Grouping: true, MinFractionDigits: 2, MaxFractionDigits: 6},
+				},
 				ResponseMediaType: "application/json",
 				Pagination:        &PaginationHint{Strategy: "cursor", TokenParam: "page_token", TokenField: "next_page_token", LimitParam: "limit"},
 				Streaming: &StreamingHint{Strategy: "sse", Policy: &StreamPolicy{
@@ -140,6 +144,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	if cmd.Output.Pagination == nil || cmd.Output.Pagination.TokenParam != "page_token" {
 		t.Fatalf("pagination = %+v", cmd.Output.Pagination)
 	}
+	if cmd.Output.ColumnLabels["id"] != "ID" || cmd.Output.ColumnFormats["id"].SourceScale != 6 {
+		t.Fatalf("column metadata = %+v", cmd.Output)
+	}
 	if cmd.Output.Streaming == nil || cmd.Output.Streaming.Strategy != "sse" {
 		t.Fatalf("streaming = %+v", cmd.Output.Streaming)
 	}
@@ -175,6 +182,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if !reflect.DeepEqual(roundTrip.Commands[0].KnownErrors, cmd.KnownErrors) {
 		t.Fatalf("round-trip known errors = %#v", roundTrip.Commands[0].KnownErrors)
+	}
+	if !reflect.DeepEqual(roundTrip.Commands[0].Output.ColumnLabels, cmd.Output.ColumnLabels) || !reflect.DeepEqual(roundTrip.Commands[0].Output.ColumnFormats, cmd.Output.ColumnFormats) {
+		t.Fatalf("round-trip column metadata = %#v", roundTrip.Commands[0].Output)
 	}
 	if len(roundTrip.Commands[0].Examples) != 1 || roundTrip.Commands[0].Examples[0].OutputHints.IDPath != "data.user.id" {
 		t.Fatalf("round-trip examples = %#v", roundTrip.Commands[0].Examples)

--- a/pkg/runtime/column_format.go
+++ b/pkg/runtime/column_format.go
@@ -1,0 +1,137 @@
+package runtime
+
+import (
+	"encoding/json"
+	"math/big"
+	"strconv"
+	"strings"
+)
+
+func formatColumnValue(value any, format ColumnFormat) (string, bool) {
+	if format.Kind != "currency" || !validColumnFormat(format) {
+		return "", false
+	}
+	negative, digits, ok := integerValue(value)
+	if !ok {
+		return "", false
+	}
+	if strings.Trim(digits, "0") == "" {
+		negative = false
+	}
+	integer, fraction := scaleDigits(digits, format.SourceScale)
+	for len(fraction) > format.MinFractionDigits && strings.HasSuffix(fraction, "0") {
+		fraction = fraction[:len(fraction)-1]
+	}
+	for len(fraction) < format.MinFractionDigits {
+		fraction += "0"
+	}
+	if format.Grouping {
+		integer = groupInteger(integer)
+	}
+	prefix := format.Currency + " "
+	if format.Currency == "USD" {
+		prefix = "$"
+	}
+	var result strings.Builder
+	if negative {
+		result.WriteByte('-')
+	}
+	result.WriteString(prefix)
+	result.WriteString(integer)
+	if fraction != "" {
+		result.WriteByte('.')
+		result.WriteString(fraction)
+	}
+	return result.String(), true
+}
+
+func validColumnFormat(format ColumnFormat) bool {
+	if len(format.Currency) != 3 {
+		return false
+	}
+	for _, r := range format.Currency {
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+	return format.SourceScale >= 0 && format.SourceScale <= 18 &&
+		format.MinFractionDigits >= 0 && format.MinFractionDigits <= 18 &&
+		format.MaxFractionDigits >= format.MinFractionDigits && format.MaxFractionDigits <= 18 &&
+		format.MaxFractionDigits >= format.SourceScale
+}
+
+func integerValue(value any) (bool, string, bool) {
+	var raw string
+	switch value := value.(type) {
+	case json.Number:
+		raw = value.String()
+	case string:
+		raw = value
+	case int:
+		raw = strconv.Itoa(value)
+	case int8:
+		raw = strconv.FormatInt(int64(value), 10)
+	case int16:
+		raw = strconv.FormatInt(int64(value), 10)
+	case int32:
+		raw = strconv.FormatInt(int64(value), 10)
+	case int64:
+		raw = strconv.FormatInt(value, 10)
+	case uint:
+		raw = strconv.FormatUint(uint64(value), 10)
+	case uint8:
+		raw = strconv.FormatUint(uint64(value), 10)
+	case uint16:
+		raw = strconv.FormatUint(uint64(value), 10)
+	case uint32:
+		raw = strconv.FormatUint(uint64(value), 10)
+	case uint64:
+		raw = strconv.FormatUint(value, 10)
+	default:
+		return false, "", false
+	}
+	return parseInteger(raw)
+}
+
+func parseInteger(raw string) (bool, string, bool) {
+	if raw == "" || len(raw) > 4096 || strings.TrimSpace(raw) != raw || !json.Valid([]byte(raw)) {
+		return false, "", false
+	}
+	if _, err := strconv.ParseFloat(raw, 64); err != nil {
+		return false, "", false
+	}
+	value, ok := new(big.Rat).SetString(raw)
+	if !ok || !value.IsInt() {
+		return false, "", false
+	}
+	integer := value.Num()
+	return integer.Sign() < 0, new(big.Int).Abs(integer).String(), true
+}
+
+func scaleDigits(digits string, scale int) (string, string) {
+	if scale == 0 {
+		return digits, ""
+	}
+	if len(digits) <= scale {
+		return "0", strings.Repeat("0", scale-len(digits)) + digits
+	}
+	return digits[:len(digits)-scale], digits[len(digits)-scale:]
+}
+
+func groupInteger(value string) string {
+	if len(value) <= 3 {
+		return value
+	}
+	first := len(value) % 3
+	if first == 0 {
+		first = 3
+	}
+	var result strings.Builder
+	result.Grow(len(value) + len(value)/3)
+	result.WriteString(value[:first])
+	for index := first; index < len(value); index += 3 {
+		result.WriteByte(',')
+		result.WriteString(value[index : index+3])
+	}
+	return result.String()
+}

--- a/pkg/runtime/column_format.go
+++ b/pkg/runtime/column_format.go
@@ -1,11 +1,26 @@
 package runtime
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"strconv"
 	"strings"
 )
+
+func decodeNumberPreserving(data []byte) (any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var v any
+	if err := decoder.Decode(&v); err != nil {
+		return nil, err
+	}
+	if decoder.More() {
+		return nil, errors.New("trailing data after JSON value")
+	}
+	return v, nil
+}
 
 func formatColumnValue(value any, format ColumnFormat) (string, bool) {
 	if format.Kind != "currency" || !validColumnFormat(format) {

--- a/pkg/runtime/formatter_test.go
+++ b/pkg/runtime/formatter_test.go
@@ -99,6 +99,51 @@ func TestFormatOutput_TableUsesConfiguredColumnLabels(t *testing.T) {
 	}
 }
 
+func TestFormatOutput_TableUsesExactCurrencyFormats(t *testing.T) {
+	var buf bytes.Buffer
+	data := []byte(`{"items":[{"amount":1000000},{"amount":1234567},{"amount":1},{"amount":-5000000},{"amount":9007199254740993},{"amount":"2500000"},{"amount":1.25}]}`)
+	err := FormatOutput(data, "table", &buf, OutputHints{
+		ListPath:       "items",
+		DefaultColumns: []string{"amount"},
+		ColumnFormats: map[string]ColumnFormat{
+			"amount": {
+				Kind:              "currency",
+				Currency:          "USD",
+				SourceScale:       6,
+				Grouping:          true,
+				MinFractionDigits: 2,
+				MaxFractionDigits: 6,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "AMOUNT\n$1.00\n$1.234567\n$0.000001\n-$5.00\n$9,007,199,254.740993\n$2.50\n1.25\n"
+	if buf.String() != want {
+		t.Fatalf("table output = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestFormatOutput_CurrencyFormatIsTableOnly(t *testing.T) {
+	data := []byte(`{"amount":1000000}`)
+	hints := OutputHints{
+		DefaultColumns: []string{"amount"},
+		ColumnFormats: map[string]ColumnFormat{
+			"amount": {Kind: "currency", Currency: "USD", SourceScale: 6, MinFractionDigits: 2, MaxFractionDigits: 6},
+		},
+	}
+	for _, format := range []string{"json", "raw"} {
+		var buf bytes.Buffer
+		if err := FormatOutput(data, format, &buf, hints); err != nil {
+			t.Fatalf("%s: %v", format, err)
+		}
+		if !strings.Contains(buf.String(), "1000000") || strings.Contains(buf.String(), "$1.00") {
+			t.Fatalf("%s output changed: %q", format, buf.String())
+		}
+	}
+}
+
 func TestRegisterFormatter(t *testing.T) {
 	RegisterFormatter("custom", rawFormatter{})
 	defer delete(formatters, "custom")

--- a/pkg/runtime/formatter_test.go
+++ b/pkg/runtime/formatter_test.go
@@ -125,6 +125,24 @@ func TestFormatOutput_TableUsesExactCurrencyFormats(t *testing.T) {
 	}
 }
 
+func TestFormatOutput_TableWithFormatsDumpsRawOnTrailingData(t *testing.T) {
+	data := []byte(`{"items":[{"amount":1000000}]}{"error":"tail"}`)
+	var buf bytes.Buffer
+	err := FormatOutput(data, "table", &buf, OutputHints{
+		ListPath:       "items",
+		DefaultColumns: []string{"amount"},
+		ColumnFormats: map[string]ColumnFormat{
+			"amount": {Kind: "currency", Currency: "USD", SourceScale: 6, MinFractionDigits: 2, MaxFractionDigits: 6},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != string(data) {
+		t.Fatalf("table output = %q, want raw payload", buf.String())
+	}
+}
+
 func TestFormatOutput_CurrencyFormatIsTableOnly(t *testing.T) {
 	data := []byte(`{"amount":1000000}`)
 	hints := OutputHints{

--- a/pkg/runtime/paginate.go
+++ b/pkg/runtime/paginate.go
@@ -89,8 +89,8 @@ func setBodyParam(body any, path string, value string) ([]byte, error) {
 }
 
 func extractItemsRaw(data []byte, listPath string) []json.RawMessage {
-	var root any
-	if err := json.Unmarshal(data, &root); err != nil {
+	root, err := decodeNumberPreserving(data)
+	if err != nil {
 		return nil
 	}
 	var arr []any

--- a/pkg/runtime/paginate_test.go
+++ b/pkg/runtime/paginate_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestPaginateAll_Cursor(t *testing.T) {
 	pages := []map[string]any{
-		{"items": []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}}, "next_page_token": "tok2"},
+		{"items": []any{map[string]any{"id": "1", "amount": int64(9007199254740993)}, map[string]any{"id": "2"}}, "next_page_token": "tok2"},
 		{"items": []any{map[string]any{"id": "3"}}, "next_page_token": ""},
 	}
 	var call int32
@@ -37,12 +37,15 @@ func TestPaginateAll_Cursor(t *testing.T) {
 		t.Fatalf("PaginateAll: %v", err)
 	}
 
-	var result map[string][]map[string]string
+	var result map[string][]map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if len(result["items"]) != 3 {
 		t.Errorf("got %d items, want 3", len(result["items"]))
+	}
+	if !strings.Contains(string(data), "9007199254740993") {
+		t.Errorf("merged output lost integer precision: %s", data)
 	}
 	if atomic.LoadInt32(&call) != 2 {
 		t.Errorf("made %d requests, want 2", atomic.LoadInt32(&call))

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 11
+const SchemaVersion = 12
 
 type CommandSpec struct {
 	Group           string
@@ -144,10 +144,20 @@ func (s *AdditionalPropertiesSpec) UnmarshalJSON(data []byte) error {
 type OutputHints struct {
 	ListPath          string
 	DefaultColumns    []string
-	ColumnLabels      map[string]string `json:",omitempty"`
+	ColumnLabels      map[string]string       `json:",omitempty"`
+	ColumnFormats     map[string]ColumnFormat `json:",omitempty"`
 	ResponseMediaType string
 	Pagination        *PaginationHint
 	Streaming         *StreamingHint
+}
+
+type ColumnFormat struct {
+	Kind              string `json:"kind"`
+	Currency          string `json:"currency,omitempty"`
+	SourceScale       int    `json:"source_scale,omitempty"`
+	Grouping          bool   `json:"grouping,omitempty"`
+	MinFractionDigits int    `json:"min_fraction_digits,omitempty"`
+	MaxFractionDigits int    `json:"max_fraction_digits,omitempty"`
 }
 
 type PaginationHint struct {

--- a/pkg/runtime/stream.go
+++ b/pkg/runtime/stream.go
@@ -22,8 +22,8 @@ func collectStream(r io.Reader, hint *StreamingHint, live io.Writer, outcome *st
 	collected := map[string]any{}
 	stopped := false
 	handle := func(transportEvent string, data []byte) error {
-		var payload any
-		if err := json.Unmarshal(data, &payload); err != nil {
+		payload, err := decodeNumberPreserving(data)
+		if err != nil {
 			return newAPIError(fmt.Errorf("decode %s stream event: %w", hint.Strategy, err), 0)
 		}
 		event := transportEvent

--- a/pkg/runtime/stream_test.go
+++ b/pkg/runtime/stream_test.go
@@ -22,7 +22,7 @@ func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
 		close(firstSent)
 		select {
 		case <-release:
-			_, _ = io.WriteString(w, "data: {\"kind\":\"chunk\",\"text\":\"lo\"}\r\rdata: {\"kind\":\"done\",\"id\":\"msg-1\"}\r\r")
+			_, _ = io.WriteString(w, "data: {\"kind\":\"chunk\",\"text\":\"lo\"}\r\rdata: {\"kind\":\"done\",\"id\":\"msg-1\",\"usage\":9007199254740993}\r\r")
 		case <-r.Context().Done():
 		}
 	}))
@@ -37,6 +37,7 @@ func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
 				{Events: []string{"chunk"}, From: "text", To: "answer", Reduce: "concat"},
 				{Events: []string{"chunk"}, From: "mode", To: "mode", Reduce: "first"},
 				{Events: []string{"done"}, From: "id", To: "message_id", Reduce: "last"},
+				{Events: []string{"done"}, From: "usage", To: "usage", Reduce: "last"},
 			},
 		},
 		Live: &StreamLiveHint{Events: []string{"chunk"}, From: "text"},
@@ -72,11 +73,11 @@ func TestInvokeOperation_CollectsAndProjectsSSE(t *testing.T) {
 	if result.Outcome != OperationOutcomeCompleted || out.String() != "hello" {
 		t.Fatalf("outcome = %q, live = %q", result.Outcome, out.String())
 	}
-	var got map[string]any
-	if err := json.Unmarshal(result.Data, &got); err != nil {
+	got, err := decodeNumberPreserving(result.Data)
+	if err != nil {
 		t.Fatalf("decode result: %v", err)
 	}
-	want := map[string]any{"answer": "hello", "message_id": "msg-1", "mode": "chat"}
+	want := map[string]any{"answer": "hello", "message_id": "msg-1", "mode": "chat", "usage": json.Number("9007199254740993")}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("result = %#v, want %#v", got, want)
 	}

--- a/pkg/runtime/table.go
+++ b/pkg/runtime/table.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,9 +32,7 @@ func renderTable(data []byte, w io.Writer, hints OutputHints) error {
 	if len(hints.ColumnFormats) == 0 {
 		err = json.Unmarshal(data, &v)
 	} else {
-		decoder := json.NewDecoder(bytes.NewReader(data))
-		decoder.UseNumber()
-		err = decoder.Decode(&v)
+		v, err = decodeNumberPreserving(data)
 	}
 	if err != nil {
 		_, werr := w.Write(data)

--- a/pkg/runtime/table.go
+++ b/pkg/runtime/table.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -28,7 +29,9 @@ const maxColumns = 6
 
 func renderTable(data []byte, w io.Writer, hints OutputHints) error {
 	var v any
-	if err := json.Unmarshal(data, &v); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&v); err != nil {
 		_, werr := w.Write(data)
 		return werr
 	}
@@ -40,7 +43,7 @@ func renderTable(data []byte, w io.Writer, hints OutputHints) error {
 	if len(cols) == 0 {
 		return renderJSON(data, w)
 	}
-	return writeTable(cols, rows, hints.ColumnLabels, w)
+	return writeTable(cols, rows, hints.ColumnLabels, hints.ColumnFormats, w)
 }
 
 // chooseColumns prefers codegen-supplied DefaultColumns when available,
@@ -173,10 +176,15 @@ func collectPaths(v any, prefix string, maxDepth int, out map[string]struct{}) {
 	}
 }
 
-func lookupPath(row map[string]any, path string) string {
+func lookupPath(row map[string]any, path string, formats map[string]ColumnFormat) string {
 	v, ok := tableValue(row, path)
 	if !ok {
 		return ""
+	}
+	if format, ok := formats[path]; ok {
+		if formatted, ok := formatColumnValue(v, format); ok {
+			return formatted
+		}
 	}
 	return stringify(v)
 }
@@ -210,6 +218,12 @@ func stringify(v any) string {
 		return x
 	case nil:
 		return ""
+	case json.Number:
+		value, err := x.Float64()
+		if err != nil {
+			return x.String()
+		}
+		return stringify(value)
 	case float64:
 		if x == float64(int64(x)) {
 			return fmt.Sprintf("%d", int64(x))
@@ -222,7 +236,7 @@ func stringify(v any) string {
 	}
 }
 
-func writeTable(cols []string, rows []map[string]any, labels map[string]string, w io.Writer) error {
+func writeTable(cols []string, rows []map[string]any, labels map[string]string, formats map[string]ColumnFormat, w io.Writer) error {
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	for i, c := range cols {
 		if i > 0 {
@@ -236,7 +250,7 @@ func writeTable(cols []string, rows []map[string]any, labels map[string]string, 
 			if i > 0 {
 				fmt.Fprint(tw, "\t")
 			}
-			fmt.Fprint(tw, lookupPath(r, c))
+			fmt.Fprint(tw, lookupPath(r, c, formats))
 		}
 		fmt.Fprintln(tw)
 	}

--- a/pkg/runtime/table.go
+++ b/pkg/runtime/table.go
@@ -29,9 +29,15 @@ const maxColumns = 6
 
 func renderTable(data []byte, w io.Writer, hints OutputHints) error {
 	var v any
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := decoder.Decode(&v); err != nil {
+	var err error
+	if len(hints.ColumnFormats) == 0 {
+		err = json.Unmarshal(data, &v)
+	} else {
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.UseNumber()
+		err = decoder.Decode(&v)
+	}
+	if err != nil {
 		_, werr := w.Write(data)
 		return werr
 	}


### PR DESCRIPTION
### What is changed?

- Add declarative column_formats for currency, fixed-point source scaling, grouping, and fraction bounds.
- Preserve exact scaled values without floating-point conversion and keep JSON, YAML, and raw output unchanged.
- Expose column labels and formats through catalog schema 19 and bump the generated runtime schema.
- Add overlay validation, code generation, runtime formatting, catalog round-trip coverage, and usage documentation.

### Why

- Let downstream generated CLIs produce readable monetary tables entirely through overlays, without application-specific renderers.

### Verification

- make check
- go test -race ./...
- go test -race -count=1 ./pkg/runtime ./internal/codegen/render ./internal/overlay
- Generated and built a Tokener scratch CLI, then verified catalog metadata and live currency table output.