### PR TITLE
feat(runtime): add error details, method-safety mutation, search terms

### DIFF
--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -328,8 +328,15 @@ commands:
 ```
 
 Supported property types are string, number, integer, boolean, nullable scalars,
-and scalar arrays. Nested objects, maps, leftover `oneOf`/`anyOf`/`allOf` after
-nullable flattening, multipart bodies, and GraphQL templates fail codegen.
+and scalar arrays. Nested object properties (including arrays of objects) are
+skipped instead of failing codegen: top-level scalar and scalar-array
+properties still become typed flags, while the skipped fields stay reachable
+through `--set`, `--set-str`, or `--file`. The `--set`/`--set-str` help and the
+catalog `body.set_only_fields` list name those fields. Flattening nested
+fields into typed flags (e.g. `--limits-max-budget-usd`) is a possible future
+extension, not current behavior. A body whose properties are all nested
+objects, plus maps, leftover `oneOf`/`anyOf`/`allOf` after nullable
+flattening, multipart bodies, and GraphQL templates still fail codegen.
 Property descriptions become flag help, and typed scalar or array-item enum
 flags are validated locally. Required properties may be supplied by a typed flag,
 `--file`, `--set`, or `--set-str`; omitting an optional body remains valid.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -85,6 +85,19 @@ user-provided values. It is a single bounded line. Human-readable output
 prints it as a `Detail:` line between `Error:` and `Hint:`. Cobra unknown
 command and unknown flag errors never carry a detail.
 
+For `api_error`, `message` stays `API request failed` and `detail` is filled
+from the first available layer:
+
+1. The response Content-Type is JSON and a string is extractable from a
+   declared field (`message`; `error` as a string or `error.message`;
+   `detail`; depth <= 2): detail is that message, control characters
+   stripped, bounded to 240 runes. Bodies over 32KB are never parsed.
+2. Otherwise, if the command catalog declares a `known_errors` entry matching
+   the HTTP status, detail is its `cause`. Layers never stack.
+3. Otherwise detail is absent and only the numeric status plus hint remain.
+
+The raw response body is never emitted in any layer.
+
 | Code | Exit |
 | --- | ---: |
 | `general` | 1 |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -58,6 +58,14 @@ Framework commands such as `auth`, `commands`, `search`, `skill`, `update`, and
 `catalog.cli.capabilities` reports compiled first-party capabilities such as
 `skill.bundle` and `workflow.dsl`.
 
+Operation entries may carry `search_terms`: overlay-curated synonyms that
+flow from the overlay through the generated `CommandSpec` into the catalog.
+Search indexes them as identifying synonyms weighted like the summary text,
+so a single curated term surfaces the command without outranking exact
+command-name or operation-id matches. Generated Skill module references list
+them per operation. Downstream CLIs must be regenerated to pick up
+`search_terms` (SchemaVersion 15, CatalogSchemaVersion 22).
+
 Search is discovery only. Inspect the selected command with `commands show`
 before execution. Read `mutation` and `dry_run` from that JSON; do not infer
 write vs read from the HTTP method, and do not assume a `--dry-run` flag is

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -79,6 +79,12 @@ and YAML errors contain `code`, `message`, and `hint`; `error.http` may contain
 only a numeric status. URLs, headers, bodies, credentials, and raw transport
 errors are excluded.
 
+`error.detail` is optional, locally constructed from spec metadata only
+(flag names, declared value sets, required field names); it never echoes
+user-provided values. It is a single bounded line. Human-readable output
+prints it as a `Detail:` line between `Error:` and `Hint:`. Cobra unknown
+command and unknown flag errors never carry a detail.
+
 | Code | Exit |
 | --- | ---: |
 | `general` | 1 |

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -44,10 +44,14 @@ Catalog entries have two kinds:
   is the heaviest step classification. Workflow `dry_run.mode` is
   `unsupported`.
 
-`mutation` is `read`, `write`, or `unknown`. GET and HEAD are `read`. GraphQL
+`mutation` is `read`, `write`, or `unknown`. An explicit overlay
+`mutation: read|write` override wins over every inference. Otherwise GraphQL
 operations are classified from the request template (`query` / `mutation`),
-not from HTTP POST. Other methods stay `unknown` unless the template proves
-otherwise.
+not from HTTP POST. Otherwise RFC 9110 safe methods (GET, HEAD, OPTIONS,
+TRACE) are `read` and every other declared method is `write`; `unknown` is
+reserved for operations whose method cannot be determined. Consumers that
+previously treated `unknown` as dangerous now see `write` for the same
+operations: handle it the same way, the classification is just more precise.
 
 Framework commands such as `auth`, `commands`, `search`, `skill`, `update`, and
 `__lathe` are discovered through `--help`; they are not operation entries.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -66,6 +66,11 @@ command-name or operation-id matches. Generated Skill module references list
 them per operation. Downstream CLIs must be regenerated to pick up
 `search_terms` (SchemaVersion 15, CatalogSchemaVersion 22).
 
+When JSON body flags are enabled, `body.set_only_fields` lists body fields
+that received no typed flag (nested object properties); they remain settable
+through `--set`, `--set-str`, or `--file` (SchemaVersion 16,
+CatalogSchemaVersion 23).
+
 Search is discovery only. Inspect the selected command with `commands show`
 before execution. Read `mutation` and `dry_run` from that JSON; do not infer
 write vs read from the HTTP method, and do not assume a `--dry-run` flag is

--- a/internal/codegen/backends/openapi3/backend_test.go
+++ b/internal/codegen/backends/openapi3/backend_test.go
@@ -266,7 +266,7 @@ func TestParse_NullableEnumAnyOfBecomesBodyFlagSchema(t *testing.T) {
 	if spec.RequestBody.Schema.Properties["maxBudgetUsd"].Type != "number" || !spec.RequestBody.Schema.Properties["maxBudgetUsd"].Nullable {
 		t.Fatalf("maxBudgetUsd = %#v", spec.RequestBody.Schema.Properties["maxBudgetUsd"])
 	}
-	got, err := normalize.ExpandJSONBodyFlags(spec)
+	got, _, err := normalize.ExpandJSONBodyFlags(spec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codegen/normalize/body_flags.go
+++ b/internal/codegen/normalize/body_flags.go
@@ -1,6 +1,7 @@
 package normalize
 
 import (
+	"errors"
 	"fmt"
 	"mime"
 	"sort"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/lathe-cli/lathe/pkg/runtime"
 )
+
+var errNestedObjectProperty = errors.New("nested objects are not supported")
 
 var reservedBodyFlagNames = map[string]bool{
 	"all":       true,
@@ -25,32 +28,32 @@ var reservedBodyFlagNames = map[string]bool{
 	"wait":      true,
 }
 
-func ExpandJSONBodyFlags(spec runtime.CommandSpec) ([]runtime.ParamSpec, error) {
+func ExpandJSONBodyFlags(spec runtime.CommandSpec) ([]runtime.ParamSpec, []string, error) {
 	if spec.RequestBody == nil {
-		return nil, fmt.Errorf("command has no request body")
+		return nil, nil, fmt.Errorf("command has no request body")
 	}
 	if spec.RequestBody.Template != "" {
-		return nil, fmt.Errorf("GraphQL request templates cannot enable body flags")
+		return nil, nil, fmt.Errorf("GraphQL request templates cannot enable body flags")
 	}
 	mediaType, _, err := mime.ParseMediaType(spec.RequestBody.MediaType)
 	if spec.RequestBody.MediaType != "" && err != nil {
-		return nil, fmt.Errorf("request body media type: %w", err)
+		return nil, nil, fmt.Errorf("request body media type: %w", err)
 	}
 	if mediaType == "" {
 		mediaType = spec.RequestBody.MediaType
 	}
 	if isMultipartMediaType(mediaType) || hasFormDataParams(spec.Params) {
-		return nil, fmt.Errorf("multipart request bodies cannot enable body flags")
+		return nil, nil, fmt.Errorf("multipart request bodies cannot enable body flags")
 	}
 	if !runtimeJSONBodyMediaType(mediaType) {
-		return nil, fmt.Errorf("request body media type %q cannot enable body flags", spec.RequestBody.MediaType)
+		return nil, nil, fmt.Errorf("request body media type %q cannot enable body flags", spec.RequestBody.MediaType)
 	}
 	schema := spec.RequestBody.Schema
 	if schema == nil {
-		return nil, fmt.Errorf("request body schema is required")
+		return nil, nil, fmt.Errorf("request body schema is required")
 	}
 	if err := rejectUnsupportedJSONBodySchema(schema, true); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	required := make(map[string]bool, len(schema.Required))
 	for _, name := range schema.Required {
@@ -70,25 +73,30 @@ func ExpandJSONBodyFlags(spec runtime.CommandSpec) ([]runtime.ParamSpec, error) 
 		}
 	}
 	out := make([]runtime.ParamSpec, 0, len(names))
+	setOnly := make([]string, 0)
 	seenFlags := map[string]string{}
 	for _, name := range names {
 		property := schema.Properties[name]
 		goType, err := jsonBodyFlagGoType(property)
+		if errors.Is(err, errNestedObjectProperty) {
+			setOnly = append(setOnly, name)
+			continue
+		}
 		if err != nil {
-			return nil, fmt.Errorf("property %q: %w", name, err)
+			return nil, nil, fmt.Errorf("property %q: %w", name, err)
 		}
 		flag := camelToKebab(name)
 		if flag == "" {
-			return nil, fmt.Errorf("property %q does not produce a flag name", name)
+			return nil, nil, fmt.Errorf("property %q does not produce a flag name", name)
 		}
 		if reservedBodyFlagNames[flag] {
-			return nil, fmt.Errorf("property %q flag %q conflicts with a reserved flag", name, flag)
+			return nil, nil, fmt.Errorf("property %q flag %q conflicts with a reserved flag", name, flag)
 		}
 		if existing[flag] || existing[name] {
-			return nil, fmt.Errorf("property %q flag %q conflicts with an existing parameter", name, flag)
+			return nil, nil, fmt.Errorf("property %q flag %q conflicts with an existing parameter", name, flag)
 		}
 		if prior, ok := seenFlags[flag]; ok {
-			return nil, fmt.Errorf("properties %q and %q produce the same flag %q", prior, name, flag)
+			return nil, nil, fmt.Errorf("properties %q and %q produce the same flag %q", prior, name, flag)
 		}
 		seenFlags[flag] = name
 		out = append(out, runtime.ParamSpec{
@@ -103,7 +111,13 @@ func ExpandJSONBodyFlags(spec runtime.CommandSpec) ([]runtime.ParamSpec, error) 
 			Format:   property.Format,
 		})
 	}
-	return out, nil
+	if len(out) == 0 {
+		return nil, nil, fmt.Errorf("no body properties support typed flags (nested object fields: %s); use --set, --set-str, or --file", strings.Join(setOnly, ", "))
+	}
+	if len(setOnly) == 0 {
+		setOnly = nil
+	}
+	return out, setOnly, nil
 }
 
 func ValidateJSONBodyFlagParams(spec runtime.CommandSpec) error {
@@ -190,7 +204,7 @@ func rejectUnsupportedJSONBodySchema(schema *runtime.SchemaSpec, root bool) erro
 		return nil
 	}
 	if schema.Type == "object" || len(schema.Properties) > 0 {
-		return fmt.Errorf("nested objects are not supported")
+		return errNestedObjectProperty
 	}
 	return nil
 }

--- a/internal/codegen/normalize/body_flags_test.go
+++ b/internal/codegen/normalize/body_flags_test.go
@@ -28,9 +28,12 @@ func TestExpandJSONBodyFlags(t *testing.T) {
 			},
 		},
 	}
-	got, err := ExpandJSONBodyFlags(spec)
+	got, setOnly, err := ExpandJSONBodyFlags(spec)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(setOnly) != 0 {
+		t.Fatalf("setOnly = %#v, want empty", setOnly)
 	}
 	byName := map[string]runtime.ParamSpec{}
 	for _, param := range got {
@@ -72,12 +75,12 @@ func TestExpandJSONBodyFlags_RequiredAndCollision(t *testing.T) {
 			},
 		},
 	}
-	if _, err := ExpandJSONBodyFlags(spec); err == nil || !strings.Contains(err.Error(), "conflicts") {
+	if _, _, err := ExpandJSONBodyFlags(spec); err == nil || !strings.Contains(err.Error(), "conflicts") {
 		t.Fatalf("error = %v, want flag conflict", err)
 	}
 	spec.Params = nil
 	spec.RequestBody.Schema.Properties = map[string]*runtime.SchemaSpec{"name": {Type: "string"}, "enabled": {Type: "boolean"}}
-	got, err := ExpandJSONBodyFlags(spec)
+	got, _, err := ExpandJSONBodyFlags(spec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,9 +96,9 @@ func TestExpandJSONBodyFlags_RejectsUnsupported(t *testing.T) {
 		want string
 	}{
 		{
-			name: "nested",
+			name: "only nested properties",
 			spec: jsonBodySpec(&runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"limits": {Type: "object", Properties: map[string]*runtime.SchemaSpec{"rpm": {Type: "integer"}}}}}),
-			want: "nested objects",
+			want: "no body properties support typed flags",
 		},
 		{
 			name: "oneof",
@@ -120,11 +123,33 @@ func TestExpandJSONBodyFlags_RejectsUnsupported(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := ExpandJSONBodyFlags(tc.spec)
+			_, _, err := ExpandJSONBodyFlags(tc.spec)
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestExpandJSONBodyFlags_SkipsNestedObjectProperties(t *testing.T) {
+	spec := jsonBodySpec(&runtime.SchemaSpec{
+		Type:     "object",
+		Required: []string{"name"},
+		Properties: map[string]*runtime.SchemaSpec{
+			"name":   {Type: "string"},
+			"limits": {Type: "object", Properties: map[string]*runtime.SchemaSpec{"maxBudgetUsd": {Type: "number"}}},
+			"admins": {Type: "array", Items: &runtime.SchemaSpec{Type: "object", Properties: map[string]*runtime.SchemaSpec{"id": {Type: "string"}}}},
+		},
+	})
+	got, setOnly, err := ExpandJSONBodyFlags(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "name" || got[0].Flag != "name" || !got[0].Required {
+		t.Fatalf("params = %#v", got)
+	}
+	if !equalStrings(setOnly, []string{"admins", "limits"}) {
+		t.Fatalf("setOnly = %#v", setOnly)
 	}
 }
 

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -297,6 +297,9 @@ func mergeOverlaySpecs(specs []runtime.CommandSpec, mod overlay.Module) ([]runti
 	for i := range merged {
 		applyBulkDefaults(&merged[i], mod.Defaults, matchedLegacyUses[i])
 		if matched[i] {
+			if err := validateMutationOverride(overrides[i]); err != nil {
+				return nil, fmt.Errorf("command %q: %w", merged[i].Use, err)
+			}
 			if err := applyBodyFlags(&merged[i], overrides[i]); err != nil {
 				return nil, fmt.Errorf("command %q body.flags: %w", merged[i].Use, err)
 			}
@@ -792,6 +795,15 @@ func validateStreamingOverride(spec runtime.CommandSpec, stream overlay.Streamin
 	return nil
 }
 
+func validateMutationOverride(override overlay.Override) error {
+	switch override.Mutation {
+	case "", "read", "write":
+		return nil
+	default:
+		return fmt.Errorf("mutation must be %q or %q, got %q", "read", "write", override.Mutation)
+	}
+}
+
 func overrideMatches(spec runtime.CommandSpec, override overlay.Override) bool {
 	if override.Match.Method != "" && !strings.EqualFold(override.Match.Method, spec.Method) {
 		return false
@@ -911,6 +923,9 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 		for _, ke := range override.KnownErrors {
 			spec.KnownErrors = append(spec.KnownErrors, runtime.KnownError{Status: ke.Status, Cause: ke.Cause})
 		}
+	}
+	if override.Mutation != "" {
+		spec.Mutation = override.Mutation
 	}
 	if len(override.Aliases) > 0 {
 		spec.Aliases = append(spec.Aliases, override.Aliases...)
@@ -1332,6 +1347,7 @@ func commandSpecLiteral(spec runtime.CommandSpec) string {
 	if spec.SetContext != nil {
 		fmt.Fprintf(&b, "SetContext: &runtime.ContextSetHint{Name: %q, Param: %q},", spec.SetContext.Name, spec.SetContext.Param)
 	}
+	writeStringField(&b, "Mutation", spec.Mutation)
 	b.WriteByte('}')
 	return b.String()
 }
@@ -1784,6 +1800,9 @@ var Specs = []runtime.CommandSpec{
 		{{- end}}
 		{{- if $op.SetContext}}
 		SetContext: &runtime.ContextSetHint{Name: {{printf "%q" $op.SetContext.Name}}, Param: {{printf "%q" $op.SetContext.Param}}},
+		{{- end}}
+		{{- if $op.Mutation}}
+		Mutation: {{printf "%q" $op.Mutation}},
 		{{- end}}
 		{{- if $op.OperationID}}
 		OperationID: {{printf "%q" $op.OperationID}},

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -390,7 +390,7 @@ func ValidateOverlayModule(specs []runtime.CommandSpec, mod overlay.Module) erro
 			}
 		}
 		if override.Body != nil && override.Body.Flags {
-			if _, err := normalize.ExpandJSONBodyFlags(spec); err != nil {
+			if _, _, err := normalize.ExpandJSONBodyFlags(spec); err != nil {
 				return fmt.Errorf("command %q body.flags: %w", spec.Use, err)
 			}
 		}
@@ -886,11 +886,12 @@ func applyBodyFlags(spec *runtime.CommandSpec, override overlay.Override) error 
 	if override.Body == nil || !override.Body.Flags {
 		return nil
 	}
-	params, err := normalize.ExpandJSONBodyFlags(*spec)
+	params, setOnly, err := normalize.ExpandJSONBodyFlags(*spec)
 	if err != nil {
 		return err
 	}
 	spec.Params = append(spec.Params, params...)
+	spec.RequestBody.SetOnlyFields = setOnly
 	return nil
 }
 
@@ -1494,6 +1495,7 @@ func requestBodyLiteral(body *runtime.RequestBody) string {
 	}
 	writeStringField(&b, "Template", body.Template)
 	writeStringField(&b, "MergePath", body.MergePath)
+	writeStringSliceField(&b, "SetOnlyFields", body.SetOnlyFields)
 	b.WriteByte('}')
 	return b.String()
 }
@@ -1849,6 +1851,11 @@ var Specs = []runtime.CommandSpec{
 				{{- end}}
 				{{- if $op.RequestBody.Template}}
 				Template: {{printf "%q" $op.RequestBody.Template}},
+				{{- end}}
+				{{- if $op.RequestBody.SetOnlyFields}}
+				SetOnlyFields: []string{
+					{{- range $op.RequestBody.SetOnlyFields}}{{printf "%q" .}},{{end}}
+				},
 				{{- end}}
 				{{- if $op.RequestBody.MergePath}}
 				MergePath: {{printf "%q" $op.RequestBody.MergePath}},

--- a/internal/codegen/render/render.go
+++ b/internal/codegen/render/render.go
@@ -828,6 +828,7 @@ func cloneCommandSpec(spec runtime.CommandSpec) runtime.CommandSpec {
 	cloned.Notes = append([]string(nil), spec.Notes...)
 	cloned.Prerequisites = append([]string(nil), spec.Prerequisites...)
 	cloned.KnownErrors = append([]runtime.KnownError(nil), spec.KnownErrors...)
+	cloned.SearchTerms = append([]string(nil), spec.SearchTerms...)
 	if spec.SetContext != nil {
 		setContext := *spec.SetContext
 		cloned.SetContext = &setContext
@@ -926,6 +927,9 @@ func applyCommandOverride(spec *runtime.CommandSpec, override overlay.Override) 
 	}
 	if override.Mutation != "" {
 		spec.Mutation = override.Mutation
+	}
+	if len(override.SearchTerms) > 0 {
+		spec.SearchTerms = append([]string(nil), override.SearchTerms...)
 	}
 	if len(override.Aliases) > 0 {
 		spec.Aliases = append(spec.Aliases, override.Aliases...)
@@ -1348,6 +1352,7 @@ func commandSpecLiteral(spec runtime.CommandSpec) string {
 		fmt.Fprintf(&b, "SetContext: &runtime.ContextSetHint{Name: %q, Param: %q},", spec.SetContext.Name, spec.SetContext.Param)
 	}
 	writeStringField(&b, "Mutation", spec.Mutation)
+	writeStringSliceField(&b, "SearchTerms", spec.SearchTerms)
 	b.WriteByte('}')
 	return b.String()
 }
@@ -1803,6 +1808,11 @@ var Specs = []runtime.CommandSpec{
 		{{- end}}
 		{{- if $op.Mutation}}
 		Mutation: {{printf "%q" $op.Mutation}},
+		{{- end}}
+		{{- if $op.SearchTerms}}
+		SearchTerms: []string{
+			{{- range $op.SearchTerms}}{{printf "%q" .}},{{end}}
+		},
 		{{- end}}
 		{{- if $op.OperationID}}
 		OperationID: {{printf "%q" $op.OperationID}},

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -100,6 +100,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 			Prerequisites: []string{"List clusters before installing."},
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing addon name"}},
 			Mutation:      "read",
+			SearchTerms:   []string{"spend", "cost"},
 			Params:        map[string]overlay.ParamOverride{"workspace_id": {Context: "workspace"}},
 			Context:       &overlay.ContextOverride{SetOnSuccess: &overlay.ContextSetOnSuccess{Name: "workspace", FromParam: "workspace_id"}},
 			Output: &overlay.OutputOverride{
@@ -137,7 +138,6 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 		`Status: 400`,
 		`Cause: "missing addon name"`,
 		`Context: "workspace"`,
-		`SetContext: &runtime.ContextSetHint{Name: "workspace", Param: "workspace_id"}`,
 		`DefaultColumns: []string{"name", "spendMicro"}`,
 		`ColumnLabels: map[string]string{"name": "Addon"}`,
 		`ColumnFormats: map[string]runtime.ColumnFormat{"spendMicro": runtime.ColumnFormat{Kind: "currency", Currency: "USD", SourceScale: 6, Grouping: true, MinFractionDigits: 2, MaxFractionDigits: 6}}`,
@@ -163,8 +163,15 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	if strings.Contains(got, `"raw short"`) {
 		t.Errorf("overlay did not replace Short; raw value leaked into output")
 	}
-	if flat := strings.Join(strings.Fields(got), " "); !strings.Contains(flat, `Mutation: "read"`) {
+	flat := strings.Join(strings.Fields(got), " ")
+	if !strings.Contains(flat, `Mutation: "read"`) {
 		t.Errorf("output missing mutation override literal")
+	}
+	if !strings.Contains(flat, `SetContext: &runtime.ContextSetHint{Name: "workspace", Param: "workspace_id"}`) {
+		t.Errorf("output missing set-context literal")
+	}
+	if !strings.Contains(flat, `SearchTerms: []string{ "spend", "cost", }`) && !strings.Contains(flat, `SearchTerms: []string{"spend", "cost"}`) && !strings.Contains(flat, `SearchTerms: []string{"spend","cost",}`) {
+		t.Errorf("output missing search terms literal:\n%s", flat)
 	}
 }
 

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -614,6 +614,7 @@ func TestMergeOverlayModule_BodyFlags(t *testing.T) {
 				Properties: map[string]*runtime.SchemaSpec{
 					"maxBudgetUsd":   {Type: "number", Nullable: true},
 					"budgetDuration": {Type: "string", Nullable: true, Enum: []string{"monthly"}},
+					"limits":         {Type: "object", Properties: map[string]*runtime.SchemaSpec{"rpm": {Type: "integer"}}},
 				},
 			},
 		},
@@ -647,6 +648,47 @@ func TestMergeOverlayModule_BodyFlags(t *testing.T) {
 	if byName["budgetDuration"].Enum[0] != "monthly" {
 		t.Fatalf("budgetDuration = %+v", byName["budgetDuration"])
 	}
+	if _, ok := byName["limits"]; ok {
+		t.Fatalf("nested object property must not produce a typed flag: %#v", byName["limits"])
+	}
+	if got := merged[0].RequestBody.SetOnlyFields; len(got) != 1 || got[0] != "limits" {
+		t.Fatalf("set-only fields = %#v", got)
+	}
+}
+
+func TestRenderModule_EmitsSetOnlyBodyFields(t *testing.T) {
+	chdirWithGoMod(t)
+
+	specs := []runtime.CommandSpec{{
+		Group:   "Keys",
+		Use:     "create-key",
+		Short:   "Create a key",
+		Method:  "POST",
+		PathTpl: "/keys",
+		RequestBody: &runtime.RequestBody{
+			Required:  true,
+			MediaType: "application/json",
+			Schema: &runtime.SchemaSpec{
+				Type:     "object",
+				Required: []string{"name"},
+				Properties: map[string]*runtime.SchemaSpec{
+					"name":   {Type: "string"},
+					"limits": {Type: "object", Properties: map[string]*runtime.SchemaSpec{"maxBudgetUsd": {Type: "number"}}},
+				},
+			},
+		},
+	}}
+	overrides := map[string]overlay.Override{"create-key": {Body: &overlay.BodyOverride{Flags: true}}}
+	if err := RenderModule("demo", "", specs, overrides); err != nil {
+		t.Fatalf("RenderModule: %v", err)
+	}
+	flat := strings.Join(strings.Fields(generatedModule(t, "demo")), " ")
+	if !strings.Contains(flat, `SetOnlyFields: []string{"limits"}`) {
+		t.Errorf("output missing set-only fields literal:\n%s", flat)
+	}
+	if !strings.Contains(flat, `Flag: "name"`) {
+		t.Errorf("output missing typed flag for top-level scalar:\n%s", flat)
+	}
 }
 
 func TestValidateOverlayModule_RejectsNestedBodyFlags(t *testing.T) {
@@ -666,7 +708,7 @@ func TestValidateOverlayModule_RejectsNestedBodyFlags(t *testing.T) {
 	err := ValidateOverlayModule(specs, overlay.Module{Commands: map[string]overlay.Override{
 		"create": {Body: &overlay.BodyOverride{Flags: true}},
 	}})
-	if err == nil || !strings.Contains(err.Error(), "nested objects") {
+	if err == nil || !strings.Contains(err.Error(), "no body properties support typed flags") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/internal/codegen/render/render_test.go
+++ b/internal/codegen/render/render_test.go
@@ -99,6 +99,7 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 			Notes:         []string{"Use the canonical addon ID."},
 			Prerequisites: []string{"List clusters before installing."},
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing addon name"}},
+			Mutation:      "read",
 			Params:        map[string]overlay.ParamOverride{"workspace_id": {Context: "workspace"}},
 			Context:       &overlay.ContextOverride{SetOnSuccess: &overlay.ContextSetOnSuccess{Name: "workspace", FromParam: "workspace_id"}},
 			Output: &overlay.OutputOverride{
@@ -161,6 +162,9 @@ func TestRenderModule_AppliesOverlay(t *testing.T) {
 	}
 	if strings.Contains(got, `"raw short"`) {
 		t.Errorf("overlay did not replace Short; raw value leaked into output")
+	}
+	if flat := strings.Join(strings.Fields(got), " "); !strings.Contains(flat, `Mutation: "read"`) {
+		t.Errorf("output missing mutation override literal")
 	}
 }
 
@@ -337,6 +341,20 @@ func TestValidateOverlayModule_RejectsInvalidGroups(t *testing.T) {
 				t.Fatalf("validation error = %v", err)
 			}
 		})
+	}
+}
+
+func TestOverlayModule_RejectsInvalidMutationOverride(t *testing.T) {
+	specs := []runtime.CommandSpec{{Group: "Reports", Use: "query-report", Method: "POST", PathTpl: "/reports/query"}}
+	mod := overlay.Module{Commands: map[string]overlay.Override{
+		"query-report": {Mutation: "maybe"},
+	}}
+	wantMsg := `mutation must be "read" or "write"`
+	if err := ValidateOverlayModule(specs, mod); err == nil || !strings.Contains(err.Error(), wantMsg) {
+		t.Fatalf("validate error = %v", err)
+	}
+	if _, err := MergeOverlayModule(specs, mod); err == nil || !strings.Contains(err.Error(), wantMsg) {
+		t.Fatalf("merge error = %v", err)
 	}
 }
 

--- a/internal/codegen/render/skill.go
+++ b/internal/codegen/render/skill.go
@@ -764,6 +764,13 @@ func commandExample(example, cli, module string, spec runtime.CommandSpec, flat 
 func writeOperationContext(b *strings.Builder, spec runtime.CommandSpec) {
 	writeStringList(b, "Notes", spec.Notes)
 	writeStringList(b, "Prerequisites", spec.Prerequisites)
+	if len(spec.SearchTerms) > 0 {
+		terms := make([]string, 0, len(spec.SearchTerms))
+		for _, term := range spec.SearchTerms {
+			terms = append(terms, "`"+strings.ReplaceAll(oneLine(term), "`", "'")+"`")
+		}
+		fmt.Fprintf(b, "- Search terms: %s\n", strings.Join(terms, ", "))
+	}
 	if spec.SetContext != nil {
 		param := spec.SetContext.Param
 		if index, count := paramByNameOrFlag(spec.Params, param); count == 1 {

--- a/internal/codegen/render/skill_test.go
+++ b/internal/codegen/render/skill_test.go
@@ -76,6 +76,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 			Notes:         []string{"clusterFilter expects a cluster UUID."},
 			Prerequisites: []string{"Find the cluster UUID first."},
 			KnownErrors:   []overlay.KnownError{{Status: 400, Cause: "missing start/end"}},
+			SearchTerms:   []string{"member", "invite"},
 			Params:        map[string]overlay.ParamOverride{unsafeParamName: {Argument: "receiver"}},
 		},
 	})
