### PR TITLE
feat(runtime): add declarative JSON body flags

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -299,11 +299,11 @@ commands:
 
 Supported uses include command/group summaries, aliases, examples, shortcuts,
 visibility, parameter help/defaults/required tightening/deprecation, positional
-alternatives, active contexts, runtime schema preflights, and stream collection.
-Unknown groups and conflicting root names fail codegen. Command overrides apply
-only to an exact command/match; unmatched command entries and most unmatched
-parameter entries are ignored. An `argument` entry for an unknown parameter
-fails validation.
+alternatives, active contexts, runtime schema preflights, JSON body flags, and
+stream collection. Unknown groups and conflicting root names fail codegen.
+Command overrides apply only to an exact command/match; unmatched command
+entries and most unmatched parameter entries are ignored. An `argument` entry
+for an unknown parameter fails validation.
 
 `ignore: true` removes a command. `hidden: true` keeps it out of normal help,
 search, and catalog output; `--include-hidden` can still inspect it.
@@ -314,6 +314,30 @@ OpenAPI multipart object fields and Swagger `formData` parameters become
 normal command flags. A field with `format: binary` accepts a local file path;
 the runtime opens it and builds the multipart request. These commands do not use
 the JSON body builder's `--file`, `--set`, or `--set-str` flags.
+
+### JSON Body Flags
+
+Opt in per command to turn a flat JSON object body into typed flags. Default
+codegen is unchanged.
+
+```yaml
+commands:
+  update-limits:
+    body:
+      flags: true
+```
+
+Supported property types are string, number, integer, boolean, nullable scalars,
+and scalar arrays. Nested objects, maps, leftover `oneOf`/`anyOf`/`allOf` after
+nullable flattening, multipart bodies, and GraphQL templates fail codegen.
+Property descriptions become flag help, and typed scalar or array-item enum
+flags are validated locally. Required properties may be supplied by a typed flag,
+`--file`, `--set`, or `--set-str`; omitting an optional body remains valid.
+`--file` cannot be combined with `--set`, `--set-str`, or body flags on these
+commands. The same field cannot be set by a typed flag and `--set`. Explicit
+`null` still uses `--set field=null`. Upgrading to this capability requires
+regenerating modules against the matching runtime and updating catalog consumers
+for the new body-location and array-item enum contract.
 
 ### Runtime Body Schema
 

--- a/examples/overlay/example.yaml
+++ b/examples/overlay/example.yaml
@@ -77,5 +77,7 @@ commands:
 #         argument: workspace
 #         help: "Target workspace name"
 #         default: "default"
+#     body:
+#       flags: true
 #   internal-debug:
 #     ignore: true

--- a/internal/codegen/backends/openapi3/backend.go
+++ b/internal/codegen/backends/openapi3/backend.go
@@ -85,6 +85,7 @@ type response struct {
 type schemaNode struct {
 	Ref                  string                      `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 	Type                 schemaType                  `json:"type,omitempty" yaml:"type,omitempty"`
+	Description          string                      `json:"description,omitempty" yaml:"description,omitempty"`
 	Format               string                      `json:"format,omitempty" yaml:"format,omitempty"`
 	Default              any                         `json:"default,omitempty" yaml:"default,omitempty"`
 	Enum                 []any                       `json:"enum,omitempty" yaml:"enum,omitempty"`
@@ -588,14 +589,19 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 	if len(s.OneOf) == 0 && len(s.AllOf) == 0 {
 		if option, ok := nullableAlternative(s, s.AnyOf); ok {
 			out := convertSchema(option)
+			if s.Description != "" {
+				out.Description = s.Description
+			}
 			out.Nullable = true
 			return out
 		}
 	}
 	out := &rawir.RawSchema{
-		Type:     s.Type.Value,
-		Format:   s.Format,
-		Nullable: s.Nullable || s.Type.Nullable,
+		Type:        s.Type.Value,
+		Description: s.Description,
+		Format:      s.Format,
+		Nullable:    s.Nullable || s.Type.Nullable,
+		Enum:        anySliceToStrings(s.Enum),
 	}
 	if s.Ref != "" {
 		if strings.HasPrefix(s.Ref, oas3RefPrefix) {

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -231,6 +231,50 @@ func TestParse_OpenAPI31SchemaFidelity(t *testing.T) {
 	}
 }
 
+func TestParse_NullableEnumAnyOfBecomesBodyFlagSchema(t *testing.T) {
+	input := `{
+  "openapi": "3.1.0",
+  "paths": {
+    "/keys/{id}/limits": {
+      "patch": {
+        "operationId": "updateLimits",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+				  "budgetDuration": {"description": "Budget duration", "anyOf": [{"type": "string", "enum": ["daily", "weekly", "monthly"]}, {"type": "null"}]},
+                  "maxBudgetUsd": {"anyOf": [{"type": "number"}, {"type": "null"}]}
+                }
+              }
+            }
+          }
+        },
+        "responses": {"200": {}}
+      }
+    }
+  }
+}`
+	spec := parseNormalized(t, input)[0]
+	duration := spec.RequestBody.Schema.Properties["budgetDuration"]
+	if duration.Type != "string" || !duration.Nullable || len(duration.Enum) != 3 || duration.Enum[0] != "daily" {
+		t.Fatalf("budgetDuration = %#v", duration)
+	}
+	if spec.RequestBody.Schema.Properties["maxBudgetUsd"].Type != "number" || !spec.RequestBody.Schema.Properties["maxBudgetUsd"].Nullable {
+		t.Fatalf("maxBudgetUsd = %#v", spec.RequestBody.Schema.Properties["maxBudgetUsd"])
+	}
+	got, err := normalize.ExpandJSONBodyFlags(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].Flag != "budget-duration" || got[0].Enum[0] != "daily" || !strings.Contains(got[0].Help, "Budget duration") || got[1].GoType != "float64" {
+		t.Fatalf("flags = %#v", got)
+	}
+}
+
 func TestParse_MultipartBodyFields(t *testing.T) {
 	input := `{
   "openapi": "3.0.3",

--- a/internal/codegen/backends/proto/backend.go
+++ b/internal/codegen/backends/proto/backend.go
@@ -217,6 +217,7 @@ func (idx *index) buildOperation(
 			schema = idx.bodyWildcardSchema(reqMsg, pathParamSet, extra)
 		} else if field := findField(reqMsg, rule.body); field != nil {
 			schema = idx.fieldToSchema(field, extra, map[string]bool{})
+			schema.Description = fieldComment(reqMsg, field)
 		}
 		op.RequestBody = &rawir.RawRequestBody{Required: true, Schema: schema}
 	}
@@ -382,10 +383,9 @@ func (idx *index) messageToSchema(entry *messageEntry, out map[string]*rawir.Raw
 		}
 		out[key] = sch
 		for _, f := range entry.msg.Field {
-			if idx.isMapField(f) {
-				continue
-			}
-			sch.Properties[jsonName(f)] = idx.fieldToSchema(f, out, visiting)
+			property := idx.fieldToSchema(f, out, visiting)
+			property.Description = fieldComment(entry, f)
+			sch.Properties[jsonName(f)] = property
 		}
 	}
 	return &rawir.RawSchema{Ref: rawir.RefPrefix + key}
