### PR TITLE
fix(runtime): align update version and host errors

### DIFF
--- a/pkg/lathe/update.go
+++ b/pkg/lathe/update.go
@@ -31,6 +31,7 @@ var (
 	updateGitHubAPIBaseURL = "https://api.github.com"
 	updateHTTPClient       = &http.Client{Timeout: 30 * time.Second}
 	installUpdate          = replaceExecutable
+	updateVersionInfo      = VersionInfo
 )
 
 type githubRelease struct {
@@ -60,6 +61,7 @@ func updateCmd(m *config.Manifest) *cobra.Command {
 }
 
 func runGitHubUpdate(cmd *cobra.Command, m *config.Manifest, yes bool) error {
+	currentVersion, _, _ := updateVersionInfo()
 	release, err := fetchLatestGitHubRelease(cmd.Context(), *m.Update.GitHub)
 	if err != nil {
 		return err
@@ -67,7 +69,7 @@ func runGitHubUpdate(cmd *cobra.Command, m *config.Manifest, yes bool) error {
 	if release.TagName == "" {
 		return fmt.Errorf("latest release has no tag_name")
 	}
-	cmp, err := compareVersions(Version, release.TagName)
+	cmp, err := compareVersions(currentVersion, release.TagName)
 	if err != nil {
 		return err
 	}
@@ -76,10 +78,10 @@ func runGitHubUpdate(cmd *cobra.Command, m *config.Manifest, yes bool) error {
 		return nil
 	}
 	if cmp > 0 {
-		fmt.Fprintf(cmd.OutOrStdout(), "%s is newer than latest release (%s > %s)\n", m.CLI.Name, Version, release.TagName)
+		fmt.Fprintf(cmd.OutOrStdout(), "%s is newer than latest release (%s > %s)\n", m.CLI.Name, currentVersion, release.TagName)
 		return nil
 	}
-	if !yes && !confirmUpdate(cmd, m.CLI.Name, Version, release.TagName) {
+	if !yes && !confirmUpdate(cmd, m.CLI.Name, currentVersion, release.TagName) {
 		fmt.Fprintln(cmd.OutOrStdout(), "Update cancelled.")
 		return nil
 	}

--- a/pkg/lathe/update_test.go
+++ b/pkg/lathe/update_test.go
@@ -1,0 +1,62 @@
+package lathe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/lathe-cli/lathe/pkg/config"
+)
+
+func TestRunGitHubUpdateUsesReportedVersion(t *testing.T) {
+	restoreVersionInfo(t)
+	Version = "dev"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/acme/demo/releases/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(githubRelease{TagName: "v0.1.2"})
+	}))
+	defer srv.Close()
+
+	oldBaseURL := updateGitHubAPIBaseURL
+	oldClient := updateHTTPClient
+	oldVersionInfo := updateVersionInfo
+	t.Cleanup(func() {
+		updateGitHubAPIBaseURL = oldBaseURL
+		updateHTTPClient = oldClient
+		updateVersionInfo = oldVersionInfo
+	})
+	updateGitHubAPIBaseURL = srv.URL
+	updateHTTPClient = srv.Client()
+	updateVersionInfo = func() (string, string, string) {
+		return "v0.1.3-0.20260830061345-0837499497e7", "0837499", "2026-08-30T06:13:45Z"
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	m := &config.Manifest{
+		CLI: config.CLIInfo{Name: "demo"},
+		Update: config.UpdateInfo{GitHub: &config.GitHubUpdate{
+			Owner: "acme",
+			Repo:  "demo",
+		}},
+	}
+
+	if err := runGitHubUpdate(cmd, m, false); err != nil {
+		t.Fatalf("runGitHubUpdate: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "demo is newer than latest release (v0.1.3-0.20260830061345-0837499497e7 > v0.1.2)") {
+		t.Fatalf("output = %q", got)
+	}
+}

--- a/pkg/runtime/ctx.go
+++ b/pkg/runtime/ctx.go
@@ -131,7 +131,7 @@ func loadHostOptions(cmd *cobra.Command, defaultHostname string, refresh bool) (
 	}
 	e, ok := hosts.Get(res.Hostname)
 	if !ok {
-		return res, ClientOptions{}, notAuthenticatedToHost(res.Hostname)
+		return res, ClientOptions{}, missingHostCredentialsError(res.Hostname, hosts.Names())
 	}
 	insecure := e.Insecure
 	if v, err := cmd.Root().PersistentFlags().GetBool("insecure"); err == nil && v {
@@ -204,4 +204,23 @@ func tryLoadHostOptions(cmd *cobra.Command, defaultHostname string, refresh bool
 
 func notAuthenticatedToHost(string) error {
 	return fmt.Errorf("authentication required for selected host: %w", ErrNotAuthenticated)
+}
+
+func missingHostCredentialsError(hostname string, configured []string) error {
+	cli := config.Active().CLI.Name
+	hint := fmt.Sprintf("run `%s auth login --hostname <host>` for that host, or check --hostname", cli)
+	if len(configured) > 0 {
+		names := make([]string, len(configured))
+		for i, name := range configured {
+			names[i] = fmt.Sprintf("%q", name)
+		}
+		hint += "; logged-in hosts: " + strings.Join(names, ", ")
+	}
+	return NewError(
+		CodeNotAuthenticated,
+		ExitNotAuthenticated,
+		fmt.Sprintf("no credentials for host %q", hostname),
+		hint,
+		ErrNotAuthenticated,
+	)
 }

--- a/pkg/runtime/host_resolution_test.go
+++ b/pkg/runtime/host_resolution_test.go
@@ -2,8 +2,11 @@ package runtime
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/lathe-cli/lathe/pkg/config"
 )
@@ -99,6 +102,32 @@ func TestResolveConfiguredHost_MultipleHostErrorStaysVisible(t *testing.T) {
 	}
 	if le.ExitCode != ExitGeneral {
 		t.Errorf("exit = %d, want %d", le.ExitCode, ExitGeneral)
+	}
+}
+
+func TestLoadHostOptions_UnknownExplicitHostIsActionable(t *testing.T) {
+	bindTestManifest(t, "demo", "DEMO_HOST")
+	hosts := hostsWith(t, "", "known.example.com")
+	if err := hosts.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	root := &cobra.Command{Use: "demo"}
+	root.PersistentFlags().String("hostname", "missing.example.com", "")
+
+	_, _, err := loadHostOptions(root, "", false)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+	le := ClassifyError(err)
+	if le.Code != CodeNotAuthenticated || le.ExitCode != ExitNotAuthenticated {
+		t.Fatalf("classified error = %#v", le)
+	}
+	if le.Message != `no credentials for host "missing.example.com"` {
+		t.Errorf("message = %q", le.Message)
+	}
+	if !strings.Contains(le.Hint, "demo auth login --hostname <host>") || !strings.Contains(le.Hint, `"known.example.com"`) {
+		t.Errorf("hint = %q", le.Hint)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Make `update` compare the same `VersionInfo()` value reported by version commands.
- Return host-specific actionable authentication errors when a resolved host has no credentials.

## Verification

- `go test -count=1 ./pkg/lathe -run TestRunGitHubUpdateUsesReportedVersion`
- `go test -count=1 ./pkg/runtime -run TestLoadHostOptions_UnknownExplicitHostIsActionable`
- `make check`
- `go test -race -count=1 ./...`
- Rebuilt Tokener against this Lathe checkout and verified that a control-character hostname stays inside a valid JSON error envelope with exit code 4.

## Compatibility

No catalog schema or generated command shape changes. Update checks now honor Go module build information, and missing-host errors keep `not_authenticated`, exit code 4, and `errors.Is(ErrNotAuthenticated)` while improving the message and hint.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented in this PR.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.