@@ -149,6 +150,7 @@ func TestRenderSkillDirectory_GeneratesSkillStructure(t *testing.T) {
 		"Find the cluster UUID first.",
 		"Known errors:",
 		"HTTP 400: missing start/end",
+		"Search terms: `member`, `invite`",
 		"context `organization` via `ACMECTL_ORG_ID`",
 		"Sets context `organization` from parameter `type` after success.",
 		"Example: `acmectl accounts create-user --set name=alice`",

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -26,6 +26,7 @@ type Override struct {
 	Prerequisites []string                 `yaml:"prerequisites"`
 	KnownErrors   []KnownError             `yaml:"known_errors"`
 	Mutation      string                   `yaml:"mutation"`
+	SearchTerms   []string                 `yaml:"search_terms"`
 	Body          *BodyOverride            `yaml:"body"`
 	Output        *OutputOverride          `yaml:"output"`
 	Context       *ContextOverride         `yaml:"context"`

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -25,6 +25,7 @@ type Override struct {
 	Notes         []string                 `yaml:"notes"`
 	Prerequisites []string                 `yaml:"prerequisites"`
 	KnownErrors   []KnownError             `yaml:"known_errors"`
+	Mutation      string                   `yaml:"mutation"`
 	Body          *BodyOverride            `yaml:"body"`
 	Output        *OutputOverride          `yaml:"output"`
 	Context       *ContextOverride         `yaml:"context"`

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -113,6 +113,7 @@ commands:
       - status: 400
         cause: "missing user name"
     mutation: read
+    search_terms: [spend, cost]
     context:
       set_on_success:
         name: workspace
@@ -190,6 +191,9 @@ commands:
 	}
 	if cu.Mutation != "read" {
 		t.Errorf("mutation = %q, want read", cu.Mutation)
+	}
+	if len(cu.SearchTerms) != 2 || cu.SearchTerms[0] != "spend" || cu.SearchTerms[1] != "cost" {
+		t.Errorf("search terms = %#v", cu.SearchTerms)
 	}
 	if cu.Context == nil || cu.Context.SetOnSuccess == nil || cu.Context.SetOnSuccess.Name != "workspace" || cu.Context.SetOnSuccess.FromParam != "status" {
 		t.Errorf("context = %#v", cu.Context)

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -112,6 +112,7 @@ commands:
     known_errors:
       - status: 400
         cause: "missing user name"
+    mutation: read
     context:
       set_on_success:
         name: workspace
@@ -186,6 +187,9 @@ commands:
 	}
 	if len(cu.KnownErrors) != 1 || cu.KnownErrors[0].Status != 400 || cu.KnownErrors[0].Cause != "missing user name" {
 		t.Errorf("known errors = %#v", cu.KnownErrors)
+	}
+	if cu.Mutation != "read" {
+		t.Errorf("mutation = %q, want read", cu.Mutation)
 	}
 	if cu.Context == nil || cu.Context.SetOnSuccess == nil || cu.Context.SetOnSuccess.Name != "workspace" || cu.Context.SetOnSuccess.FromParam != "status" {
 		t.Errorf("context = %#v", cu.Context)

--- a/pkg/lathe/lathe.go
+++ b/pkg/lathe/lathe.go
@@ -37,7 +37,10 @@ func NewApp(m *config.Manifest) *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if !slices.Contains(runtime.FormatterNames(), format) {
-				return runtime.UsageError(cmd, fmt.Errorf("unsupported output format"))
+				return runtime.UsageError(cmd, runtime.WithUsageDetail(
+					fmt.Errorf("unsupported output format"),
+					"--output accepts: "+strings.Join(runtime.FormatterNames(), ", "),
+				))
 			}
 			return nil
 		},

--- a/pkg/lathe/lathe_test.go
+++ b/pkg/lathe/lathe_test.go
@@ -219,6 +219,9 @@ func TestRunMachineErrorContract(t *testing.T) {
 				if env.Error.Code != tc.wantCode || env.Error.Message == "" || env.Error.Hint == "" {
 					t.Fatalf("error = %#v", env.Error)
 				}
+				if env.Error.Detail != "" {
+					t.Fatalf("detail must stay empty for %s errors, got %q", tc.name, env.Error.Detail)
+				}
 				if tc.status != 0 && (env.Error.HTTP == nil || env.Error.HTTP.Status != tc.status) {
 					t.Fatalf("http context = %#v, want status %d", env.Error.HTTP, tc.status)
 				}

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -232,7 +233,7 @@ func buildCmd(s CommandSpec) *cobra.Command {
 				Wait:        waitPoll,
 			}, output)
 			if err != nil {
-				return err
+				return apiErrorWithKnownDetail(s, err)
 			}
 			if result.DryRun != nil {
 				return writeDryRun(*result.DryRun, cmd.OutOrStdout())
@@ -297,6 +298,23 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		cmd.Long = fmt.Sprintf("%s\n\nRequired scopes: %s", cmd.Short, strings.Join(s.Security.Scopes, ", "))
 	}
 	return cmd
+}
+
+func apiErrorWithKnownDetail(s CommandSpec, err error) error {
+	var he *HTTPError
+	if !errors.As(err, &he) {
+		return err
+	}
+	le := ClassifyError(err)
+	if le.Detail == "" {
+		for _, ke := range s.KnownErrors {
+			if ke.Status == he.Status && ke.Cause != "" {
+				le.Detail = sanitizeErrorDetail(ke.Cause)
+				break
+			}
+		}
+	}
+	return le
 }
 
 func requiredFlagsDetail(cmd *cobra.Command) string {

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -268,6 +268,11 @@ func buildCmd(s CommandSpec) *cobra.Command {
 			setHelp += suffix
 			setStrHelp += suffix
 		}
+		if len(s.RequestBody.SetOnlyFields) > 0 {
+			suffix := fmt.Sprintf(" (no typed flags for body fields: %s)", strings.Join(s.RequestBody.SetOnlyFields, ", "))
+			setHelp += suffix
+			setStrHelp += suffix
+		}
 		cmd.Flags().StringVarP(&bodyFile, bodyFileFlag, "f", "", fileHelp)
 		cmd.Flags().StringArrayVar(&bodySets, bodySetFlag, nil, setHelp)
 		cmd.Flags().StringArrayVar(&bodyStringSets, bodyStringSetFlag, nil, setStrHelp)

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -147,14 +148,14 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		Args:    UsageArgs(cobra.NoArgs),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmd.ValidateRequiredFlags(); err != nil {
-				return UsageError(cmd, err)
+				return UsageError(cmd, WithUsageDetail(err, requiredFlagsDetail(cmd)))
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if _, ok := formatters[format]; !ok {
-				return UsageError(cmd, fmt.Errorf("unsupported output format"))
+				return UsageError(cmd, WithUsageDetail(fmt.Errorf("unsupported output format"), outputFormatDetail()))
 			}
 			if liveStream && format != "table" {
 				return UsageError(cmd, fmt.Errorf("live stream output does not support -o %s", format))
@@ -296,6 +297,26 @@ func buildCmd(s CommandSpec) *cobra.Command {
 		cmd.Long = fmt.Sprintf("%s\n\nRequired scopes: %s", cmd.Short, strings.Join(s.Security.Scopes, ", "))
 	}
 	return cmd
+}
+
+func requiredFlagsDetail(cmd *cobra.Command) string {
+	missing := make([]string, 0)
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			return
+		}
+		if slices.Contains(f.Annotations[cobra.BashCompOneRequiredFlag], "true") {
+			missing = append(missing, "--"+f.Name)
+		}
+	})
+	if len(missing) == 0 {
+		return ""
+	}
+	return "missing required: " + strings.Join(missing, ", ")
+}
+
+func outputFormatDetail() string {
+	return "--output accepts: " + strings.Join(FormatterNames(), ", ")
 }
 
 func controlFlagName(cmd *cobra.Command, name string) string {
@@ -543,7 +564,7 @@ func validateRequiredParams(params []ParamSpec, hasRequestBody bool, changed map
 			continue
 		}
 		if !changed[boundParamKey(p)] {
-			return fmt.Errorf("required flag(s) \"%s\" not set", p.Flag)
+			return WithUsageDetail(fmt.Errorf("required flag(s) \"%s\" not set", p.Flag), "missing required: --"+p.Flag)
 		}
 	}
 	return nil