@@ -413,10 +413,9 @@ func (idx *index) bodyWildcardSchema(reqMsg *messageEntry, pathParamSet map[stri
 		if pathParamSet[f.GetName()] {
 			continue
 		}
-		if idx.isMapField(f) {
-			continue
-		}
-		schema.Properties[jsonName(f)] = idx.fieldToSchema(f, out, map[string]bool{})
+		property := idx.fieldToSchema(f, out, map[string]bool{})
+		property.Description = fieldComment(reqMsg, f)
+		schema.Properties[jsonName(f)] = property
 	}
 	if len(schema.Properties) == 0 {
 		schema.Properties = nil
@@ -425,6 +424,21 @@ func (idx *index) bodyWildcardSchema(reqMsg *messageEntry, pathParamSet map[stri
 }
 
 func (idx *index) fieldToSchema(f *descriptorpb.FieldDescriptorProto, out map[string]*rawir.RawSchema, visiting map[string]bool) *rawir.RawSchema {
+	if idx.isMapField(f) {
+		entry := idx.messages[f.GetTypeName()]
+		value := findField(entry, "value")
+		var valueSchema *rawir.RawSchema
+		if value != nil {
+			valueSchema = idx.fieldToSchema(value, out, visiting)
+		}
+		return &rawir.RawSchema{
+			Type: "object",
+			AdditionalProperties: &rawir.RawAdditionalProperties{
+				Allowed: true,
+				Schema:  valueSchema,
+			},
+		}
+	}
 	repeated := f.GetLabel() == descriptorpb.FieldDescriptorProto_LABEL_REPEATED
 	s := scalarOrMessageSchema(idx, f, out, visiting)
 	if repeated {
@@ -447,7 +461,13 @@ func scalarOrMessageSchema(idx *index, f *descriptorpb.FieldDescriptorProto, out
 	case descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_TYPE_BYTES:
 		return &rawir.RawSchema{Type: "string"}
 	case descriptorpb.FieldDescriptorProto_TYPE_ENUM:
-		return &rawir.RawSchema{Type: "string"}
+		schema := &rawir.RawSchema{Type: "string"}
+		if enum := idx.enums[f.GetTypeName()]; enum != nil {
+			for _, value := range enum.Value {
+				schema.Enum = append(schema.Enum, value.GetName())
+			}
+		}
+		return schema
 	case descriptorpb.FieldDescriptorProto_TYPE_INT32, descriptorpb.FieldDescriptorProto_TYPE_INT64,
 		descriptorpb.FieldDescriptorProto_TYPE_UINT32, descriptorpb.FieldDescriptorProto_TYPE_UINT64,
 		descriptorpb.FieldDescriptorProto_TYPE_SINT32, descriptorpb.FieldDescriptorProto_TYPE_SINT64,

--- a/internal/codegen/backends/proto/backend_test.go
+++ b/internal/codegen/backends/proto/backend_test.go
@@ -72,6 +72,27 @@ func TestParseIgnoresImportedDependencyServices(t *testing.T) {
 	}
 }
 
+func TestParsePreservesMapRequestBodySchema(t *testing.T) {
+	fds := buildGoogleAPIHTTPPostBodyStarPath()
+	data, err := proto.Marshal(fds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	syncDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(syncDir, descriptorFile), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := &sourceconfig.Source{Name: "demo", Proto: &sourceconfig.ProtoConfig{Entries: []string{"demo.proto"}}}
+	mod, err := Parse(src, syncDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	labels := mod.Operations[0].RequestBody.Schema.Properties["labels"]
+	if labels == nil || labels.Type != "object" || labels.AdditionalProperties == nil || labels.AdditionalProperties.Schema == nil || labels.AdditionalProperties.Schema.Type != "string" {
+		t.Fatalf("labels schema = %#v", labels)
+	}
+}
+
 // ---- descriptor builders ----------------------------------------------------
 
 func scalarField(name string, num int32, typ descriptorpb.FieldDescriptorProto_Type) *descriptorpb.FieldDescriptorProto {

--- a/internal/codegen/backends/proto/testdata/google-api-http-post-body-star-path.golden.json
+++ b/internal/codegen/backends/proto/testdata/google-api-http-post-body-star-path.golden.json
@@ -33,6 +33,21 @@
               "Properties": null,
               "Items": null
             },
+            "labels": {
+              "Ref": "",
+              "Type": "object",
+              "Properties": null,
+              "Items": null,
+              "AdditionalProperties": {
+                "Allowed": true,
+                "Schema": {
+                  "Ref": "",
+                  "Type": "string",
+                  "Properties": null,
+                  "Items": null
+                }
+              }
+            },
             "name": {
               "Ref": "",
               "Type": "string",

--- a/internal/codegen/backends/swagger/backend.go
+++ b/internal/codegen/backends/swagger/backend.go
@@ -1,6 +1,7 @@
 package swagger
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -66,11 +67,38 @@ type response struct {
 }
 
 type schemaNode struct {
-	Ref        string                 `json:"$ref,omitempty"`
-	Type       string                 `json:"type,omitempty"`
-	Properties map[string]*schemaNode `json:"properties,omitempty"`
-	Required   []string               `json:"required,omitempty"`
-	Items      *schemaNode            `json:"items,omitempty"`
+	Ref                  string                      `json:"$ref,omitempty"`
+	Type                 string                      `json:"type,omitempty"`
+	Description          string                      `json:"description,omitempty"`
+	Format               string                      `json:"format,omitempty"`
+	Enum                 []any                       `json:"enum,omitempty"`
+	Properties           map[string]*schemaNode      `json:"properties,omitempty"`
+	Required             []string                    `json:"required,omitempty"`
+	Items                *schemaNode                 `json:"items,omitempty"`
+	AdditionalProperties *schemaAdditionalProperties `json:"additionalProperties,omitempty"`
+}
+
+type schemaAdditionalProperties struct {
+	Allowed bool
+	Schema  *schemaNode
+}
+
+func (p *schemaAdditionalProperties) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if bytes.Equal(data, []byte("true")) || bytes.Equal(data, []byte("false")) {
+		p.Schema = nil
+		return json.Unmarshal(data, &p.Allowed)
+	}
+	if len(data) == 0 || data[0] != '{' {
+		return fmt.Errorf("additionalProperties must be a boolean or schema")
+	}
+	var schema schemaNode
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return err
+	}
+	p.Allowed = false
+	p.Schema = &schema
+	return nil
 }
 
 func Parse(src *sourceconfig.Source, syncDir string) (*rawir.RawModule, error) {
@@ -258,8 +286,11 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 		return nil
 	}
 	out := &rawir.RawSchema{
-		Ref:  s.Ref,
-		Type: s.Type,
+		Ref:         s.Ref,
+		Type:        s.Type,
+		Description: s.Description,
+		Format:      s.Format,
+		Enum:        anySliceToStrings(s.Enum),
 	}
 	if len(s.Properties) > 0 {
 		out.Properties = make(map[string]*rawir.RawSchema, len(s.Properties))
@@ -272,6 +303,12 @@ func convertSchema(s *schemaNode) *rawir.RawSchema {
 	}
 	if s.Items != nil {
 		out.Items = convertSchema(s.Items)
+	}
+	if s.AdditionalProperties != nil {
+		out.AdditionalProperties = &rawir.RawAdditionalProperties{
+			Allowed: s.AdditionalProperties.Allowed,
+			Schema:  convertSchema(s.AdditionalProperties.Schema),
+		}
 	}
 	return out
 }

--- a/internal/codegen/backends/swagger/backend_test.go
+++ b/internal/codegen/backends/swagger/backend_test.go
@@ -148,6 +148,49 @@ func TestParse_SecuritySemantics(t *testing.T) {
 	}
 }
 
+func TestParse_PreservesBodySchemaMetadata(t *testing.T) {
+	input := `{
+	  "swagger": "2.0",
+	  "paths": {
+	    "/secrets": {
+	      "post": {
+	        "operationId": "Secrets_Create",
+	        "parameters": [{
+	          "name": "body",
+	          "in": "body",
+	          "required": true,
+	          "schema": {
+	            "type": "object",
+	            "properties": {
+	              "value": {"type": "string", "description": "Secret value", "format": "password", "enum": ["primary"]},
+	              "labels": {"type": "object", "additionalProperties": {"type": "string"}}
+	            }
+	          }
+	        }],
+	        "responses": {"200": {}}
+	      }
+	    }
+	  }
+	}`
+	syncDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(syncDir, "swagger.json"), []byte(input), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mod, err := Parse(&sourceconfig.Source{Name: "demo", Swagger: &sourceconfig.SwaggerConfig{Files: []string{"swagger.json"}}}, syncDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema := normalize.Normalize(mod)[0].RequestBody.Schema
+	value := schema.Properties["value"]
+	labels := schema.Properties["labels"]
+	if value.Description != "Secret value" || value.Format != "password" || len(value.Enum) != 1 || value.Enum[0] != "primary" {
+		t.Fatalf("value schema = %#v", value)
+	}
+	if labels.AdditionalProperties == nil || labels.AdditionalProperties.Schema == nil || labels.AdditionalProperties.Schema.Type != "string" {
+		t.Fatalf("labels schema = %#v", labels)
+	}
+}
+
 const petstoreMinInput = `{
   "swagger": "2.0",
   "definitions": {

--- a/internal/codegen/normalize/body_flags.go
+++ b/internal/codegen/normalize/body_flags.go
@@ -1,0 +1,244 @@
+package normalize
+
+import (
+	"fmt"
+	"mime"
+	"sort"
+	"strings"
+
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+var reservedBodyFlagNames = map[string]bool{
+	"all":       true,
+	"debug":     true,
+	"dry-run":   true,
+	"file":      true,
+	"help":      true,
+	"hostname":  true,
+	"max-pages": true,
+	"output":    true,
+	"set":       true,
+	"set-str":   true,
+	"stream":    true,
+	"version":   true,
+	"wait":      true,
+}
+
+func ExpandJSONBodyFlags(spec runtime.CommandSpec) ([]runtime.ParamSpec, error) {
+	if spec.RequestBody == nil {
+		return nil, fmt.Errorf("command has no request body")
+	}
+	if spec.RequestBody.Template != "" {
+		return nil, fmt.Errorf("GraphQL request templates cannot enable body flags")
+	}
+	mediaType, _, err := mime.ParseMediaType(spec.RequestBody.MediaType)
+	if spec.RequestBody.MediaType != "" && err != nil {
+		return nil, fmt.Errorf("request body media type: %w", err)
+	}
+	if mediaType == "" {
+		mediaType = spec.RequestBody.MediaType
+	}
+	if isMultipartMediaType(mediaType) || hasFormDataParams(spec.Params) {
+		return nil, fmt.Errorf("multipart request bodies cannot enable body flags")
+	}
+	if !runtimeJSONBodyMediaType(mediaType) {
+		return nil, fmt.Errorf("request body media type %q cannot enable body flags", spec.RequestBody.MediaType)
+	}
+	schema := spec.RequestBody.Schema
+	if schema == nil {
+		return nil, fmt.Errorf("request body schema is required")
+	}
+	if err := rejectUnsupportedJSONBodySchema(schema, true); err != nil {
+		return nil, err
+	}
+	required := make(map[string]bool, len(schema.Required))
+	for _, name := range schema.Required {
+		required[name] = true
+	}
+	names := make([]string, 0, len(schema.Properties))
+	for name := range schema.Properties {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	existing := map[string]bool{}
+	for _, param := range spec.Params {
+		existing[param.Flag] = true
+		existing[param.Name] = true
+		for _, alias := range param.Aliases {
+			existing[alias] = true
+		}
+	}
+	out := make([]runtime.ParamSpec, 0, len(names))
+	seenFlags := map[string]string{}
+	for _, name := range names {
+		property := schema.Properties[name]
+		goType, err := jsonBodyFlagGoType(property)
+		if err != nil {
+			return nil, fmt.Errorf("property %q: %w", name, err)
+		}
+		flag := camelToKebab(name)
+		if flag == "" {
+			return nil, fmt.Errorf("property %q does not produce a flag name", name)
+		}
+		if reservedBodyFlagNames[flag] {
+			return nil, fmt.Errorf("property %q flag %q conflicts with a reserved flag", name, flag)
+		}
+		if existing[flag] || existing[name] {
+			return nil, fmt.Errorf("property %q flag %q conflicts with an existing parameter", name, flag)
+		}
+		if prior, ok := seenFlags[flag]; ok {
+			return nil, fmt.Errorf("properties %q and %q produce the same flag %q", prior, name, flag)
+		}
+		seenFlags[flag] = name
+		out = append(out, runtime.ParamSpec{
+			Name:     name,
+			Flag:     flag,
+			In:       runtime.InBody,
+			GoType:   goType,
+			Help:     jsonBodyFlagHelp(name, property, required[name]),
+			Required: required[name],
+			Enum:     append([]string(nil), property.Enum...),
+			ItemEnum: jsonBodyItemEnum(property),
+			Format:   property.Format,
+		})
+	}
+	return out, nil
+}
+
+func ValidateJSONBodyFlagParams(spec runtime.CommandSpec) error {
+	hasBodyFlags := false
+	for _, param := range spec.Params {
+		if param.In == runtime.InBody {
+			hasBodyFlags = true
+			break
+		}
+	}
+	if !hasBodyFlags {
+		return nil
+	}
+	if err := runtime.ValidateParamFlags(spec.Params); err != nil {
+		return err
+	}
+	for _, param := range spec.Params {
+		names := append([]string{param.Flag}, param.Aliases...)
+		for _, name := range names {
+			if name == "" {
+				continue
+			}
+			if param.In == runtime.InBody && reservedBodyFlagNames[name] {
+				return fmt.Errorf("body property %q flag %q conflicts with a reserved flag", param.Name, name)
+			}
+		}
+	}
+	return nil
+}
+
+func jsonBodyFlagGoType(schema *runtime.SchemaSpec) (string, error) {
+	if schema == nil {
+		return "", fmt.Errorf("schema is required")
+	}
+	if err := rejectUnsupportedJSONBodySchema(schema, false); err != nil {
+		return "", err
+	}
+	switch schema.Type {
+	case "string":
+		return "string", nil
+	case "integer":
+		return "int64", nil
+	case "number":
+		return "float64", nil
+	case "boolean":
+		return "bool", nil
+	case "array":
+		if schema.Items == nil {
+			return "", fmt.Errorf("array items are required")
+		}
+		itemType, err := jsonBodyFlagGoType(schema.Items)
+		if err != nil {
+			return "", err
+		}
+		if strings.HasPrefix(itemType, "[]") {
+			return "", fmt.Errorf("nested arrays are not supported")
+		}
+		return "[]" + itemType, nil
+	default:
+		return "", fmt.Errorf("unsupported type %q", schema.Type)
+	}
+}
+
+func rejectUnsupportedJSONBodySchema(schema *runtime.SchemaSpec, root bool) error {
+	if schema == nil {
+		return fmt.Errorf("schema is required")
+	}
+	if schema.Ref != "" && schema.Type == "" && len(schema.Properties) == 0 && schema.Items == nil {
+		return fmt.Errorf("unresolved schema refs are not supported")
+	}
+	if len(schema.AnyOf) > 0 || len(schema.OneOf) > 0 || len(schema.AllOf) > 0 {
+		return fmt.Errorf("oneOf/anyOf/allOf is not supported")
+	}
+	if schema.AdditionalProperties != nil && (schema.AdditionalProperties.Allowed || schema.AdditionalProperties.Schema != nil) {
+		return fmt.Errorf("maps are not supported")
+	}
+	if root {
+		if schema.Type != "object" {
+			return fmt.Errorf("request body must be a JSON object")
+		}
+		if len(schema.Properties) == 0 {
+			return fmt.Errorf("request body object has no properties")
+		}
+		return nil
+	}
+	if schema.Type == "object" || len(schema.Properties) > 0 {
+		return fmt.Errorf("nested objects are not supported")
+	}
+	return nil
+}
+
+func jsonBodyFlagHelp(name string, schema *runtime.SchemaSpec, required bool) string {
+	base := name
+	if schema != nil && strings.TrimSpace(schema.Description) != "" {
+		base = firstLine(schema.Description)
+	}
+	parts := []string{"body"}
+	if required {
+		parts = append(parts, "required")
+	}
+	if schema != nil && schema.Format != "" {
+		parts = append(parts, schema.Format)
+	}
+	if schema != nil && len(schema.Enum) > 0 {
+		parts = append(parts, "one of: "+strings.Join(schema.Enum, "|"))
+	}
+	if items := jsonBodyItemEnum(schema); len(items) > 0 {
+		parts = append(parts, "items one of: "+strings.Join(items, "|"))
+	}
+	return fmt.Sprintf("%s (%s)", base, strings.Join(parts, ", "))
+}
+
+func jsonBodyItemEnum(schema *runtime.SchemaSpec) []string {
+	if schema == nil || schema.Type != "array" || schema.Items == nil {
+		return nil
+	}
+	return append([]string(nil), schema.Items.Enum...)
+}
+
+func runtimeJSONBodyMediaType(mediaType string) bool {
+	mt, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(mediaType)), ";")
+	mt = strings.TrimSpace(mt)
+	return mt == "" || mt == "application/json" || strings.HasSuffix(mt, "+json")
+}
+
+func isMultipartMediaType(mediaType string) bool {
+	mt, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(mediaType)), ";")
+	return strings.TrimSpace(mt) == "multipart/form-data"
+}
+
+func hasFormDataParams(params []runtime.ParamSpec) bool {
+	for _, param := range params {
+		if param.In == runtime.InFormData {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codegen/normalize/body_flags_test.go
+++ b/internal/codegen/normalize/body_flags_test.go
@@ -1,0 +1,145 @@
+package normalize
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lathe-cli/lathe/pkg/runtime"
+)
+
+func TestExpandJSONBodyFlags(t *testing.T) {
+	spec := runtime.CommandSpec{
+		Use:    "replace-limits",
+		Method: "PATCH",
+		Params: []runtime.ParamSpec{{Name: "id", Flag: "id", Argument: "key-id", In: runtime.InPath, GoType: "string", Required: true}},
+		RequestBody: &runtime.RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			Schema: &runtime.SchemaSpec{
+				Type: "object",
+				Properties: map[string]*runtime.SchemaSpec{
+					"maxBudgetUsd":        {Type: "number", Nullable: true},
+					"budgetDuration":      {Type: "string", Nullable: true, Enum: []string{"daily", "weekly", "monthly"}},
+					"rpmLimit":            {Type: "integer", Nullable: true},
+					"allowedModels":       {Type: "array", Nullable: true, Items: &runtime.SchemaSpec{Type: "string", Enum: []string{"model-a", "model-b"}}},
+					"expiresAt":           {Type: "string", Format: "date-time", Nullable: true},
+					"maxParallelRequests": {Type: "integer", Nullable: true},
+				},
+			},
+		},
+	}
+	got, err := ExpandJSONBodyFlags(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]runtime.ParamSpec{}
+	for _, param := range got {
+		byName[param.Name] = param
+		if param.In != runtime.InBody {
+			t.Errorf("%s In = %q", param.Name, param.In)
+		}
+		if param.Required {
+			t.Errorf("%s unexpectedly required", param.Name)
+		}
+	}
+	if byName["maxBudgetUsd"].Flag != "max-budget-usd" || byName["maxBudgetUsd"].GoType != "float64" {
+		t.Fatalf("maxBudgetUsd = %+v", byName["maxBudgetUsd"])
+	}
+	if byName["budgetDuration"].Flag != "budget-duration" || !equalStrings(byName["budgetDuration"].Enum, []string{"daily", "weekly", "monthly"}) {
+		t.Fatalf("budgetDuration = %+v", byName["budgetDuration"])
+	}
+	if byName["rpmLimit"].GoType != "int64" {
+		t.Fatalf("rpmLimit = %+v", byName["rpmLimit"])
+	}
+	if byName["allowedModels"].GoType != "[]string" || !equalStrings(byName["allowedModels"].ItemEnum, []string{"model-a", "model-b"}) {
+		t.Fatalf("allowedModels = %+v", byName["allowedModels"])
+	}
+	if byName["expiresAt"].Format != "date-time" {
+		t.Fatalf("expiresAt = %+v", byName["expiresAt"])
+	}
+}
+
+func TestExpandJSONBodyFlags_RequiredAndCollision(t *testing.T) {
+	spec := runtime.CommandSpec{
+		Use:    "create",
+		Params: []runtime.ParamSpec{{Name: "file", Flag: "file", In: runtime.InQuery, GoType: "string"}},
+		RequestBody: &runtime.RequestBody{
+			MediaType: "application/json",
+			Schema: &runtime.SchemaSpec{
+				Type:       "object",
+				Required:   []string{"name"},
+				Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}, "file": {Type: "string"}},
+			},
+		},
+	}
+	if _, err := ExpandJSONBodyFlags(spec); err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("error = %v, want flag conflict", err)
+	}
+	spec.Params = nil
+	spec.RequestBody.Schema.Properties = map[string]*runtime.SchemaSpec{"name": {Type: "string"}, "enabled": {Type: "boolean"}}
+	got, err := ExpandJSONBodyFlags(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[1].Name != "name" || !got[1].Required || !strings.Contains(got[1].Help, "required") {
+		t.Fatalf("params = %#v", got)
+	}
+}
+
+func TestExpandJSONBodyFlags_RejectsUnsupported(t *testing.T) {
+	cases := []struct {
+		name string
+		spec runtime.CommandSpec
+		want string
+	}{
+		{
+			name: "nested",
+			spec: jsonBodySpec(&runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"limits": {Type: "object", Properties: map[string]*runtime.SchemaSpec{"rpm": {Type: "integer"}}}}}),
+			want: "nested objects",
+		},
+		{
+			name: "oneof",
+			spec: jsonBodySpec(&runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"value": {OneOf: []*runtime.SchemaSpec{{Type: "string"}, {Type: "integer"}}}}}),
+			want: "oneOf/anyOf/allOf",
+		},
+		{
+			name: "map",
+			spec: jsonBodySpec(&runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"labels": {Type: "object", AdditionalProperties: &runtime.AdditionalPropertiesSpec{Allowed: true}}}}),
+			want: "maps",
+		},
+		{
+			name: "graphql",
+			spec: runtime.CommandSpec{RequestBody: &runtime.RequestBody{MediaType: "application/json", Template: `{"query":"q"}`, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}},
+			want: "GraphQL",
+		},
+		{
+			name: "multipart",
+			spec: runtime.CommandSpec{RequestBody: &runtime.RequestBody{MediaType: "multipart/form-data", Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}},
+			want: "multipart",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ExpandJSONBodyFlags(tc.spec)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func jsonBodySpec(schema *runtime.SchemaSpec) runtime.CommandSpec {
+	return runtime.CommandSpec{RequestBody: &runtime.RequestBody{MediaType: "application/json", Schema: schema}}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/codegen/normalize/normalize.go
+++ b/internal/codegen/normalize/normalize.go
@@ -737,10 +737,13 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 				return &runtime.SchemaSpec{AllOf: []*runtime.SchemaSpec{base, runtimeSchema(&sibling, defs, visited)}}
 			}
 			base.Nullable = base.Nullable || s.Nullable
+			if s.Description != "" {
+				base.Description = s.Description
+			}
 			return base
 		}
 	}
-	out := &runtime.SchemaSpec{Ref: s.Ref, Type: s.Type, Nullable: s.Nullable}
+	out := &runtime.SchemaSpec{Ref: s.Ref, Type: s.Type, Description: s.Description, Format: s.Format, Nullable: s.Nullable, Enum: append([]string(nil), s.Enum...)}
 	if len(s.Properties) > 0 {
 		out.Properties = make(map[string]*runtime.SchemaSpec, len(s.Properties))
 		for k, v := range s.Properties {
@@ -772,7 +775,7 @@ func runtimeSchema(s *rawir.RawSchema, defs map[string]*rawir.RawSchema, visited
 }
 
 func rawSchemaHasRefSiblings(s *rawir.RawSchema) bool {
-	return s.Type != "" || len(s.Properties) > 0 || len(s.Required) > 0 || s.Items != nil || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || len(s.AllOf) > 0 || s.AdditionalProperties != nil
+	return s.Type != "" || s.Format != "" || len(s.Enum) > 0 || len(s.Properties) > 0 || len(s.Required) > 0 || s.Items != nil || len(s.AnyOf) > 0 || len(s.OneOf) > 0 || len(s.AllOf) > 0 || s.AdditionalProperties != nil
 }
 
 func runtimeSchemas(schemas []*rawir.RawSchema, defs map[string]*rawir.RawSchema, visited map[string]bool) []*runtime.SchemaSpec {

--- a/internal/codegen/rawir/types.go
+++ b/internal/codegen/rawir/types.go
@@ -69,8 +69,10 @@ type RawPaginationHint struct {
 type RawSchema struct {
 	Ref                  string
 	Type                 string
-	Format               string `json:",omitempty"`
-	Nullable             bool   `json:",omitempty"`
+	Description          string   `json:",omitempty"`
+	Format               string   `json:",omitempty"`
+	Nullable             bool     `json:",omitempty"`
+	Enum                 []string `json:",omitempty"`
 	Properties           map[string]*RawSchema
 	Required             []string `json:",omitempty"`
 	Items                *RawSchema

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/lathe-cli/lathe/internal/codegen/normalize"
 	"github.com/lathe-cli/lathe/internal/overlay"
 	"github.com/lathe-cli/lathe/pkg/config"
 	"github.com/lathe-cli/lathe/pkg/runtime"
@@ -70,7 +71,10 @@ func RenderModule(name, cliName string, specs []runtime.CommandSpec, overrides m
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		return err
 	}
-	merged := MergeOverlayModule(specs, mod)
+	merged, err := MergeOverlayModule(specs, mod)
+	if err != nil {
+		return err
+	}
 	return renderModuleSpecs(name, cliName, merged)
 }
 
@@ -255,18 +259,24 @@ func ValidateModuleNames(names []string) error {
 	return nil
 }
 
-func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {
+func MergeOverlay(specs []runtime.CommandSpec, overrides map[string]overlay.Override) ([]runtime.CommandSpec, error) {
 	return MergeOverlayModule(specs, overlay.Module{Commands: overrides})
 }
 
-func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
-	merged := mergeOverlaySpecs(specs, mod)
+func MergeOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) ([]runtime.CommandSpec, error) {
+	merged, err := mergeOverlaySpecs(specs, mod)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateJSONBodyFlagParams(merged); err != nil {
+		return nil, err
+	}
 	applyRuntimeSchemaBindings(specs, merged, mod)
 	applyGroupOverrides(merged, mod.Groups)
-	return merged
+	return merged, nil
 }
 
-func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
+func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) ([]runtime.CommandSpec, error) {
 	var merged []runtime.CommandSpec
 	var overrides []overlay.Override
 	var matched []bool
@@ -287,10 +297,13 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) []runtim
 	for i := range merged {
 		applyBulkDefaults(&merged[i], mod.Defaults, matchedLegacyUses[i])
 		if matched[i] {
+			if err := applyBodyFlags(&merged[i], overrides[i]); err != nil {
+				return nil, fmt.Errorf("command %q body.flags: %w", merged[i].Use, err)
+			}
 			applyCommandOverride(&merged[i], overrides[i])
 		}
 	}
-	return merged
+	return merged, nil
 }
 
 // legacyOverlayUses reproduces the pre-v0.6 collision keys so existing
@@ -373,12 +386,32 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 				return fmt.Errorf("command %q stream policy: %w", spec.Use, err)
 			}
 		}
+		if override.Body != nil && override.Body.Flags {
+			if _, err := normalize.ExpandJSONBodyFlags(spec); err != nil {
+				return fmt.Errorf("command %q body.flags: %w", spec.Use, err)
+			}
+		}
 	}
-	merged := mergeOverlaySpecs(specs, mod)
+	merged, err := mergeOverlaySpecs(specs, mod)
+	if err != nil {
+		return err
+	}
+	if err := validateJSONBodyFlagParams(merged); err != nil {
+		return err
+	}
 	if err := validateGroupOverrides(merged, mod.Groups); err != nil {
 		return err
 	}
 	return validateRuntimeSchemaBindings(specs, merged, mod)
+}
+
+func validateJSONBodyFlagParams(specs []runtime.CommandSpec) error {
+	for _, spec := range specs {
+		if err := normalize.ValidateJSONBodyFlagParams(spec); err != nil {
+			return fmt.Errorf("command %q body.flags: %w", spec.Use, err)
+		}
+	}
+	return nil
 }
 
 func validateGroupOverrides(specs []runtime.CommandSpec, groups map[string]overlay.GroupOverride) error {
@@ -791,6 +824,7 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	for i := range cloned.Params {
 		cloned.Params[i].Aliases = append([]string(nil), spec.Params[i].Aliases...)
 		cloned.Params[i].Enum = append([]string(nil), spec.Params[i].Enum...)
+		cloned.Params[i].ItemEnum = append([]string(nil), spec.Params[i].ItemEnum...)
 	}
 	if spec.RequestBody != nil {
 		body := *spec.RequestBody
@@ -833,6 +867,18 @@ func matchesAny(patterns []string, value string) bool {
 		}
 	}
 	return false
+}
+
+func applyBodyFlags(spec *runtime.CommandSpec, override overlay.Override) error {
+	if override.Body == nil || !override.Body.Flags {
+		return nil
+	}
+	params, err := normalize.ExpandJSONBodyFlags(*spec)
+	if err != nil {
+		return err
+	}
+	spec.Params = append(spec.Params, params...)
+	return nil
 }
 
 func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) {
@@ -1360,6 +1406,7 @@ func paramSpecsLiteral(params []runtime.ParamSpec) string {
 		writeBoolField(&b, "Required", param.Required)
 		writeStringField(&b, "Default", param.Default)
 		writeStringSliceField(&b, "Enum", param.Enum)
+		writeStringSliceField(&b, "ItemEnum", param.ItemEnum)
 		writeStringField(&b, "Format", param.Format)
 		writeBoolField(&b, "Deprecated", param.Deprecated)
 		writeStringField(&b, "Context", param.Context)
@@ -1586,6 +1633,9 @@ func writeSchemaLiteral(b *strings.Builder, s *runtime.SchemaSpec) {
 	if s.Type != "" {
 		fmt.Fprintf(b, "Type: %q,", s.Type)
 	}
+	writeStringField(b, "Description", s.Description)
+	writeStringField(b, "Format", s.Format)
+	writeStringSliceField(b, "Enum", s.Enum)
 	writeBoolField(b, "Nullable", s.Nullable)
 	if len(s.Properties) > 0 {
 		b.WriteString("Properties: map[string]*runtime.SchemaSpec{")
@@ -1752,7 +1802,7 @@ var Specs = []runtime.CommandSpec{
 		{{- if $op.Params}}
 		Params: []runtime.ParamSpec{
 			{{- range $op.Params}}
-			{Name: {{printf "%q" .Name}}, Flag: {{printf "%q" .Flag}}{{- if .Aliases}}, Aliases: []string{ {{- range .Aliases}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Argument}}, Argument: {{printf "%q" .Argument}}{{end}}, In: {{printf "%q" .In}}, GoType: {{printf "%q" .GoType}}, Help: {{printf "%q" .Help}}, Required: {{.Required}}{{- if .Default}}, Default: {{printf "%q" .Default}}{{end}}{{- if .Enum}}, Enum: []string{ {{- range .Enum}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{- if .Deprecated}}, Deprecated: true{{end}}{{- if .Context}}, Context: {{printf "%q" .Context}}{{end}}},
+			{Name: {{printf "%q" .Name}}, Flag: {{printf "%q" .Flag}}{{- if .Aliases}}, Aliases: []string{ {{- range .Aliases}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Argument}}, Argument: {{printf "%q" .Argument}}{{end}}, In: {{printf "%q" .In}}, GoType: {{printf "%q" .GoType}}, Help: {{printf "%q" .Help}}, Required: {{.Required}}{{- if .Default}}, Default: {{printf "%q" .Default}}{{end}}{{- if .Enum}}, Enum: []string{ {{- range .Enum}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .ItemEnum}}, ItemEnum: []string{ {{- range .ItemEnum}}{{printf "%q" .}}, {{end -}} }{{end}}{{- if .Format}}, Format: {{printf "%q" .Format}}{{end}}{{- if .Deprecated}}, Deprecated: true{{end}}{{- if .Context}}, Context: {{printf "%q" .Context}}{{end}}},
 			{{- end}}
 		},
 		{{- end}}

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -56,11 +56,29 @@ func generatedWorkflows(t *testing.T) string {
 	return string(out)
 }
 
+func mustMergeOverlay(t *testing.T, specs []runtime.CommandSpec, overrides map[string]overlay.Override) []runtime.CommandSpec {
+	t.Helper()
+	merged, err := MergeOverlay(specs, overrides)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return merged
+}
+
+func mustMergeOverlayModule(t *testing.T, specs []runtime.CommandSpec, mod overlay.Module) []runtime.CommandSpec {
+	t.Helper()
+	merged, err := MergeOverlayModule(specs, mod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return merged
+}
+
 func TestRenderModule_AppliesOverlay(t *testing.T) {
 	chdirWithGoMod(t)
 
 	specs := []runtime.CommandSpec{
-		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/api/v1/addon", Params: []runtime.ParamSpec{{Name: "workspace_id", Flag: "workspace-id", In: runtime.InQuery, GoType: "string"}}, RequestBody: &runtime.RequestBody{Required: true, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}}}}, Output: runtime.OutputHints{DefaultColumns: []string{"id"}}},
+		{Group: "Addon", Use: "install-addon", Short: "raw short", Method: "POST", PathTpl: "/api/v1/addon", Params: []runtime.ParamSpec{{Name: "workspace_id", Flag: "workspace-id", In: runtime.InQuery, GoType: "string"}}, RequestBody: &runtime.RequestBody{Required: true, Schema: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string", Description: "Addon name", Format: "password", Enum: []string{"primary"}}}}}, Output: runtime.OutputHints{DefaultColumns: []string{"id"}}},
 		{Group: "Addon", Use: "untouched", Short: "untouched short", Method: "GET", PathTpl: "/api/v1/x"},
 	}
 	overrides := map[string]overlay.Override{
@@ -133,6 +151,9 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`Properties: map[string]*runtime.SchemaSpec`,
 		`"name":`,
 		`Type: "string"`,
+		`Description: "Addon name"`,
+		`Format: "password"`,
+		`Enum: []string{"primary"}`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("output missing %q", want)
@@ -274,7 +295,7 @@ func TestRenderModule_GroupAndHiddenOverride(t *testing.T) {
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		t.Fatalf("ValidateOverlayModule: %v", err)
 	}
-	merged := MergeOverlayModule(specs, mod)
+	merged := mustMergeOverlayModule(t, specs, mod)
 	if merged[0].GroupShort != "Inspect inventory items" {
 		t.Fatalf("group short = %q", merged[0].GroupShort)
 	}
@@ -327,7 +348,7 @@ func TestMergeOverlayModule_IgnoresCollisionBeforeDisambiguation(t *testing.T) {
 	mod := overlay.Module{Commands: map[string]overlay.Override{
 		"list": {Match: overlay.OperationMatch{Path: "/v2/groups"}, Ignore: true},
 	}}
-	merged := MergeOverlayModule(specs, mod)
+	merged := mustMergeOverlayModule(t, specs, mod)
 	if len(merged) != 1 {
 		t.Fatalf("merged command count = %d, want 1", len(merged))
 	}
@@ -352,7 +373,7 @@ func TestMergeOverlayModule_PreservesLegacyCollisionOverlayKey(t *testing.T) {
 		if err := ValidateOverlayModule(specs, mod); err != nil {
 			t.Fatalf("ValidateOverlayModule: %v", err)
 		}
-		merged := MergeOverlayModule(specs, mod)
+		merged := mustMergeOverlayModule(t, specs, mod)
 		if len(merged) != 1 || merged[0].PathTpl != "/v1/groups" || merged[0].Use != "list" {
 			t.Fatalf("merged = %#v, want only /v1/groups as list", merged)
 		}
@@ -365,14 +386,14 @@ func TestMergeOverlayModule_PreservesLegacyCollisionOverlayKey(t *testing.T) {
 		if err := ValidateOverlayModule(specs, mod); err != nil {
 			t.Fatalf("ValidateOverlayModule: %v", err)
 		}
-		merged := MergeOverlayModule(specs, mod)
+		merged := mustMergeOverlayModule(t, specs, mod)
 		if len(merged) != 2 || merged[0].Short == "Legacy second command" || merged[1].Short != "Legacy second command" {
 			t.Fatalf("merged = %#v, want override only on second command", merged)
 		}
 	})
 
 	t.Run("unsuffixed override remains first", func(t *testing.T) {
-		merged := MergeOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+		merged := mustMergeOverlayModule(t, specs, overlay.Module{Commands: map[string]overlay.Override{
 			"list": {Short: "First command only"},
 		}})
 		if len(merged) != 2 || merged[0].Short != "First command only" || merged[1].Short == "First command only" {
@@ -386,7 +407,7 @@ func TestMergeOverlayModule_DisambiguatesSurvivingCollisions(t *testing.T) {
 		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/Groups"},
 		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/groups"},
 	}})
-	merged := MergeOverlayModule(specs, overlay.Module{})
+	merged := mustMergeOverlayModule(t, specs, overlay.Module{})
 	if len(merged) != 2 {
 		t.Fatalf("merged command count = %d, want 2", len(merged))
 	}
@@ -414,7 +435,7 @@ func TestRenderModule_ParamOverride(t *testing.T) {
 			},
 		},
 	}
-	merged := MergeOverlay(specs, overrides)
+	merged := mustMergeOverlay(t, specs, overrides)
 	if merged[0].Params[0].Argument != "state" {
 		t.Fatalf("merged positional mapping = %#v", merged[0].Params[0])
 	}
@@ -488,7 +509,7 @@ func TestMergeOverlayModule_RuntimeSchema(t *testing.T) {
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		t.Fatalf("ValidateOverlayModule: %v", err)
 	}
-	merged := MergeOverlayModule(specs, mod)
+	merged := mustMergeOverlayModule(t, specs, mod)
 	binding := merged[1].RequestBody.RuntimeSchema
 	if binding == nil || binding.Operation.OperationID != "describeApp" || binding.Operation.DefaultHostname != "https://api.example.com" || binding.Params["app_id"] != "${params.app-id}" {
 		t.Fatalf("runtime schema = %#v", binding)
@@ -554,6 +575,124 @@ func TestMergeOverlayModule_RuntimeSchema(t *testing.T) {
 	}
 }
 
+func TestMergeOverlayModule_BodyFlags(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group:  "keys",
+		Use:    "update-limits",
+		Method: "PATCH",
+		Params: []runtime.ParamSpec{{Name: "id", Flag: "id", In: runtime.InPath, GoType: "string", Required: true}},
+		RequestBody: &runtime.RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			Schema: &runtime.SchemaSpec{
+				Type: "object",
+				Properties: map[string]*runtime.SchemaSpec{
+					"maxBudgetUsd":   {Type: "number", Nullable: true},
+					"budgetDuration": {Type: "string", Nullable: true, Enum: []string{"monthly"}},
+				},
+			},
+		},
+	}}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"update-limits": {
+			Use:  "replace-limits",
+			Body: &overlay.BodyOverride{Flags: true},
+			Params: map[string]overlay.ParamOverride{
+				"maxBudgetUsd": {Help: "Budget in USD"},
+			},
+		},
+	}}
+	if err := ValidateOverlayModule(specs, mod); err != nil {
+		t.Fatalf("ValidateOverlayModule: %v", err)
+	}
+	merged := mustMergeOverlayModule(t, specs, mod)
+	if merged[0].Use != "replace-limits" {
+		t.Fatalf("use = %q", merged[0].Use)
+	}
+	if len(merged[0].Params) != 3 {
+		t.Fatalf("params = %#v", merged[0].Params)
+	}
+	byName := map[string]runtime.ParamSpec{}
+	for _, param := range merged[0].Params {
+		byName[param.Name] = param
+	}
+	if byName["maxBudgetUsd"].In != runtime.InBody || byName["maxBudgetUsd"].Flag != "max-budget-usd" || byName["maxBudgetUsd"].Help != "Budget in USD" {
+		t.Fatalf("maxBudgetUsd = %+v", byName["maxBudgetUsd"])
+	}
+	if byName["budgetDuration"].Enum[0] != "monthly" {
+		t.Fatalf("budgetDuration = %+v", byName["budgetDuration"])
+	}
+}
+
+func TestValidateOverlayModule_RejectsNestedBodyFlags(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group: "keys",
+		Use:   "create",
+		RequestBody: &runtime.RequestBody{
+			MediaType: "application/json",
+			Schema: &runtime.SchemaSpec{
+				Type: "object",
+				Properties: map[string]*runtime.SchemaSpec{
+					"limits": {Type: "object", Properties: map[string]*runtime.SchemaSpec{"rpm": {Type: "integer"}}},
+				},
+			},
+		},
+	}}
+	err := ValidateOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+		"create": {Body: &overlay.BodyOverride{Flags: true}},
+	}})
+	if err == nil || !strings.Contains(err.Error(), "nested objects") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestValidateOverlayModule_RejectsBodyFlagOverrideCollision(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group:  "users",
+		Use:    "update",
+		Method: "PATCH",
+		Params: []runtime.ParamSpec{{Name: "id", Flag: "id", In: runtime.InPath, GoType: "string", Required: true}},
+		RequestBody: &runtime.RequestBody{MediaType: "application/json", Schema: &runtime.SchemaSpec{
+			Type:       "object",
+			Properties: map[string]*runtime.SchemaSpec{"name": {Type: "string"}},
+		}},
+	}}
+	err := ValidateOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+		"update": {
+			Body:   &overlay.BodyOverride{Flags: true},
+			Params: map[string]overlay.ParamOverride{"name": {Flag: "id"}},
+		},
+	}})
+	if err == nil {
+		t.Fatal("expected duplicate flag validation error")
+	}
+	specs[0].Params = []runtime.ParamSpec{{Name: "tokenEnv", Flag: "token-env", In: runtime.InQuery, GoType: "string"}}
+	specs[0].RequestBody.Schema.Properties = map[string]*runtime.SchemaSpec{"token": {Type: "string"}}
+	err = ValidateOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+		"update": {Body: &overlay.BodyOverride{Flags: true}},
+	}})
+	if err == nil {
+		t.Fatal("expected sensitive input companion collision error")
+	}
+}
+
+func TestMergeOverlayModule_ReturnsBodyFlagExpansionError(t *testing.T) {
+	specs := []runtime.CommandSpec{{
+		Group: "users",
+		Use:   "update",
+		RequestBody: &runtime.RequestBody{MediaType: "application/json", Schema: &runtime.SchemaSpec{
+			Type:       "object",
+			Properties: map[string]*runtime.SchemaSpec{"profile": {Type: "object"}},
+		}},
+	}}
+	_, err := MergeOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
+		"update": {Body: &overlay.BodyOverride{Flags: true}},
+	}})
+	if err == nil {
+		t.Fatal("expected body flag expansion error")
+	}
+}
+
 func TestMergeOverlay_ParamRequiredOverride(t *testing.T) {
 	specs := []runtime.CommandSpec{
 		{
@@ -564,7 +703,7 @@ func TestMergeOverlay_ParamRequiredOverride(t *testing.T) {
 		},
 	}
 
-	merged := MergeOverlay(specs, map[string]overlay.Override{
+	merged := mustMergeOverlay(t, specs, map[string]overlay.Override{
 		"get-user": {
 			Params: map[string]overlay.ParamOverride{
 				"type":    {Required: true, Help: "override help"},
@@ -594,7 +733,7 @@ func TestMergeOverlay_UseRename(t *testing.T) {
 		Use:     "create-repo",
 		Aliases: []string{"new-repo"},
 	}}
-	merged := MergeOverlay(specs, map[string]overlay.Override{
+	merged := mustMergeOverlay(t, specs, map[string]overlay.Override{
 		"create-repo": {Use: "create", Aliases: []string{"new"}},
 	})
 
@@ -616,7 +755,7 @@ func TestMergeOverlay_PathScopedRename(t *testing.T) {
 		t.Fatalf("conflict error = %v", err)
 	}
 
-	merged := MergeOverlay(specs, map[string]overlay.Override{
+	merged := mustMergeOverlay(t, specs, map[string]overlay.Override{
 		"create-service": {Match: overlay.OperationMatch{Method: "POST", Path: "/apis/v1alpha2/services"}, Use: "create-service-v1alpha2"},
 	})
 	if merged[0].Use != "create-service" || merged[1].Use != "create-service-v1alpha2" {
@@ -651,7 +790,7 @@ func TestMergeOverlayModule_BulkPaginationDefaults(t *testing.T) {
 		},
 	}
 
-	bulk := MergeOverlayModule(specs, overlay.Module{
+	bulk := mustMergeOverlayModule(t, specs, overlay.Module{
 		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
 			MatchCommands: []string{"list-*", "query-*"},
 			Params:        map[string]string{"page": "1", "pageSize": "20"},
@@ -660,7 +799,7 @@ func TestMergeOverlayModule_BulkPaginationDefaults(t *testing.T) {
 			"query-users": {Params: map[string]overlay.ParamOverride{"page": {Default: "7"}}},
 		},
 	})
-	explicit := MergeOverlay(specs, map[string]overlay.Override{
+	explicit := mustMergeOverlay(t, specs, map[string]overlay.Override{
 		"list-users": {
 			Params: map[string]overlay.ParamOverride{
 				"page":     {Default: "1"},
@@ -688,7 +827,7 @@ func TestMergeOverlayModule_BulkDefaultsUseLegacyCollisionName(t *testing.T) {
 		{Group: "Groups", OperationID: "Groups_List", Method: "GET", Path: "/v1/groups", Parameters: []rawir.RawParameter{{Name: "page", In: "query", Type: "integer"}}},
 		{Group: "Groups", OperationID: "Groups_list", Method: "GET", Path: "/v2/groups", Parameters: []rawir.RawParameter{{Name: "page", In: "query", Type: "integer"}}},
 	}})
-	merged := MergeOverlayModule(specs, overlay.Module{Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
+	merged := mustMergeOverlayModule(t, specs, overlay.Module{Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
 		MatchCommands: []string{"list-2"},
 		Params:        map[string]string{"page": "2"},
 	}}})
@@ -708,7 +847,7 @@ func TestMergeOverlayModule_BulkDefaultsDoNotReplaceSpecDefaults(t *testing.T) {
 		},
 	}
 
-	merged := MergeOverlayModule(specs, overlay.Module{
+	merged := mustMergeOverlayModule(t, specs, overlay.Module{
 		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
 			MatchCommands: []string{"list-*"},
 			Params:        map[string]string{"page": "1", "pageSize": "20"},
@@ -725,7 +864,7 @@ func TestMergeOverlayModule_BulkDefaultsDoNotReplaceSpecDefaults(t *testing.T) {
 		t.Fatalf("bulk pageSize default = %q, want 20", got)
 	}
 
-	withoutCommandOverride := MergeOverlayModule(specs, overlay.Module{
+	withoutCommandOverride := mustMergeOverlayModule(t, specs, overlay.Module{
 		Defaults: overlay.Defaults{Pagination: &overlay.PaginationDefaults{
 			MatchCommands: []string{"list-*"},
 			Params:        map[string]string{"page": "1"},
@@ -754,7 +893,7 @@ func TestMergeOverlayModule_StreamPolicy(t *testing.T) {
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		t.Fatalf("ValidateOverlayModule: %v", err)
 	}
-	merged := MergeOverlayModule(specs, mod)
+	merged := mustMergeOverlayModule(t, specs, mod)
 	policy := merged[0].Output.Streaming.Policy
 	if policy == nil || policy.Collect == nil || policy.Collect.Fields[0].Reduce != "concat" || policy.Live == nil {
 		t.Fatalf("policy = %#v", policy)
@@ -787,7 +926,7 @@ func TestMergeOverlayModule_OutputColumns(t *testing.T) {
 	if err := ValidateOverlayModule(specs, mod); err != nil {
 		t.Fatalf("ValidateOverlayModule: %v", err)
 	}
-	merged := MergeOverlayModule(specs, mod)
+	merged := mustMergeOverlayModule(t, specs, mod)
 	if got := strings.Join(merged[0].Output.DefaultColumns, ","); got != "resourceId,displayName,spendMicro" {
 		t.Fatalf("default columns = %q", got)
 	}
@@ -1075,7 +1214,7 @@ func TestResolveFlatCommandPath(t *testing.T) {
 		t.Fatalf("expected duplicate group flat conflict error, got %v", err)
 	}
 
-	renamed := MergeOverlay([]runtime.CommandSpec{
+	renamed := mustMergeOverlay(t, []runtime.CommandSpec{
 		{Group: "Repos", Use: "create-repo", OperationID: "Repos_CreateRepo"},
 		{Group: "Repos", Use: "create", OperationID: "Repos_Create"},
 	}, map[string]overlay.Override{
@@ -1086,7 +1225,7 @@ func TestResolveFlatCommandPath(t *testing.T) {
 		t.Fatalf("expected renamed command conflict error, got %v", err)
 	}
 
-	aliased := MergeOverlay([]runtime.CommandSpec{
+	aliased := mustMergeOverlay(t, []runtime.CommandSpec{
 		{Group: "Users", Use: "get-user", OperationID: "Users_GetUser", Method: "GET", PathTpl: "/users/{id}"},
 		{Group: "Users", Use: "remove-user", OperationID: "Users_RemoveUser", Method: "DELETE", PathTpl: "/users/{id}"},
 	}, map[string]overlay.Override{

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -667,6 +667,9 @@ func renderModuleReference(manifest *config.Manifest, mod SkillModule, flat bool
 					if len(p.Enum) > 0 {
 						enum = ", one of: " + strings.Join(p.Enum, "|")
 					}
+					if len(p.ItemEnum) > 0 {
+						enum = ", items one of: " + strings.Join(p.ItemEnum, "|")
+					}
 					deprecated := ""
 					if p.Deprecated {
 						deprecated = ", deprecated"

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -68,7 +68,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		},
 		{Group: "Users", Use: "delete-user", Short: "Delete user", Method: "DELETE", PathTpl: "/users/{id}", Hidden: true},
 	}
-	merged := MergeOverlay(specs, map[string]overlay.Override{
+	merged := mustMergeOverlay(t, specs, map[string]overlay.Override{
 		"create-user": {
 			Short:         "Create a user",
 			Group:         "Accounts",

--- a/internal/lathecmd/lathecmd.go
+++ b/internal/lathecmd/lathecmd.go
@@ -239,7 +239,10 @@ func buildGeneratedApp(cfg *sourceconfig.Config, overlays map[string]overlay.Mod
 		if err := render.ValidateOverlayModule(specs, overlays[src.Name]); err != nil {
 			return nil, fmt.Errorf("source %q overlay: %w", src.Name, err)
 		}
-		specs = render.MergeOverlayModule(specs, overlays[src.Name])
+		specs, err = render.MergeOverlayModule(specs, overlays[src.Name])
+		if err != nil {
+			return nil, fmt.Errorf("source %q overlay: %w", src.Name, err)
+		}
 		if len(specs) == 0 {
 			return nil, fmt.Errorf("source %q produced no commands: check its entry/file list, expose policy, and overlay ignore rules", src.Name)
 		}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -40,6 +40,7 @@ type ContextSetOnSuccess struct {
 }
 
 type BodyOverride struct {
+	Flags         bool                   `yaml:"flags"`
 	RuntimeSchema *RuntimeSchemaOverride `yaml:"runtime_schema"`
 }
 

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -117,6 +117,7 @@ commands:
         name: workspace
         from_param: status
     body:
+      flags: true
       runtime_schema:
         operation_id: describeUser
         response_path: input_schema
@@ -189,8 +190,8 @@ commands:
 	if cu.Context == nil || cu.Context.SetOnSuccess == nil || cu.Context.SetOnSuccess.Name != "workspace" || cu.Context.SetOnSuccess.FromParam != "status" {
 		t.Errorf("context = %#v", cu.Context)
 	}
-	if cu.Body == nil || cu.Body.RuntimeSchema == nil || cu.Body.RuntimeSchema.OperationID != "describeUser" || cu.Body.RuntimeSchema.ResponsePath != "input_schema" || cu.Body.RuntimeSchema.Params["user_id"] != "${params.user_id}" {
-		t.Errorf("runtime schema = %#v", cu.Body)
+	if cu.Body == nil || !cu.Body.Flags || cu.Body.RuntimeSchema == nil || cu.Body.RuntimeSchema.OperationID != "describeUser" || cu.Body.RuntimeSchema.ResponsePath != "input_schema" || cu.Body.RuntimeSchema.Params["user_id"] != "${params.user_id}" {
+		t.Errorf("body override = %#v", cu.Body)
 	}
 	if cu.Output == nil || len(cu.Output.DefaultColumns) != 3 || cu.Output.DefaultColumns[0] != "name" || cu.Output.DefaultColumns[1] != "spendMicro" || cu.Output.DefaultColumns[2] != "status.phase" {
 		t.Errorf("output = %#v", cu.Output)

--- a/pkg/runtime/body.go
+++ b/pkg/runtime/body.go
@@ -28,25 +28,79 @@ func BuildBodyFromSet(sets []string) ([]byte, error) {
 
 func buildBodyFromSet(sets []string, stringSets []string) ([]byte, error) {
 	out := map[string]any{}
+	if err := mergeJSONBodySets(out, nil, sets, stringSets); err != nil {
+		return nil, err
+	}
+	return json.Marshal(out)
+}
+
+func hasJSONBodyFlags(params []ParamSpec) bool {
+	for _, param := range params {
+		if param.In == InBody {
+			return true
+		}
+	}
+	return false
+}
+
+func jsonBodyFromFlags(s CommandSpec, input OperationInput) (map[string]any, map[string]ParamSpec, error) {
+	out := map[string]any{}
+	changed := map[string]ParamSpec{}
+	for _, p := range s.Params {
+		if p.In != InBody || !operationChanged(input, p) {
+			continue
+		}
+		v, _, err := operationValue(input, p)
+		if err != nil {
+			return nil, nil, err
+		}
+		out[p.Name] = v
+		changed[p.Name] = p
+	}
+	return out, changed, nil
+}
+
+func mergeJSONBodySets(out map[string]any, flagFields map[string]ParamSpec, sets, stringSets []string) error {
 	for _, kv := range sets {
 		path, value, err := parseSet(kv, "--set")
 		if err != nil {
-			return nil, err
+			return err
+		}
+		if err := rejectBodyFlagSetConflict(path, flagFields, "--set"); err != nil {
+			return err
 		}
 		if err := setNestedPath(out, path, inferValue(value)); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	for _, kv := range stringSets {
 		path, value, err := parseSet(kv, "--set-str")
 		if err != nil {
-			return nil, err
+			return err
+		}
+		if err := rejectBodyFlagSetConflict(path, flagFields, "--set-str"); err != nil {
+			return err
 		}
 		if err := setNestedPath(out, path, value); err != nil {
-			return nil, err
+			return err
 		}
 	}
-	return json.Marshal(out)
+	return nil
+}
+
+func rejectBodyFlagSetConflict(path string, flagFields map[string]ParamSpec, setFlag string) error {
+	if len(flagFields) == 0 {
+		return nil
+	}
+	segs := parsePath(path)
+	if len(segs) == 0 {
+		return nil
+	}
+	param, ok := flagFields[segs[0].key]
+	if !ok {
+		return nil
+	}
+	return fmt.Errorf("body field %q cannot be set by both --%s and %s", param.Name, param.Flag, setFlag)
 }
 
 func buildEnvelopeBody(template, mergePath string, vars map[string]any, sets, stringSets []string, fileData []byte, hasFile bool) ([]byte, error) {

--- a/pkg/runtime/body_test.go
+++ b/pkg/runtime/body_test.go
@@ -3,8 +3,116 @@ package runtime
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestJSONBodyFromFlags(t *testing.T) {
+	spec := CommandSpec{
+		Method:  "PATCH",
+		PathTpl: "/keys/{id}/limits",
+		Params: []ParamSpec{
+			{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true},
+			{Name: "maxBudgetUsd", Flag: "max-budget-usd", In: InBody, GoType: "float64"},
+			{Name: "budgetDuration", Flag: "budget-duration", In: InBody, GoType: "string", Enum: []string{"daily", "weekly", "monthly"}},
+			{Name: "rpmLimit", Flag: "rpm-limit", In: InBody, GoType: "int64"},
+			{Name: "allowedModels", Flag: "allowed-models", In: InBody, GoType: "[]string", ItemEnum: []string{"model-a", "model-b"}},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+	}
+	budget := 100.0
+	rpm := int64(60)
+	models := []string{"model-a", "model-b"}
+	duration := "monthly"
+	input := OperationInput{
+		Values: map[string]any{
+			boundParamKey(spec.Params[0]): "key-1",
+			boundParamKey(spec.Params[1]): &budget,
+			boundParamKey(spec.Params[2]): &duration,
+			boundParamKey(spec.Params[3]): &rpm,
+			boundParamKey(spec.Params[4]): &models,
+		},
+		Changed: map[string]bool{
+			boundParamKey(spec.Params[0]): true,
+			boundParamKey(spec.Params[1]): true,
+			boundParamKey(spec.Params[2]): true,
+			boundParamKey(spec.Params[3]): true,
+			boundParamKey(spec.Params[4]): true,
+		},
+	}
+	_, body, _, err := resolveOperationRequest(spec, input, ClientOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _, err := encodeRequestBody(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]any{
+		"maxBudgetUsd":   float64(100),
+		"budgetDuration": "monthly",
+		"rpmLimit":       float64(60),
+		"allowedModels":  []any{"model-a", "model-b"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+	models = []string{"model-a", "unknown"}
+	if _, _, _, err := resolveOperationRequest(spec, input, ClientOptions{}); err == nil {
+		t.Fatal("expected invalid array item error")
+	}
+}
+
+func TestJSONBodyFlagsExclusiveWithFileAndSet(t *testing.T) {
+	spec := CommandSpec{
+		Method:  "PATCH",
+		PathTpl: "/keys/{id}",
+		Params: []ParamSpec{
+			{Name: "maxBudgetUsd", Flag: "max-budget-usd", In: InBody, GoType: "float64"},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+	}
+	budget := 100.0
+	flagKey := boundParamKey(spec.Params[0])
+	_, _, _, err := resolveOperationRequest(spec, OperationInput{
+		Values:   map[string]any{flagKey: &budget},
+		Changed:  map[string]bool{flagKey: true},
+		HasFile:  true,
+		FileBody: []byte(`{"maxBudgetUsd":1}`),
+	}, ClientOptions{})
+	if err == nil || !strings.Contains(err.Error(), "--file cannot be combined") {
+		t.Fatalf("error = %v", err)
+	}
+	_, _, _, err = resolveOperationRequest(spec, OperationInput{
+		Values:   map[string]any{flagKey: &budget},
+		Changed:  map[string]bool{flagKey: true},
+		BodySets: []string{"maxBudgetUsd=null"},
+	}, ClientOptions{})
+	if err == nil || !strings.Contains(err.Error(), "cannot be set by both") {
+		t.Fatalf("error = %v", err)
+	}
+	_, body, _, err := resolveOperationRequest(spec, OperationInput{
+		BodySets: []string{"expiresAt=null"},
+	}, ClientOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _, err := encodeRequestBody(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["expiresAt"]; !ok || got["expiresAt"] != nil {
+		t.Fatalf("got %#v", got)
+	}
+}
 
 func TestBuildBodyFromSet(t *testing.T) {
 	cases := []struct {

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -85,6 +85,9 @@ func buildGroups(service string, specs []CommandSpec) ([]*cobra.Command, error) 
 	ordered := make([]*cobra.Command, 0)
 	for i := range specs {
 		s := specs[i]
+		if err := ValidateParamFlags(s.Params); err != nil {
+			return nil, fmt.Errorf("command %q: %w", s.Use, err)
+		}
 		groupShort := s.GroupShort
 		if groupShort == "" {
 			groupShort = s.Group + " operations"
@@ -370,12 +373,62 @@ func bindParamFlag(cmd *cobra.Command, vals map[string]any, p ParamSpec, hasRequ
 		cmd.Flags().StringVar(v, p.Flag, p.Default, p.Help)
 		addSafeInputFlags(cmd, p)
 	}
-	if p.Required && p.Default == "" && p.Argument == "" && p.Context == "" && (p.In != InVariable || !hasRequestBody) && !isSensitiveStringParam(p) {
+	if p.Required && p.Default == "" && p.Argument == "" && p.Context == "" && p.In != InBody && (p.In != InVariable || !hasRequestBody) && !isSensitiveStringParam(p) {
 		_ = cmd.MarkFlagRequired(p.Flag)
 	}
 	if p.Deprecated {
 		_ = cmd.Flags().MarkDeprecated(p.Flag, "this flag is deprecated")
 	}
+}
+
+func ValidateParamFlags(params []ParamSpec) error {
+	type bindingOwner struct {
+		param  int
+		target string
+	}
+	seen := map[string]bindingOwner{}
+	for i, param := range params {
+		for _, binding := range paramFlagBindings(param) {
+			if binding.name == "" {
+				return fmt.Errorf("parameter %q has an empty flag name", param.Name)
+			}
+			if prior, ok := seen[binding.name]; ok {
+				if prior.param != i {
+					return fmt.Errorf("flag %q is shared by parameters %q and %q", binding.name, params[prior.param].Name, param.Name)
+				}
+				if prior.target != binding.target {
+					return fmt.Errorf("flag %q has conflicting bindings for parameter %q", binding.name, param.Name)
+				}
+				continue
+			}
+			seen[binding.name] = bindingOwner{param: i, target: binding.target}
+		}
+	}
+	return nil
+}
+
+type paramFlagBinding struct {
+	name   string
+	target string
+}
+
+func paramFlagBindings(param ParamSpec) []paramFlagBinding {
+	bindings := []paramFlagBinding{{name: param.Flag, target: param.Flag}}
+	for _, alias := range param.Aliases {
+		bindings = append(bindings, paramFlagBinding{name: alias, target: param.Flag})
+	}
+	if !isSensitiveStringParam(param) {
+		return bindings
+	}
+	for _, suffix := range []string{"-env", "-file", "-stdin"} {
+		bindings = append(bindings, paramFlagBinding{name: param.Flag + suffix, target: param.Flag + suffix})
+	}
+	for _, alias := range param.Aliases {
+		for _, suffix := range []string{"-env", "-file", "-stdin"} {
+			bindings = append(bindings, paramFlagBinding{name: alias + suffix, target: param.Flag + suffix})
+		}
+	}
+	return bindings
 }
 
 func redactedDryRunHeaders(headers map[string][]string) map[string]string {
@@ -386,14 +439,14 @@ func redactedDryRunHeaders(headers map[string][]string) map[string]string {
 	return out
 }
 
-func redactedDryRunBody(contentType string, body []byte) any {
+func redactedDryRunBody(contentType string, body []byte, sensitive map[string]bool) any {
 	if len(body) == 0 {
 		return nil
 	}
 	if isMultipartMediaType(contentType) {
 		return fmt.Sprintf("<multipart body omitted: %d bytes>", len(body))
 	}
-	redacted := redactDebugBody(contentType, body)
+	redacted := redactDebugBody(contentType, body, sensitive)
 	if strings.HasPrefix(contentType, "application/json") {
 		var v any
 		if err := json.Unmarshal(redacted, &v); err == nil {
@@ -484,6 +537,9 @@ func validateRequiredParams(params []ParamSpec, hasRequestBody bool, changed map
 			continue
 		}
 		if p.In == InVariable && hasRequestBody {
+			continue
+		}
+		if p.In == InBody {
 			continue
 		}
 		if !changed[boundParamKey(p)] {
@@ -671,6 +727,35 @@ func validateRequiredVariableParams(s CommandSpec, body any) error {
 	return nil
 }
 
+func validateRequiredBodyParams(s CommandSpec, body any) error {
+	if body == nil {
+		return nil
+	}
+	required := make([]ParamSpec, 0)
+	for _, p := range s.Params {
+		if p.In == InBody && p.Required && p.Default == "" {
+			required = append(required, p)
+		}
+	}
+	if len(required) == 0 {
+		return nil
+	}
+	raw, _, err := encodeRequestBody(body)
+	if err != nil {
+		return err
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("validate request body: %w", err)
+	}
+	for _, p := range required {
+		if _, ok := doc[p.Name]; !ok {
+			return fmt.Errorf("required body field missing: %s", p.Name)
+		}
+	}
+	return nil
+}
+
 func shortcutName(use string, target string) (string, error) {
 	name := strings.TrimSpace(use)
 	if name == "" || name != use || len(strings.Fields(name)) != 1 {
@@ -697,7 +782,7 @@ func validateShortcutParamValue(p ParamSpec, value string) error {
 		return fmt.Errorf("type %s is not supported for %s params", p.GoType, p.In)
 	case p.In == InFormData && p.GoType == "float64":
 		return fmt.Errorf("type %s is not supported for %s params", p.GoType, p.In)
-	case p.In != InVariable && p.GoType == "float64":
+	case p.In != InVariable && p.In != InBody && p.GoType == "float64":
 		return fmt.Errorf("type %s is not supported for %s params", p.GoType, p.In)
 	}
 	switch p.GoType {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -55,6 +56,36 @@ func TestBuild_RejectsExistingRootCommandConflict(t *testing.T) {
 	if len(root.Commands()) != 1 {
 		t.Fatalf("conflicting module must not be mounted; root commands = %v", cmdNames(root.Commands()))
 	}
+}
+
+func TestBuild_RejectsParamFlagCollision(t *testing.T) {
+	t.Run("across parameters", func(t *testing.T) {
+		root := newRootWithModuleGroup()
+		err := Build(root, "demo", []CommandSpec{{
+			Group: "Users",
+			Use:   "update",
+			Params: []ParamSpec{
+				{Name: "tokenEnv", Flag: "token-env", In: InQuery, GoType: "string"},
+				{Name: "token", Flag: "token", In: InBody, GoType: "string"},
+			},
+		}})
+		if err == nil {
+			t.Fatal("expected parameter flag collision error")
+		}
+	})
+	t.Run("within sensitive aliases", func(t *testing.T) {
+		root := newRootWithModuleGroup()
+		err := Build(root, "demo", []CommandSpec{{
+			Group: "Users",
+			Use:   "update",
+			Params: []ParamSpec{{
+				Name: "token", Flag: "token", Aliases: []string{"token-env"}, In: InBody, GoType: "string",
+			}},
+		}})
+		if err == nil {
+			t.Fatal("expected sensitive alias binding collision error")
+		}
+	})
 }
 
 func TestBuild_RejectsCompletionModuleName(t *testing.T) {
@@ -547,7 +578,123 @@ func TestBuild_SetStrSendsStringBodyFields(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
+		t.Errorf("body = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuild_TypedBodyFlagsSendJSON(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	specs := []CommandSpec{{
+		Group:   "Keys",
+		Use:     "replace-limits",
+		Method:  "PATCH",
+		PathTpl: "/keys/{id}/limits",
+		Params: []ParamSpec{
+			{Name: "id", Flag: "id", Argument: "key-id", In: InPath, GoType: "string", Required: true},
+			{Name: "maxBudgetUsd", Flag: "max-budget-usd", In: InBody, GoType: "float64"},
+			{Name: "budgetDuration", Flag: "budget-duration", In: InBody, GoType: "string", Enum: []string{"daily", "weekly", "monthly"}},
+			{Name: "rpmLimit", Flag: "rpm-limit", In: InBody, GoType: "int64"},
+			{Name: "allowedModels", Flag: "allowed-models", In: InBody, GoType: "[]string"},
+			{Name: "expiresAt", Flag: "expires-at", In: InBody, GoType: "string"},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+		Security:    &SecurityHint{Public: true},
+	}}
+
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", specs)
+	root.SetArgs([]string{
+		"--hostname", srv.URL,
+		"demo", "keys", "replace-limits", "key-1",
+		"--max-budget-usd", "100",
+		"--budget-duration", "monthly",
+		"--rpm-limit", "60",
+		"--allowed-models", "model-a,model-b",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rawBody, &got); err != nil {
+		t.Fatalf("invalid request JSON %q: %v", string(rawBody), err)
+	}
+	want := map[string]any{
+		"maxBudgetUsd":   float64(100),
+		"budgetDuration": "monthly",
+		"rpmLimit":       float64(60),
+		"allowedModels":  []any{"model-a", "model-b"},
+	}
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestBuild_RequiredBodyFieldsAcceptEveryBodyInput(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+	bodyFile := filepath.Join(t.TempDir(), "body.json")
+	if err := os.WriteFile(bodyFile, []byte(`{"name":"from-file"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name         string
+		bodyRequired bool
+		args         []string
+		wantBody     string
+	}{
+		{name: "typed flag", bodyRequired: true, args: []string{"--name", "from-flag"}, wantBody: `{"name":"from-flag"}`},
+		{name: "set", bodyRequired: true, args: []string{"--set", "name=from-set"}, wantBody: `{"name":"from-set"}`},
+		{name: "file", bodyRequired: true, args: []string{"--file", bodyFile}, wantBody: `{"name":"from-file"}`},
+		{name: "explicit null", bodyRequired: true, args: []string{"--set", "name=null"}, wantBody: `{"name":null}`},
+		{name: "optional body omitted"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				gotBody = string(raw)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			root := newRootWithModuleGroup()
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "raw", "")
+			mustBuild(t, root, "demo", []CommandSpec{{
+				Group:   "Users",
+				Use:     "create-user",
+				Method:  "POST",
+				PathTpl: "/users",
+				Params: []ParamSpec{{
+					Name: "name", Flag: "name", In: InBody, GoType: "string", Required: true,
+				}},
+				RequestBody: &RequestBody{Required: tc.bodyRequired, MediaType: "application/json"},
+				Security:    &SecurityHint{Public: true},
+			}})
+			args := []string{"--hostname", srv.URL, "demo", "users", "create-user"}
+			root.SetArgs(append(args, tc.args...))
+			if err := root.Execute(); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if gotBody != tc.wantBody {
+				t.Fatalf("body = %q, want %q", gotBody, tc.wantBody)
+			}
+		})
 	}
 }
 
@@ -761,11 +908,18 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 			{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true},
 			{Name: "limit", Flag: "limit", In: InQuery, GoType: "int64"},
 			{Name: "opaque", Flag: "opaque", In: InQuery, GoType: "string", Format: "password"},
+			{Name: "value", Flag: "value", In: InBody, GoType: "string", Format: "password"},
+			{Name: "values", Flag: "values", In: InBody, GoType: "[]string"},
 			{Name: "page_token", Flag: "page-token", In: InQuery, GoType: "string"},
 			{Name: "key", Flag: "key", In: InQuery, GoType: "string"},
 			{Name: "Authorization", Flag: "authorization", In: InHeader, GoType: "string"},
 		},
-		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json", Schema: &SchemaSpec{
+			Type: "object",
+			Properties: map[string]*SchemaSpec{
+				"values": {Type: "array", Items: &SchemaSpec{Type: "string", Format: "password"}},
+			},
+		}},
 		Output: OutputHints{
 			ListPath:          "data.items",
 			DefaultColumns:    []string{"id", "name"},
@@ -779,6 +933,8 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 		"--id", "u 1",
 		"--limit", "5",
 		"--opaque", "dry-run-query-secret",
+		"--value", "dry-run-body-secret",
+		"--values", "dry-run-array-secret,another-array-secret",
 		"--page-token", "cursor-1",
 		"--key", "dry-run-key-secret",
 		"--authorization", "Bearer secret",
@@ -819,8 +975,8 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 	if out.URL != srv.URL+"/users/u%201?key=%2A%2A%2A&limit=5&opaque=%2A%2A%2A&page_token=cursor-1" {
 		t.Fatalf("url = %q", out.URL)
 	}
-	if strings.Contains(stdout.String(), "dry-run-query-secret") || strings.Contains(stdout.String(), "dry-run-key-secret") {
-		t.Fatalf("dry-run leaked query credential: %s", stdout.String())
+	if strings.Contains(stdout.String(), "dry-run-query-secret") || strings.Contains(stdout.String(), "dry-run-key-secret") || strings.Contains(stdout.String(), "dry-run-body-secret") || strings.Contains(stdout.String(), "dry-run-array-secret") || strings.Contains(stdout.String(), "another-array-secret") {
+		t.Fatalf("dry-run leaked credential: %s", stdout.String())
 	}
 	if out.Headers["Authorization"] != "***" {
 		t.Fatalf("authorization header = %q", out.Headers["Authorization"])
@@ -833,6 +989,12 @@ func TestBuild_DryRunPrintsResolvedRequestWithoutSending(t *testing.T) {
 	}
 	if out.Body["name"] != "alice" || out.Body["password"] != "***" {
 		t.Fatalf("body = %#v", out.Body)
+	}
+	if out.Body["value"] != "***" {
+		t.Fatalf("sensitive body field = %#v", out.Body["value"])
+	}
+	if out.Body["values"] != "***" {
+		t.Fatalf("sensitive body array = %#v", out.Body["values"])
 	}
 	envVars, ok := out.Body["envVars"].([]any)
 	if !ok || len(envVars) != 1 {

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lathe-cli/lathe/pkg/config"
 )
 
-const CatalogSchemaVersion = 19
+const CatalogSchemaVersion = 20
 const DefaultSearchLimit = 20
 
 const (
@@ -185,6 +185,7 @@ type CatalogFlag struct {
 	Required   bool                   `json:"required"`
 	Default    string                 `json:"default,omitempty"`
 	Enum       []string               `json:"enum,omitempty"`
+	ItemEnum   []string               `json:"item_enum,omitempty"`
 	Format     string                 `json:"format,omitempty"`
 	InputModes []string               `json:"input_modes,omitempty"`
 	Deprecated bool                   `json:"deprecated"`
@@ -572,6 +573,7 @@ func catalogFlags(params []ParamSpec) []CatalogFlag {
 			Required:   p.Required,
 			Default:    p.Default,
 			Enum:       append([]string(nil), p.Enum...),
+			ItemEnum:   append([]string(nil), p.ItemEnum...),
 			Format:     p.Format,
 			InputModes: inputModes,
 			Deprecated: p.Deprecated,

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -301,6 +301,34 @@ func TestBuildCatalog_ProjectsLegacyExample(t *testing.T) {
 	}
 }
 
+func TestBuildCatalog_BodyFlagLocation(t *testing.T) {
+	root := newRootWithModuleGroup()
+	mustBuild(t, root, "demo", []CommandSpec{{
+		Group:   "Keys",
+		Use:     "replace-limits",
+		Method:  "PATCH",
+		PathTpl: "/keys/{id}/limits",
+		Params: []ParamSpec{
+			{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true},
+			{Name: "allowedModels", Flag: "allowed-models", In: InBody, GoType: "[]string", ItemEnum: []string{"model-a", "model-b"}},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+	}})
+	catalog := BuildCatalog(root, CatalogOptions{CLIName: "myctl"})
+	if len(catalog.Commands) != 1 {
+		t.Fatalf("commands = %d", len(catalog.Commands))
+	}
+	var bodyFlag *CatalogFlag
+	for i := range catalog.Commands[0].Flags {
+		if catalog.Commands[0].Flags[i].Name == "allowedModels" {
+			bodyFlag = &catalog.Commands[0].Flags[i]
+		}
+	}
+	if bodyFlag == nil || bodyFlag.Location != InBody || bodyFlag.Flag != "allowed-models" || !reflect.DeepEqual(bodyFlag.ItemEnum, []string{"model-a", "model-b"}) {
+		t.Fatalf("body flag = %#v", bodyFlag)
+	}
+}
+
 func TestBuildCatalog_RequestBodyEnvelope(t *testing.T) {
 	root := newRootWithModuleGroup()
 	const tmpl = `{"query":"mutation CreateApp($name:String!){createApp(name:$name){id}}","variables":{}}`

--- a/pkg/runtime/debug.go
+++ b/pkg/runtime/debug.go
@@ -113,7 +113,7 @@ func isSensitiveDebugName(name string) bool {
 	return false
 }
 
-func redactDebugBody(contentType string, body []byte) []byte {
+func redactDebugBody(contentType string, body []byte, sensitive map[string]bool) []byte {
 	if len(body) == 0 {
 		return body
 	}
@@ -121,7 +121,7 @@ func redactDebugBody(contentType string, body []byte) []byte {
 	if mt == "application/json" {
 		var v any
 		if err := json.Unmarshal(body, &v); err == nil {
-			if redactDebugJSON(v) {
+			if redactDebugJSON(v, sensitive) {
 				redacted, err := json.Marshal(v)
 				if err == nil {
 					return redacted
@@ -132,16 +132,21 @@ func redactDebugBody(contentType string, body []byte) []byte {
 	return []byte(redactDebugText(string(body)))
 }
 
-func redactDebugJSON(v any) bool {
-	return redactDebugJSONAt(v, nil)
+func redactDebugJSON(v any, sensitive map[string]bool) bool {
+	return redactDebugJSONAt(v, nil, sensitive)
 }
 
-func redactDebugJSONAt(v any, path []string) bool {
+func redactDebugJSONAt(v any, path []string, sensitive map[string]bool) bool {
 	switch tv := v.(type) {
 	case map[string]any:
 		changed := false
 		envVarPair := isDebugEnvVarPair(path, tv)
 		for k, child := range tv {
+			if len(path) == 0 && sensitive[k] {
+				tv[k] = "***"
+				changed = true
+				continue
+			}
 			if envVarPair && strings.EqualFold(k, "value") {
 				tv[k] = "***"
 				changed = true
@@ -155,7 +160,7 @@ func redactDebugJSONAt(v any, path []string) bool {
 				changed = true
 				continue
 			}
-			if redactDebugJSONAt(child, append(path, k)) {
+			if redactDebugJSONAt(child, append(path, k), sensitive) {
 				changed = true
 			}
 		}
@@ -163,7 +168,7 @@ func redactDebugJSONAt(v any, path []string) bool {
 	case []any:
 		changed := false
 		for _, child := range tv {
-			if redactDebugJSONAt(child, path) {
+			if redactDebugJSONAt(child, path, sensitive) {
 				changed = true
 			}
 		}
@@ -171,6 +176,42 @@ func redactDebugJSONAt(v any, path []string) bool {
 	default:
 		return false
 	}
+}
+
+func sensitiveBodyFields(s CommandSpec) map[string]bool {
+	out := map[string]bool{}
+	for _, p := range s.Params {
+		if p.In == InBody && isSensitiveStringParam(p) {
+			out[p.Name] = true
+		}
+	}
+	if s.RequestBody == nil || s.RequestBody.Schema == nil {
+		return out
+	}
+	for name, schema := range s.RequestBody.Schema.Properties {
+		if schemaUsesPasswordFormat(schema, map[*SchemaSpec]bool{}) {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+func schemaUsesPasswordFormat(s *SchemaSpec, visited map[*SchemaSpec]bool) bool {
+	if s == nil || visited[s] {
+		return false
+	}
+	visited[s] = true
+	if strings.EqualFold(s.Format, "password") || schemaUsesPasswordFormat(s.Items, visited) {
+		return true
+	}
+	for _, variants := range [][]*SchemaSpec{s.AnyOf, s.OneOf, s.AllOf} {
+		for _, variant := range variants {
+			if schemaUsesPasswordFormat(variant, visited) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isDebugEnvVarPair(path []string, v map[string]any) bool {

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -197,6 +197,8 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 				form.Set(p.Name, operationStringValue(v))
 			}
 			continue
+		case InBody:
+			continue
 		}
 		if !operationChanged(input, p) {
 			continue
@@ -235,6 +237,9 @@ func resolveOperationRequest(s CommandSpec, input OperationInput, clientOpts Cli
 	if err := validateRequiredVariableParams(s, body); err != nil {
 		return "", nil, ClientOptions{}, err
 	}
+	if err := validateRequiredBodyParams(s, body); err != nil {
+		return "", nil, ClientOptions{}, err
+	}
 	if body != nil && s.RequestBody != nil && s.RequestBody.MediaType != "" && !isMultipartMediaType(s.RequestBody.MediaType) {
 		hdrs["Content-Type"] = s.RequestBody.MediaType
 	}
@@ -259,8 +264,25 @@ func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, 
 	if s.RequestBody.Template != "" {
 		return buildEnvelopeBody(s.RequestBody.Template, s.RequestBody.MergePath, vars, input.BodySets, input.BodyStringSets, input.FileBody, input.HasFile)
 	}
+	hasSets := len(input.BodySets) > 0 || len(input.BodyStringSets) > 0
+	flagBody, flagFields, err := jsonBodyFromFlags(s, input)
+	if err != nil {
+		return nil, err
+	}
+	if hasJSONBodyFlags(s.Params) && input.HasFile && (hasSets || len(flagFields) > 0) {
+		return nil, fmt.Errorf("--file cannot be combined with --set, --set-str, or body flags")
+	}
+	if len(flagFields) > 0 || (hasJSONBodyFlags(s.Params) && hasSets) {
+		if !supportsJSONBodyBuilder(s.RequestBody.MediaType) {
+			return nil, fmt.Errorf("request body media type %s requires --file; --set and --set-str only support JSON request bodies", s.RequestBody.MediaType)
+		}
+		if err := mergeJSONBodySets(flagBody, flagFields, input.BodySets, input.BodyStringSets); err != nil {
+			return nil, err
+		}
+		return json.Marshal(flagBody)
+	}
 	switch {
-	case len(input.BodySets) > 0 || len(input.BodyStringSets) > 0:
+	case hasSets:
 		if !supportsJSONBodyBuilder(s.RequestBody.MediaType) {
 			return nil, fmt.Errorf("request body media type %s requires --file; --set and --set-str only support JSON request bodies", s.RequestBody.MediaType)
 		}
@@ -270,6 +292,9 @@ func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, 
 	case s.RequestBody.Required:
 		if !supportsJSONBodyBuilder(s.RequestBody.MediaType) {
 			return nil, fmt.Errorf("request body media type %s requires --file", s.RequestBody.MediaType)
+		}
+		if hasJSONBodyFlags(s.Params) {
+			return nil, fmt.Errorf("request body required: pass --file, --set, --set-str, or a body flag")
 		}
 		return nil, fmt.Errorf("request body required: pass --file, --set, or --set-str")
 	default:
@@ -304,7 +329,7 @@ func buildDryRunRequest(ctx context.Context, s CommandSpec, hostname, hostSource
 		Hostname:   hostname,
 		HostSource: hostSource,
 		Headers:    redactedDryRunHeaders(req.Header),
-		Body:       redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes),
+		Body:       redactedDryRunBody(req.Header.Get("Content-Type"), bodyBytes, sensitiveBodyFields(s)),
 		Auth:       dryRunAuthForSpec(s),
 		Output: CatalogOutput{
 			ListPath:          s.Output.ListPath,
@@ -324,6 +349,9 @@ func validateRequiredOperationParams(s CommandSpec, input OperationInput) error 
 		if p.In == InVariable && s.RequestBody != nil {
 			continue
 		}
+		if p.In == InBody {
+			continue
+		}
 		if !operationChanged(input, p) {
 			return fmt.Errorf("required param %q missing", p.Name)
 		}
@@ -333,26 +361,62 @@ func validateRequiredOperationParams(s CommandSpec, input OperationInput) error 
 
 func validateOperationEnums(s CommandSpec, input OperationInput) error {
 	for _, p := range s.Params {
-		if len(p.Enum) == 0 || !operationChanged(input, p) {
+		if len(p.Enum) == 0 && len(p.ItemEnum) == 0 || !operationChanged(input, p) {
 			continue
 		}
 		v, _, err := operationValue(input, p)
 		if err != nil {
 			return err
 		}
-		raw := operationStringValue(v)
-		valid := false
-		for _, e := range p.Enum {
-			if raw == e {
-				valid = true
-				break
+		if len(p.Enum) > 0 {
+			raw := operationStringValue(v)
+			if !enumContains(p.Enum, raw) {
+				return fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", "))
 			}
 		}
-		if !valid {
-			return fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", "))
+		for _, raw := range operationStringValues(v) {
+			if len(p.ItemEnum) > 0 && !enumContains(p.ItemEnum, raw) {
+				return fmt.Errorf("invalid item %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.ItemEnum, ", "))
+			}
 		}
 	}
 	return nil
+}
+
+func enumContains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func operationStringValues(v any) []string {
+	switch tv := v.(type) {
+	case []string:
+		return append([]string(nil), tv...)
+	case []int64:
+		out := make([]string, len(tv))
+		for i, value := range tv {
+			out[i] = strconv.FormatInt(value, 10)
+		}
+		return out
+	case []float64:
+		out := make([]string, len(tv))
+		for i, value := range tv {
+			out[i] = strconv.FormatFloat(value, 'f', -1, 64)
+		}
+		return out
+	case []bool:
+		out := make([]string, len(tv))
+		for i, value := range tv {
+			out[i] = strconv.FormatBool(value)
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func operationChanged(input OperationInput, p ParamSpec) bool {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 12
+const SchemaVersion = 13
 
 type CommandSpec struct {
 	Group           string
@@ -68,6 +68,7 @@ type ParamSpec struct {
 	Required   bool
 	Default    string
 	Enum       []string
+	ItemEnum   []string `json:",omitempty"`
 	Format     string
 	Deprecated bool
 	Context    string `json:",omitempty"`
@@ -79,6 +80,7 @@ const (
 	InHeader   = "header"
 	InFormData = "formData"
 	InVariable = "variable"
+	InBody     = "body"
 	InInput    = "input"
 )
 
@@ -101,7 +103,10 @@ type RuntimeSchemaSpec struct {
 type SchemaSpec struct {
 	Ref                  string                    `json:"ref,omitempty"`
 	Type                 string                    `json:"type,omitempty"`
+	Description          string                    `json:"description,omitempty"`
+	Format               string                    `json:"format,omitempty"`
 	Nullable             bool                      `json:"nullable,omitempty"`
+	Enum                 []string                  `json:"enum,omitempty"`
 	Properties           map[string]*SchemaSpec    `json:"properties,omitempty"`
 	Required             []string                  `json:"required,omitempty"`
 	Items                *SchemaSpec               `json:"items,omitempty"`


### PR DESCRIPTION
### What's changed?

- add an opt-in `body.flags` overlay that projects flat JSON request bodies into typed CLI flags
- preserve descriptions, formats, enums, and map schemas across OpenAPI, Swagger, and protobuf backends while rejecting unsupported body shapes
- validate required body fields, enum items, flag bindings, and mixed body inputs without panics
- redact schema-declared password fields in dry-run output
- bump the generated runtime schema to 13 and the catalog schema to 20

### Why

- make JSON request bodies discoverable and usable through normal CLI flags without replacing `--file`, `--set`, or `--set-str`
- keep generated code, runtime behavior, catalog metadata, and backend schema fidelity aligned under an explicit versioned contract

### Verification

- `make check`
- `go test -race -count=1 ./...`
- generated and built a Tokener scratch CLI, then passed `__lathe verify --json`
- exercised typed flags, `--set-str`, stdin `--file -`, enum rejection, mixed-input rejection, catalog schema 20, and dry-run password redaction