@@ -712,7 +733,7 @@ func validateRequiredVariableParams(s CommandSpec, body any) error {
 	}
 	raw, ok := body.([]byte)
 	if !ok || len(raw) == 0 {
-		return fmt.Errorf("required body field missing: %s", required[0].Name)
+		return missingBodyFieldError(required[0].Name)
 	}
 	var doc any
 	if err := json.Unmarshal(raw, &doc); err != nil {
@@ -721,7 +742,7 @@ func validateRequiredVariableParams(s CommandSpec, body any) error {
 	for _, p := range required {
 		v, ok := getNestedPath(doc, joinBodyPath(s.RequestBody.MergePath, p.Name))
 		if !ok || v == nil {
-			return fmt.Errorf("required body field missing: %s", p.Name)
+			return missingBodyFieldError(p.Name)
 		}
 	}
 	return nil
@@ -750,10 +771,14 @@ func validateRequiredBodyParams(s CommandSpec, body any) error {
 	}
 	for _, p := range required {
 		if _, ok := doc[p.Name]; !ok {
-			return fmt.Errorf("required body field missing: %s", p.Name)
+			return missingBodyFieldError(p.Name)
 		}
 	}
 	return nil
+}
+
+func missingBodyFieldError(name string) error {
+	return WithUsageDetail(fmt.Errorf("required body field missing: %s", name), "missing required: "+name)
 }
 
 func shortcutName(use string, target string) (string, error) {

--- a/pkg/runtime/build.go
+++ b/pkg/runtime/build.go
@@ -781,7 +781,8 @@ func validateRequiredBodyParams(s CommandSpec, body any) error {
 			required = append(required, p)
 		}
 	}
-	if len(required) == 0 {
+	setOnlyRequired := requiredSetOnlyFields(s)
+	if len(required) == 0 && len(setOnlyRequired) == 0 {
 		return nil
 	}
 	raw, _, err := encodeRequestBody(body)
@@ -797,7 +798,29 @@ func validateRequiredBodyParams(s CommandSpec, body any) error {
 			return missingBodyFieldError(p.Name)
 		}
 	}
+	for _, name := range setOnlyRequired {
+		if _, ok := doc[name]; !ok {
+			return missingBodyFieldError(name)
+		}
+	}
 	return nil
+}
+
+func requiredSetOnlyFields(s CommandSpec) []string {
+	if s.RequestBody == nil || len(s.RequestBody.SetOnlyFields) == 0 || s.RequestBody.Schema == nil {
+		return nil
+	}
+	setOnly := make(map[string]bool, len(s.RequestBody.SetOnlyFields))
+	for _, name := range s.RequestBody.SetOnlyFields {
+		setOnly[name] = true
+	}
+	out := make([]string, 0)
+	for _, name := range s.RequestBody.Schema.Required {
+		if setOnly[name] {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func missingBodyFieldError(name string) error {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1690,3 +1690,64 @@ func TestBuild_APIErrorKnownErrorFallbackDetail(t *testing.T) {
 		})
 	}
 }
+
+func TestBuild_SetOnlyBodyFieldsHelpAndCoexistence(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	var rawBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	specs := []CommandSpec{{
+		Group:   "Keys",
+		Use:     "create",
+		Method:  "POST",
+		PathTpl: "/keys",
+		Params: []ParamSpec{
+			{Name: "name", Flag: "name", In: InBody, GoType: "string", Required: true, Help: "name (body, required)"},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json", SetOnlyFields: []string{"limits"}},
+		Security:    &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	mustBuild(t, root, "demo", specs)
+
+	cmd, _, err := root.Find([]string{"demo", "keys", "create"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, flag := range []string{"set", "set-str"} {
+		usage := cmd.Flags().Lookup(flag).Usage
+		if !strings.Contains(usage, "limits") {
+			t.Fatalf("--%s help missing set-only field note: %q", flag, usage)
+		}
+	}
+
+	root.SetArgs([]string{
+		"--hostname", srv.URL,
+		"demo", "keys", "create",
+		"--name", "demo",
+		"--set", "limits.maxBudgetUsd=3",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rawBody, &got); err != nil {
+		t.Fatalf("invalid request JSON %q: %v", string(rawBody), err)
+	}
+	want := map[string]any{
+		"name":   "demo",
+		"limits": map[string]any{"maxBudgetUsd": float64(3)},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("body = %#v, want %#v", got, want)
+	}
+}

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime"
 	"net/http"
@@ -1476,4 +1477,140 @@ func isRequiredFlag(annotations map[string][]string) bool {
 		}
 	}
 	return false
+}
+
+func TestBuild_EnumUsageErrorSafeDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	specs := []CommandSpec{{
+		Group:   "Usage",
+		Use:     "summary",
+		Method:  "GET",
+		PathTpl: "/usage",
+		Params: []ParamSpec{
+			{Name: "range", Flag: "range", In: InQuery, GoType: "string", Enum: []string{"7", "30"}},
+		},
+		Security: &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	mustBuild(t, root, "demo", specs)
+	root.SetArgs([]string{"demo", "usage", "summary", "--range", "14"})
+
+	err := root.Execute()
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	if le.Code != CodeUsage {
+		t.Fatalf("code = %q, want %q", le.Code, CodeUsage)
+	}
+	if le.Detail != "--range accepts: 7, 30" {
+		t.Fatalf("detail = %q", le.Detail)
+	}
+	if strings.Contains(le.Detail, "14") {
+		t.Fatalf("detail echoed user input: %q", le.Detail)
+	}
+}
+
+func TestBuild_RequiredFlagUsageErrorDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	specs := []CommandSpec{{
+		Group:   "Keys",
+		Use:     "get",
+		Method:  "GET",
+		PathTpl: "/keys/{id}",
+		Params: []ParamSpec{
+			{Name: "id", Flag: "id", In: InPath, GoType: "string", Required: true},
+		},
+		Security: &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	mustBuild(t, root, "demo", specs)
+	root.SetArgs([]string{"demo", "keys", "get"})
+
+	err := root.Execute()
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	if le.Detail != "missing required: --id" {
+		t.Fatalf("detail = %q", le.Detail)
+	}
+}
+
+func TestBuild_MissingBodyFieldUsageErrorDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	specs := []CommandSpec{{
+		Group:   "Keys",
+		Use:     "create",
+		Method:  "POST",
+		PathTpl: "/keys",
+		Params: []ParamSpec{
+			{Name: "name", Flag: "name", In: InVariable, GoType: "string", Required: true},
+		},
+		RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+		Security:    &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	mustBuild(t, root, "demo", specs)
+	root.SetArgs([]string{"demo", "keys", "create", "--set", "other=1"})
+
+	err := root.Execute()
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	if le.Detail != "missing required: name" {
+		t.Fatalf("detail = %q", le.Detail)
+	}
+}
+
+func TestBuild_UnsupportedOutputFormatDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	specs := []CommandSpec{{
+		Group:    "Usage",
+		Use:      "summary",
+		Method:   "GET",
+		PathTpl:  "/usage",
+		Security: &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "table", "")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	mustBuild(t, root, "demo", specs)
+	root.SetArgs([]string{"-o", "bogus-format", "demo", "usage", "summary"})
+
+	err := root.Execute()
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	want := "--output accepts: " + strings.Join(FormatterNames(), ", ")
+	if le.Detail != want {
+		t.Fatalf("detail = %q, want %q", le.Detail, want)
+	}
+	if strings.Contains(le.Detail, "bogus-format") {
+		t.Fatalf("detail echoed user input: %q", le.Detail)
+	}
 }

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1614,3 +1614,79 @@ func TestBuild_UnsupportedOutputFormatDetail(t *testing.T) {
 		t.Fatalf("detail echoed user input: %q", le.Detail)
 	}
 }
+
+func TestBuild_APIErrorKnownErrorFallbackDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	cases := []struct {
+		name        string
+		contentType string
+		body        string
+		known       []KnownError
+		wantDetail  string
+	}{
+		{
+			name:        "declared message wins over known error",
+			contentType: "application/json",
+			body:        `{"message":"key was revoked upstream"}`,
+			known:       []KnownError{{Status: 403, Cause: "the API key is revoked"}},
+			wantDetail:  "key was revoked upstream",
+		},
+		{
+			name:        "known error fallback for non-json body",
+			contentType: "text/plain",
+			body:        "upstream-secret",
+			known:       []KnownError{{Status: 403, Cause: "the API key is revoked"}},
+			wantDetail:  "the API key is revoked",
+		},
+		{
+			name:        "status mismatch keeps detail empty",
+			contentType: "text/plain",
+			body:        "upstream-secret",
+			known:       []KnownError{{Status: 404, Cause: "no such key"}},
+			wantDetail:  "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			specs := []CommandSpec{{
+				Group:       "Keys",
+				Use:         "reveal",
+				Method:      "GET",
+				PathTpl:     "/keys/reveal",
+				KnownErrors: tc.known,
+				Security:    &SecurityHint{Public: true},
+			}}
+			root := newRootWithModuleGroup()
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "table", "")
+			root.SilenceErrors = true
+			root.SilenceUsage = true
+			mustBuild(t, root, "demo", specs)
+			root.SetArgs([]string{"--hostname", srv.URL, "demo", "keys", "reveal"})
+
+			err := root.Execute()
+			var le *LatheError
+			if !errors.As(err, &le) {
+				t.Fatalf("expected LatheError, got %v", err)
+			}
+			if le.Code != CodeAPIError || le.Message != "API request failed" {
+				t.Fatalf("error = %#v", le)
+			}
+			if le.Detail != tc.wantDetail {
+				t.Fatalf("detail = %q, want %q", le.Detail, tc.wantDetail)
+			}
+			if strings.Contains(le.Detail, "upstream-secret") {
+				t.Fatalf("detail leaked raw body: %q", le.Detail)
+			}
+		})
+	}
+}

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1751,3 +1751,52 @@ func TestBuild_SetOnlyBodyFieldsHelpAndCoexistence(t *testing.T) {
 		t.Fatalf("body = %#v, want %#v", got, want)
 	}
 }
+
+func TestBuild_RequiredSetOnlyBodyFieldValidatedLocally(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	specs := []CommandSpec{{
+		Group:   "Keys",
+		Use:     "create",
+		Method:  "POST",
+		PathTpl: "/keys",
+		Params: []ParamSpec{
+			{Name: "name", Flag: "name", In: InBody, GoType: "string", Required: true, Help: "name (body, required)"},
+		},
+		RequestBody: &RequestBody{
+			Required:      true,
+			MediaType:     "application/json",
+			Schema:        &SchemaSpec{Type: "object", Required: []string{"name", "limits"}, Properties: map[string]*SchemaSpec{"name": {Type: "string"}, "limits": {Type: "object"}}},
+			SetOnlyFields: []string{"limits"},
+		},
+		Security: &SecurityHint{Public: true},
+	}}
+	root := newRootWithModuleGroup()
+	root.PersistentFlags().String("hostname", "", "")
+	root.PersistentFlags().StringP("output", "o", "raw", "")
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	mustBuild(t, root, "demo", specs)
+
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "keys", "create", "--name", "demo"})
+	err := root.Execute()
+	var le *LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError for missing required set-only field, got %v", err)
+	}
+	if le.Code != CodeUsage || le.Detail != "missing required: limits" {
+		t.Fatalf("error = %#v", le)
+	}
+
+	root.SetArgs([]string{"--hostname", srv.URL, "demo", "keys", "create", "--name", "demo", "--set", "limits.rpm=3"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute with --set limits: %v", err)
+	}
+}

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lathe-cli/lathe/pkg/config"
 )
 
-const CatalogSchemaVersion = 21
+const CatalogSchemaVersion = 22
 const DefaultSearchLimit = 20
 
 const (
@@ -95,6 +95,7 @@ type CatalogCommand struct {
 	Prerequisites []string           `json:"prerequisites,omitempty"`
 	KnownErrors   []KnownError       `json:"known_errors,omitempty"`
 	SetsContext   *CatalogContextSet `json:"sets_context,omitempty"`
+	SearchTerms   []string           `json:"search_terms,omitempty"`
 }
 
 type CatalogWorkflow struct {
@@ -444,6 +445,7 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 		Notes:         append([]string(nil), spec.Notes...),
 		Prerequisites: append([]string(nil), spec.Prerequisites...),
 		KnownErrors:   append([]KnownError(nil), spec.KnownErrors...),
+		SearchTerms:   append([]string(nil), spec.SearchTerms...),
 	}
 	if spec.SetContext != nil {
 		cmd.SetsContext = &CatalogContextSet{Name: spec.SetContext.Name, FromParam: spec.SetContext.Param}

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lathe-cli/lathe/pkg/config"
 )
 
-const CatalogSchemaVersion = 20
+const CatalogSchemaVersion = 21
 const DefaultSearchLimit = 20
 
 const (

--- a/pkg/runtime/catalog.go
+++ b/pkg/runtime/catalog.go
@@ -11,7 +11,7 @@ import (
 	"github.com/lathe-cli/lathe/pkg/config"
 )
 
-const CatalogSchemaVersion = 22
+const CatalogSchemaVersion = 23
 const DefaultSearchLimit = 20
 
 const (
@@ -165,6 +165,7 @@ type CatalogBody struct {
 	RuntimeSchema *CatalogRuntimeSchema `json:"runtime_schema,omitempty"`
 	Template      string                `json:"template,omitempty"`
 	MergePath     string                `json:"merge_path,omitempty"`
+	SetOnlyFields []string              `json:"set_only_fields,omitempty"`
 }
 
 type CatalogRuntimeSchema struct {
@@ -452,11 +453,12 @@ func catalogCommand(service string, spec CommandSpec, path []string) CatalogComm
 	}
 	if spec.RequestBody != nil {
 		cmd.Body = &CatalogBody{
-			Required:  spec.RequestBody.Required,
-			MediaType: spec.RequestBody.MediaType,
-			Schema:    spec.RequestBody.Schema,
-			Template:  spec.RequestBody.Template,
-			MergePath: spec.RequestBody.MergePath,
+			Required:      spec.RequestBody.Required,
+			MediaType:     spec.RequestBody.MediaType,
+			Schema:        spec.RequestBody.Schema,
+			Template:      spec.RequestBody.Template,
+			MergePath:     spec.RequestBody.MergePath,
+			SetOnlyFields: append([]string(nil), spec.RequestBody.SetOnlyFields...),
 		}
 		if binding := spec.RequestBody.RuntimeSchema; binding != nil {
 			cmd.Body.RuntimeSchema = &CatalogRuntimeSchema{

--- a/pkg/runtime/catalog_mutation.go
+++ b/pkg/runtime/catalog_mutation.go
@@ -6,14 +6,19 @@ import (
 )
 
 func catalogMutation(spec CommandSpec) string {
+	if spec.Mutation == MutationRead || spec.Mutation == MutationWrite {
+		return spec.Mutation
+	}
 	if kind := graphqlTemplateMutation(spec); kind != "" {
 		return kind
 	}
 	switch strings.ToUpper(spec.Method) {
-	case "GET", "HEAD":
+	case "GET", "HEAD", "OPTIONS", "TRACE":
 		return MutationRead
-	default:
+	case "":
 		return MutationUnknown
+	default:
+		return MutationWrite
 	}
 }
 

--- a/pkg/runtime/catalog_mutation_test.go
+++ b/pkg/runtime/catalog_mutation_test.go
@@ -3,17 +3,38 @@ package runtime
 import "testing"
 
 func TestCatalogMutation_HTTPMethods(t *testing.T) {
-	if got := catalogMutation(CommandSpec{Method: "GET", PathTpl: "/users"}); got != MutationRead {
-		t.Fatalf("GET = %q", got)
+	for _, method := range []string{"GET", "HEAD", "OPTIONS", "TRACE"} {
+		if got := catalogMutation(CommandSpec{Method: method, PathTpl: "/users"}); got != MutationRead {
+			t.Fatalf("%s = %q", method, got)
+		}
 	}
-	if got := catalogMutation(CommandSpec{Method: "HEAD", PathTpl: "/users"}); got != MutationRead {
-		t.Fatalf("HEAD = %q", got)
+	for _, method := range []string{"POST", "PUT", "PATCH", "DELETE"} {
+		if got := catalogMutation(CommandSpec{Method: method, PathTpl: "/users"}); got != MutationWrite {
+			t.Fatalf("%s = %q", method, got)
+		}
 	}
-	if got := catalogMutation(CommandSpec{Method: "POST", PathTpl: "/users"}); got != MutationUnknown {
-		t.Fatalf("POST without GraphQL = %q", got)
+	if got := catalogMutation(CommandSpec{PathTpl: "/users"}); got != MutationUnknown {
+		t.Fatalf("empty method = %q", got)
 	}
-	if got := catalogMutation(CommandSpec{Method: "DELETE", PathTpl: "/users/{id}"}); got != MutationUnknown {
-		t.Fatalf("DELETE = %q", got)
+}
+
+func TestCatalogMutation_ExplicitOverride(t *testing.T) {
+	if got := catalogMutation(CommandSpec{Method: "POST", PathTpl: "/reports/query", Mutation: MutationRead}); got != MutationRead {
+		t.Fatalf("POST override read = %q", got)
+	}
+	if got := catalogMutation(CommandSpec{Method: "GET", PathTpl: "/trigger", Mutation: MutationWrite}); got != MutationWrite {
+		t.Fatalf("GET override write = %q", got)
+	}
+	overridden := catalogMutation(CommandSpec{
+		Method:  "POST",
+		PathTpl: "/graphql",
+		RequestBody: &RequestBody{
+			Template: `{"query":"mutation CreateApp { createApp { id } }","variables":{}}`,
+		},
+		Mutation: MutationRead,
+	})
+	if overridden != MutationRead {
+		t.Fatalf("override must beat graphql template = %q", overridden)
 	}
 }
 
@@ -63,7 +84,7 @@ func TestCatalogMutation_GraphQLTemplate(t *testing.T) {
 	}
 }
 
-func TestCatalogMutation_NonGraphQLTemplateStaysUnknown(t *testing.T) {
+func TestCatalogMutation_NonGraphQLTemplateFallsBackToMethod(t *testing.T) {
 	got := catalogMutation(CommandSpec{
 		Method:  "POST",
 		PathTpl: "/users",
@@ -71,7 +92,7 @@ func TestCatalogMutation_NonGraphQLTemplateStaysUnknown(t *testing.T) {
 			Template: `{"name":"alice"}`,
 		},
 	})
-	if got != MutationUnknown {
+	if got != MutationWrite {
 		t.Fatalf("rest template = %q", got)
 	}
 }
@@ -85,12 +106,20 @@ func TestCatalogWorkflowMutation_HeaviestStep(t *testing.T) {
 		t.Fatalf("all GET = %q", read)
 	}
 
-	unknown := catalogWorkflowMutation(WorkflowSpec{Steps: []WorkflowStepSpec{
+	mixed := catalogWorkflowMutation(WorkflowSpec{Steps: []WorkflowStepSpec{
 		{Operation: CommandSpec{Method: "GET", PathTpl: "/health"}},
 		{Operation: CommandSpec{Method: "POST", PathTpl: "/tenants"}},
 	}})
-	if unknown != MutationUnknown {
-		t.Fatalf("GET+POST = %q", unknown)
+	if mixed != MutationWrite {
+		t.Fatalf("GET+POST = %q", mixed)
+	}
+
+	undecidable := catalogWorkflowMutation(WorkflowSpec{Steps: []WorkflowStepSpec{
+		{Operation: CommandSpec{Method: "GET", PathTpl: "/health"}},
+		{Operation: CommandSpec{PathTpl: "/tenants"}},
+	}})
+	if undecidable != MutationUnknown {
+		t.Fatalf("GET+empty method = %q", undecidable)
 	}
 
 	write := catalogWorkflowMutation(WorkflowSpec{Steps: []WorkflowStepSpec{

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -68,6 +68,7 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 			Notes:         []string{"Use the canonical user ID."},
 			Prerequisites: []string{"List users before fetching details."},
 			KnownErrors:   []KnownError{{Status: 400, Cause: "missing id"}},
+			SearchTerms:   []string{"account", "profile"},
 		},
 	})
 
@@ -161,6 +162,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if !reflect.DeepEqual(cmd.KnownErrors, []KnownError{{Status: 400, Cause: "missing id"}}) {
 		t.Fatalf("known errors = %#v", cmd.KnownErrors)
+	}
+	if !reflect.DeepEqual(cmd.SearchTerms, []string{"account", "profile"}) {
+		t.Fatalf("search terms = %#v", cmd.SearchTerms)
 	}
 
 	raw, err := json.Marshal(catalog)

--- a/pkg/runtime/catalog_test.go
+++ b/pkg/runtime/catalog_test.go
@@ -48,6 +48,7 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 					ResponsePath: "input_schema",
 					Params:       map[string]string{"id": "${params.user_id}"},
 				},
+				SetOnlyFields: []string{"limits"},
 			},
 			Output: OutputHints{
 				ListPath:       "data.items",
@@ -165,6 +166,9 @@ func TestBuildCatalog_UsesAttachedSpec(t *testing.T) {
 	}
 	if !reflect.DeepEqual(cmd.SearchTerms, []string{"account", "profile"}) {
 		t.Fatalf("search terms = %#v", cmd.SearchTerms)
+	}
+	if !reflect.DeepEqual(cmd.Body.SetOnlyFields, []string{"limits"}) {
+		t.Fatalf("set-only fields = %#v", cmd.Body.SetOnlyFields)
 	}
 
 	raw, err := json.Marshal(catalog)

--- a/pkg/runtime/client.go
+++ b/pkg/runtime/client.go
@@ -283,10 +283,11 @@ func doRawFullOnce(req *http.Request, opts ClientOptions, consume responseConsum
 			return nil, newAPIError(fmt.Errorf("read response: %w", err), resp.StatusCode)
 		}
 		return nil, &HTTPError{
-			Method: method,
-			URL:    redactDebugURL(req.URL, opts.sensitiveQueryParams),
-			Status: resp.StatusCode,
-			Body:   data,
+			Method:      method,
+			URL:         redactDebugURL(req.URL, opts.sensitiveQueryParams),
+			Status:      resp.StatusCode,
+			ContentType: resp.Header.Get("Content-Type"),
+			Body:        data,
 		}
 	}
 	if consume != nil {
@@ -330,10 +331,11 @@ func DoRaw(ctx context.Context, hostname, method, path string, body any, opts Cl
 }
 
 type HTTPError struct {
-	Method string
-	URL    string
-	Status int
-	Body   []byte
+	Method      string
+	URL         string
+	Status      int
+	ContentType string
+	Body        []byte
 }
 
 func (e *HTTPError) Error() string {

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -140,7 +140,61 @@ func newAPIError(cause error, status int) *LatheError {
 	if status != 0 {
 		err.HTTP = &ErrorHTTPContext{Status: status}
 	}
+	var he *HTTPError
+	if errors.As(cause, &he) {
+		err.Detail = declaredServerMessage(he)
+	}
 	return err
+}
+
+const maxServerErrorBodyBytes = 32 << 10
+
+func declaredServerMessage(he *HTTPError) string {
+	if he == nil || len(he.Body) == 0 || len(he.Body) > maxServerErrorBodyBytes {
+		return ""
+	}
+	if !isJSONErrorMediaType(he.ContentType) {
+		return ""
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(he.Body, &doc); err != nil {
+		return ""
+	}
+	if s := jsonStringField(doc["message"]); s != "" {
+		return sanitizeErrorDetail(s)
+	}
+	if raw, ok := doc["error"]; ok {
+		if s := jsonStringField(raw); s != "" {
+			return sanitizeErrorDetail(s)
+		}
+		var nested map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &nested); err == nil {
+			if s := jsonStringField(nested["message"]); s != "" {
+				return sanitizeErrorDetail(s)
+			}
+		}
+	}
+	if s := jsonStringField(doc["detail"]); s != "" {
+		return sanitizeErrorDetail(s)
+	}
+	return ""
+}
+
+func isJSONErrorMediaType(contentType string) bool {
+	mt, _, _ := strings.Cut(strings.ToLower(strings.TrimSpace(contentType)), ";")
+	mt = strings.TrimSpace(mt)
+	return mt == "application/json" || strings.HasSuffix(mt, "+json")
+}
+
+func jsonStringField(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(s)
 }
 
 func ClassifyError(err error) *LatheError {

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -35,6 +36,7 @@ type ErrorHTTPContext struct {
 type LatheError struct {
 	Code     string            `json:"code" yaml:"code"`
 	Message  string            `json:"message" yaml:"message"`
+	Detail   string            `json:"detail,omitempty" yaml:"detail,omitempty"`
 	Hint     string            `json:"hint" yaml:"hint"`
 	HTTP     *ErrorHTTPContext `json:"http,omitempty" yaml:"http,omitempty"`
 	ExitCode int               `json:"-" yaml:"-"`
@@ -71,7 +73,47 @@ func UsageError(cmd *cobra.Command, cause error) *LatheError {
 	if cmd != nil && cmd.CommandPath() != "" {
 		hint = fmt.Sprintf("run `%s --help` and correct the arguments", cmd.CommandPath())
 	}
-	return NewError(CodeUsage, ExitUsage, "invalid command usage", hint, cause)
+	le := NewError(CodeUsage, ExitUsage, "invalid command usage", hint, cause)
+	var de *usageDetailError
+	if errors.As(cause, &de) {
+		le.Detail = de.detail
+	}
+	return le
+}
+
+const maxErrorDetailRunes = 240
+
+type usageDetailError struct {
+	cause  error
+	detail string
+}
+
+func (e *usageDetailError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *usageDetailError) Unwrap() error {
+	return e.cause
+}
+
+func WithUsageDetail(cause error, detail string) error {
+	return &usageDetailError{cause: cause, detail: sanitizeErrorDetail(detail)}
+}
+
+func sanitizeErrorDetail(detail string) string {
+	var b strings.Builder
+	for _, r := range detail {
+		if r < 0x20 || r == 0x7f {
+			r = ' '
+		}
+		b.WriteRune(r)
+	}
+	out := strings.Join(strings.Fields(b.String()), " ")
+	runes := []rune(out)
+	if len(runes) > maxErrorDetailRunes {
+		out = strings.TrimSpace(string(runes[:maxErrorDetailRunes-1])) + "…"
+	}
+	return out
 }
 
 func UsageArgs(validate cobra.PositionalArgs) cobra.PositionalArgs {
@@ -165,6 +207,9 @@ func FormatError(err error, format string, w io.Writer) int {
 		_ = enc.Close()
 	default:
 		fmt.Fprintln(w, "Error:", le.Message)
+		if le.Detail != "" {
+			fmt.Fprintln(w, "Detail:", le.Detail)
+		}
 		fmt.Fprintln(w, "Hint:", le.Hint)
 	}
 	return le.ExitCode

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -103,7 +104,7 @@ func WithUsageDetail(cause error, detail string) error {
 func sanitizeErrorDetail(detail string) string {
 	var b strings.Builder
 	for _, r := range detail {
-		if r < 0x20 || r == 0x7f {
+		if !unicode.IsGraphic(r) {
 			r = ' '
 		}
 		b.WriteRune(r)

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -164,6 +164,10 @@ func TestWithUsageDetailSanitizesAndBounds(t *testing.T) {
 	if le.Detail != "a b c d e" {
 		t.Fatalf("sanitized detail = %q", le.Detail)
 	}
+	hostile := UsageError(nil, WithUsageDetail(errors.New("x"), "a\u009b31mb c\u009d0;d e\u202ef"))
+	if hostile.Detail != "a 31mb c 0;d e f" {
+		t.Fatalf("hostile detail = %q, C1/bidi runes must be stripped", hostile.Detail)
+	}
 	long := strings.Repeat("v", 500)
 	bounded := UsageError(nil, WithUsageDetail(errors.New("x"), long))
 	if n := len([]rune(bounded.Detail)); n > 240 {
@@ -242,14 +246,14 @@ func TestClassifyError_DeclaredServerMessageDetail(t *testing.T) {
 }
 
 func TestClassifyError_ServerMessageSanitizedAndBounded(t *testing.T) {
-	msg := "line1\nline2\t\x07" + strings.Repeat("x", 400)
+	msg := "line1\nline2\t\x07\u009b31m\u009d0;\u202e" + strings.Repeat("x", 400)
 	body, err := json.Marshal(map[string]string{"message": msg})
 	if err != nil {
 		t.Fatal(err)
 	}
 	he := &HTTPError{Status: 500, ContentType: "application/json", Body: body}
 	le := ClassifyError(he)
-	if strings.ContainsAny(le.Detail, "\n\t\x07") {
+	if strings.ContainsAny(le.Detail, "\n\t\x07\u009b\u009d\u202e") {
 		t.Fatalf("detail not sanitized: %q", le.Detail)
 	}
 	if n := len([]rune(le.Detail)); n > 240 {

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -209,6 +209,62 @@ func TestFormatError_JSONDetail(t *testing.T) {
 	}
 }
 
+func TestClassifyError_DeclaredServerMessageDetail(t *testing.T) {
+	cases := []struct {
+		name        string
+		contentType string
+		body        string
+		want        string
+	}{
+		{"message field", "application/json", `{"message":"api key revoked"}`, "api key revoked"},
+		{"message wins over error", "application/json", `{"message":"m","error":"e"}`, "m"},
+		{"error string", "application/json", `{"error":"quota exceeded"}`, "quota exceeded"},
+		{"nested error message", "application/json; charset=utf-8", `{"error":{"message":"nested cause"}}`, "nested cause"},
+		{"detail field", "application/problem+json", `{"detail":"missing scope"}`, "missing scope"},
+		{"non-json content type", "text/plain", `{"message":"nope"}`, ""},
+		{"missing content type", "", `{"message":"nope"}`, ""},
+		{"invalid json", "application/json", `{"message":`, ""},
+		{"non-string message", "application/json", `{"message":{"deep":"x"}}`, ""},
+		{"blank message", "application/json", `{"message":"   "}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			he := &HTTPError{Method: "GET", URL: "/private", Status: 403, ContentType: tc.contentType, Body: []byte(tc.body)}
+			le := ClassifyError(he)
+			if le.Message != "API request failed" {
+				t.Fatalf("message = %q", le.Message)
+			}
+			if le.Detail != tc.want {
+				t.Fatalf("detail = %q, want %q", le.Detail, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError_ServerMessageSanitizedAndBounded(t *testing.T) {
+	msg := "line1\nline2\t\x07" + strings.Repeat("x", 400)
+	body, err := json.Marshal(map[string]string{"message": msg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	he := &HTTPError{Status: 500, ContentType: "application/json", Body: body}
+	le := ClassifyError(he)
+	if strings.ContainsAny(le.Detail, "\n\t\x07") {
+		t.Fatalf("detail not sanitized: %q", le.Detail)
+	}
+	if n := len([]rune(le.Detail)); n > 240 {
+		t.Fatalf("detail rune length = %d, want <= 240", n)
+	}
+}
+
+func TestClassifyError_OversizedErrorBodyIgnored(t *testing.T) {
+	body := []byte(`{"message":"` + strings.Repeat("a", 33*1024) + `"}`)
+	he := &HTTPError{Status: 500, ContentType: "application/json", Body: body}
+	if le := ClassifyError(he); le.Detail != "" {
+		t.Fatalf("oversized body must not produce detail, got %q", le.Detail)
+	}
+}
+
 type testSilentExitError struct{}
 
 func (testSilentExitError) Error() string {

--- a/pkg/runtime/errors_test.go
+++ b/pkg/runtime/errors_test.go
@@ -144,6 +144,71 @@ func TestClassifyError_Canceled(t *testing.T) {
 	}
 }
 
+func TestUsageErrorLiftsSafeDetail(t *testing.T) {
+	cause := fmt.Errorf("invalid value %q for --range: must be one of 7, 30", "14")
+	le := UsageError(nil, WithUsageDetail(cause, "--range accepts: 7, 30"))
+	if le.Detail != "--range accepts: 7, 30" {
+		t.Fatalf("detail = %q", le.Detail)
+	}
+	wrapped := UsageError(nil, fmt.Errorf("outer: %w", WithUsageDetail(cause, "--range accepts: 7, 30")))
+	if wrapped.Detail != "--range accepts: 7, 30" {
+		t.Fatalf("wrapped detail = %q", wrapped.Detail)
+	}
+	if plain := UsageError(nil, cause); plain.Detail != "" {
+		t.Fatalf("plain detail = %q, want empty", plain.Detail)
+	}
+}
+
+func TestWithUsageDetailSanitizesAndBounds(t *testing.T) {
+	le := UsageError(nil, WithUsageDetail(errors.New("x"), "a\nb\tc\x07d  e"))
+	if le.Detail != "a b c d e" {
+		t.Fatalf("sanitized detail = %q", le.Detail)
+	}
+	long := strings.Repeat("v", 500)
+	bounded := UsageError(nil, WithUsageDetail(errors.New("x"), long))
+	if n := len([]rune(bounded.Detail)); n > 240 {
+		t.Fatalf("detail rune length = %d, want <= 240", n)
+	}
+	if !strings.HasSuffix(bounded.Detail, "…") {
+		t.Fatalf("bounded detail missing truncation marker: %q", bounded.Detail)
+	}
+}
+
+func TestFormatError_PlainIncludesDetail(t *testing.T) {
+	var buf bytes.Buffer
+	le := UsageError(nil, WithUsageDetail(errors.New("boom"), "--range accepts: 7, 30"))
+	if code := FormatError(le, "table", &buf); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	want := "Error: invalid command usage\nDetail: --range accepts: 7, 30\nHint: run the command with --help and correct the arguments\n"
+	if buf.String() != want {
+		t.Fatalf("plain output = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestFormatError_JSONDetail(t *testing.T) {
+	var buf bytes.Buffer
+	le := UsageError(nil, WithUsageDetail(errors.New("boom"), "missing required: name"))
+	if code := FormatError(le, "json", &buf); code != ExitUsage {
+		t.Fatalf("exit = %d, want %d", code, ExitUsage)
+	}
+	var env errorEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, buf.String())
+	}
+	if env.Error.Detail != "missing required: name" {
+		t.Fatalf("json detail = %q", env.Error.Detail)
+	}
+
+	buf.Reset()
+	if code := FormatError(errors.New("oops"), "json", &buf); code != ExitGeneral {
+		t.Fatalf("exit = %d, want %d", code, ExitGeneral)
+	}
+	if strings.Contains(buf.String(), "detail") {
+		t.Fatalf("empty detail must be omitted from envelope: %s", buf.String())
+	}
+}
+
 type testSilentExitError struct{}
 
 func (testSilentExitError) Error() string {

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -353,7 +353,7 @@ func validateRequiredOperationParams(s CommandSpec, input OperationInput) error 
 			continue
 		}
 		if !operationChanged(input, p) {
-			return fmt.Errorf("required param %q missing", p.Name)
+			return WithUsageDetail(fmt.Errorf("required param %q missing", p.Name), "missing required: --"+p.Flag)
 		}
 	}
 	return nil
@@ -371,16 +371,26 @@ func validateOperationEnums(s CommandSpec, input OperationInput) error {
 		if len(p.Enum) > 0 {
 			raw := operationStringValue(v)
 			if !enumContains(p.Enum, raw) {
-				return fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", "))
+				return WithUsageDetail(
+					fmt.Errorf("invalid value %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.Enum, ", ")),
+					enumDetail(p.Flag, p.Enum),
+				)
 			}
 		}
 		for _, raw := range operationStringValues(v) {
 			if len(p.ItemEnum) > 0 && !enumContains(p.ItemEnum, raw) {
-				return fmt.Errorf("invalid item %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.ItemEnum, ", "))
+				return WithUsageDetail(
+					fmt.Errorf("invalid item %q for --%s: must be one of %s", raw, p.Flag, strings.Join(p.ItemEnum, ", ")),
+					enumDetail(p.Flag, p.ItemEnum),
+				)
 			}
 		}
 	}
 	return nil
+}
+
+func enumDetail(flag string, values []string) string {
+	return fmt.Sprintf("--%s accepts: %s", flag, strings.Join(values, ", "))
 }
 
 func enumContains(values []string, target string) bool {

--- a/pkg/runtime/search.go
+++ b/pkg/runtime/search.go
@@ -96,6 +96,9 @@ func newSearchView(cmd CatalogCommand) searchView {
 	}
 	view.identity = appendSearchField(view.identity, strings.Join(cmd.Path, " "), weightPath)
 	view.identity = appendSearchField(view.identity, cmd.HTTP.PathTemplate, weightPathTemplate)
+	for _, term := range cmd.SearchTerms {
+		view.identity = appendSearchField(view.identity, term, weightText)
+	}
 
 	view.descriptive = appendSearchField(view.descriptive, cmd.Summary, weightText)
 	view.descriptive = appendSearchField(view.descriptive, cmd.Description, weightText)

--- a/pkg/runtime/search_test.go
+++ b/pkg/runtime/search_test.go
@@ -194,3 +194,40 @@ func TestSearchCatalog_IdentityHitSurvivesStrongerDescriptiveMatch(t *testing.T)
 		t.Errorf("query %q returned %v", "revoking", paths)
 	}
 }
+
+func TestSearchCatalog_SearchTermsSurfaceCommand(t *testing.T) {
+	root := newRootWithModuleGroup()
+	mustBuild(t, root, "billing", []CommandSpec{
+		{Group: "Usage", Use: "usage-summary", Short: "Get usage summary", OperationID: "getUsageSummary", Method: "GET", PathTpl: "/usage", SearchTerms: []string{"spend"}},
+		{Group: "Invoices", Use: "list-invoices", Short: "List invoices", OperationID: "listInvoices", Method: "GET", PathTpl: "/invoices"},
+	})
+
+	paths := searchPaths(root, "spend")
+	if len(paths) == 0 || paths[0] != "billing usage usage-summary" {
+		t.Fatalf("query %q = %v, want usage-summary first", "spend", paths)
+	}
+	if slices.Contains(paths, "billing invoices list-invoices") {
+		t.Fatalf("query %q matched unrelated command: %v", "spend", paths)
+	}
+
+	if paths := searchPaths(root, "usage summary"); len(paths) == 0 || paths[0] != "billing usage usage-summary" {
+		t.Fatalf("identity query = %v, want usage-summary first", paths)
+	}
+
+	results := SearchCatalog(root, "usage", SearchOptions{Limit: 10})
+	for _, result := range results {
+		if strings.Join(result.Command.Path, " ") != "billing usage usage-summary" {
+			continue
+		}
+		direct := result.Score
+		synonym := 0
+		for _, r := range SearchCatalog(root, "spend", SearchOptions{Limit: 10}) {
+			if strings.Join(r.Command.Path, " ") == "billing usage usage-summary" {
+				synonym = r.Score
+			}
+		}
+		if synonym <= 0 || synonym >= direct {
+			t.Fatalf("synonym score %d must be positive and below direct identity score %d", synonym, direct)
+		}
+	}
+}

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 15
+const SchemaVersion = 16
 
 type CommandSpec struct {
 	Group           string
@@ -92,8 +92,9 @@ type RequestBody struct {
 	Schema        *SchemaSpec        `json:",omitempty"`
 	RuntimeSchema *RuntimeSchemaSpec `json:",omitempty"`
 
-	Template  string `json:",omitempty"`
-	MergePath string `json:",omitempty"`
+	Template      string   `json:",omitempty"`
+	MergePath     string   `json:",omitempty"`
+	SetOnlyFields []string `json:",omitempty"`
 }
 
 type RuntimeSchemaSpec struct {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 13
+const SchemaVersion = 14
 
 type CommandSpec struct {
 	Group           string
@@ -32,6 +32,7 @@ type CommandSpec struct {
 	Prerequisites   []string        `json:",omitempty"`
 	KnownErrors     []KnownError    `json:",omitempty"`
 	SetContext      *ContextSetHint `json:",omitempty"`
+	Mutation        string          `json:",omitempty"`
 }
 
 type ContextSetHint struct {

--- a/pkg/runtime/spec.go
+++ b/pkg/runtime/spec.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-const SchemaVersion = 14
+const SchemaVersion = 15
 
 type CommandSpec struct {
 	Group           string
@@ -33,6 +33,7 @@ type CommandSpec struct {
 	KnownErrors     []KnownError    `json:",omitempty"`
 	SetContext      *ContextSetHint `json:",omitempty"`
 	Mutation        string          `json:",omitempty"`
+	SearchTerms     []string        `json:",omitempty"`
 }
 
 type ContextSetHint struct {

--- a/pkg/runtime/workflow.go
+++ b/pkg/runtime/workflow.go
@@ -71,14 +71,14 @@ func buildWorkflowCmd(spec WorkflowSpec) *cobra.Command {
 		Args:    UsageArgs(cobra.NoArgs),
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := cmd.ValidateRequiredFlags(); err != nil {
-				return UsageError(cmd, err)
+				return UsageError(cmd, WithUsageDetail(err, requiredFlagsDetail(cmd)))
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			format, _ := cmd.Root().PersistentFlags().GetString("output")
 			if _, ok := formatters[format]; !ok {
-				return UsageError(cmd, fmt.Errorf("unsupported output format"))
+				return UsageError(cmd, WithUsageDetail(fmt.Errorf("unsupported output format"), outputFormatDetail()))
 			}
 			if err := resolveSafeInputFlags(cmd, spec.Params, vals); err != nil {
 				return UsageError(cmd, err)


### PR DESCRIPTION
## Summary

Round 2 of runtime UX contracts for agent-facing generated CLIs, 7 commits:

- `feat(runtime)`: usage errors carry an optional `detail` built only from spec metadata (enum sets, required flag/field names, output formats) via an explicit constructor; never echoes user input; cobra unknown command/flag paths stay detail-free.
- `feat(runtime)`: API errors surface a layered `detail`: declared JSON fields (`message`, `error`, `error.message`, `detail`, depth <= 2, sanitized, <= 240 runes, bodies > 32KB skipped) -> `known_errors` cause matching the status -> unchanged status + hint. Raw response bodies are never emitted.
- `feat(runtime)`: catalog `mutation` follows RFC 9110 method safety (GET/HEAD/OPTIONS/TRACE = `read`, other declared methods = `write`, `unknown` only for undeterminable); overlay `mutation: read|write` overrides every inference.
- `feat(overlay)`: `search_terms` flow overlay -> `CommandSpec` -> generated literal -> catalog -> search index (identity synonym at summary weight) -> generated Skill docs.
- `feat(codegen)`: `body.flags` skips nested object properties instead of rejecting the whole body; skipped fields land in `body.set_only_fields`, `--set/--set-str` help, and keep local required validation.
- `fix(runtime)`: detail sanitization strips all non-graphic runes (C1 controls, bidi overrides); required set-only body fields are validated locally.

## Verification

- `make check` (fmt-check, vet, golangci-lint, tests) — pass
- `go test -race -count=1 ./...` — pass
- `go vet ./...` — pass
- Isolated real-behavior verification: scratch copy of a downstream generated CLI (tokener) with `replace` to this branch, regenerated via `lathe bootstrap`; `__lathe verify --json` 20/20 checks ok; verified enum detail output, declared server message + `known_errors` fallback against a local mock upstream, `mutation` values, `search_terms` hit, and `--name demo --dry-run` producing `{"name":"demo"}` with nested `limits` skipped.

## Compatibility

- `SchemaVersion` 13 -> 16 and `CatalogSchemaVersion` 20 -> 23: downstream CLIs must regenerate after bumping (enforced explicitly by `AssertSchema`).
- Catalog/envelope additions are all optional fields (`error.detail`, `search_terms`, `body.set_only_fields`).
- `mutation` value semantics: operations previously reported `unknown` for REST write methods now report `write`; consumer handling is unchanged, classification is more precise (documented in `docs/contracts.md`).
- Docs updated: `docs/contracts.md`, `docs/cli-usage.md`.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.
