### PR TITLE
fix(runtime): extend usage details to body and catalog discovery errors

### DIFF
--- a/pkg/lathe/catalog.go
+++ b/pkg/lathe/catalog.go
@@ -48,7 +48,10 @@ func commandsShowCmd(m *config.Manifest) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entry, ok := runtime.FindCatalogCommand(cmd.Root(), args, catalogOptions(m, includeHidden))
 			if !ok {
-				return fmt.Errorf("generated command not found: %s", strings.Join(args, " "))
+				return runtime.UsageError(cmd, runtime.WithUsageDetail(
+					fmt.Errorf("generated command not found"),
+					fmt.Sprintf("no generated command at that path; run `%s commands` to list paths", cmd.Root().Name()),
+				))
 			}
 			if jsonOut {
 				return writeJSON(cmd, entry)
@@ -105,6 +108,12 @@ func searchCmd(m *config.Manifest) *cobra.Command {
 		Args:  runtime.UsageArgs(cobra.MinimumNArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query := strings.Join(args, " ")
+			if strings.TrimSpace(query) == "" {
+				return runtime.UsageError(cmd, runtime.WithUsageDetail(
+					fmt.Errorf("empty search query"),
+					"search query must not be empty",
+				))
+			}
 			results := runtime.SearchCatalog(cmd.Root(), query, runtime.SearchOptions{
 				CatalogOptions: catalogOptions(m, false),
 				Limit:          limit,

--- a/pkg/lathe/catalog_test.go
+++ b/pkg/lathe/catalog_test.go
@@ -3,6 +3,7 @@ package lathe
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -231,6 +232,42 @@ func TestSearchExcludesHiddenCommands(t *testing.T) {
 
 func testManifest() *config.Manifest {
 	return &config.Manifest{CLI: config.CLIInfo{Name: "myctl", Short: "test cli", HostEnv: "MYCTL_HOST"}}
+}
+
+func TestCommandsShowUnknownPathUsageError(t *testing.T) {
+	root := NewApp(testManifest())
+	_, err := execute(root, "commands", "show", "keys", "nope-secret")
+	var le *runtime.LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	if le.Code != runtime.CodeUsage {
+		t.Fatalf("code = %q, want %q", le.Code, runtime.CodeUsage)
+	}
+	if !strings.Contains(le.Detail, "no generated command") {
+		t.Fatalf("detail = %q", le.Detail)
+	}
+	if !strings.Contains(le.Detail, "myctl commands") {
+		t.Fatalf("detail missing listing hint: %q", le.Detail)
+	}
+	if strings.Contains(le.Detail, "nope-secret") {
+		t.Fatalf("detail echoed user input: %q", le.Detail)
+	}
+}
+
+func TestSearchEmptyQueryUsageError(t *testing.T) {
+	root := NewApp(testManifest())
+	_, err := execute(root, "search", "  ")
+	var le *runtime.LatheError
+	if !errors.As(err, &le) {
+		t.Fatalf("expected LatheError, got %v", err)
+	}
+	if le.Code != runtime.CodeUsage {
+		t.Fatalf("code = %q, want %q", le.Code, runtime.CodeUsage)
+	}
+	if le.Detail != "search query must not be empty" {
+		t.Fatalf("detail = %q", le.Detail)
+	}
 }
 
 func execute(root *cobra.Command, args ...string) (string, error) {

--- a/pkg/runtime/build_test.go
+++ b/pkg/runtime/build_test.go
@@ -1582,6 +1582,59 @@ func TestBuild_MissingBodyFieldUsageErrorDetail(t *testing.T) {
 	}
 }
 
+func TestBuild_RequiredBodyUsageErrorDetail(t *testing.T) {
+	bindTestManifest(t, "myctl", "MYCTL_HOST")
+	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())
+
+	tests := []struct {
+		name       string
+		params     []ParamSpec
+		wantDetail string
+	}{
+		{
+			name:       "with body flags",
+			params:     []ParamSpec{{Name: "name", Flag: "name", In: InBody, GoType: "string"}},
+			wantDetail: "request body required: pass --file, --set, --set-str, or a body flag",
+		},
+		{
+			name:       "without body flags",
+			wantDetail: "request body required: pass --file, --set, or --set-str",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			specs := []CommandSpec{{
+				Group:       "Keys",
+				Use:         "create",
+				Method:      "POST",
+				PathTpl:     "/keys",
+				Params:      tc.params,
+				RequestBody: &RequestBody{Required: true, MediaType: "application/json"},
+				Security:    &SecurityHint{Public: true},
+			}}
+			root := newRootWithModuleGroup()
+			root.PersistentFlags().String("hostname", "", "")
+			root.PersistentFlags().StringP("output", "o", "table", "")
+			root.SilenceErrors = true
+			root.SilenceUsage = true
+			mustBuild(t, root, "demo", specs)
+			root.SetArgs([]string{"demo", "keys", "create"})
+
+			err := root.Execute()
+			var le *LatheError
+			if !errors.As(err, &le) {
+				t.Fatalf("expected LatheError, got %v", err)
+			}
+			if le.Code != CodeUsage {
+				t.Fatalf("code = %q, want %q", le.Code, CodeUsage)
+			}
+			if le.Detail != tc.wantDetail {
+				t.Fatalf("detail = %q, want %q", le.Detail, tc.wantDetail)
+			}
+		})
+	}
+}
+
 func TestBuild_UnsupportedOutputFormatDetail(t *testing.T) {
 	bindTestManifest(t, "myctl", "MYCTL_HOST")
 	t.Setenv("MYCTL_CONFIG_DIR", t.TempDir())

--- a/pkg/runtime/operation.go
+++ b/pkg/runtime/operation.go
@@ -294,9 +294,9 @@ func resolveOperationBody(s CommandSpec, input OperationInput, form url.Values, 
 			return nil, fmt.Errorf("request body media type %s requires --file", s.RequestBody.MediaType)
 		}
 		if hasJSONBodyFlags(s.Params) {
-			return nil, fmt.Errorf("request body required: pass --file, --set, --set-str, or a body flag")
+			return nil, WithUsageDetail(fmt.Errorf("request body required"), "request body required: pass --file, --set, --set-str, or a body flag")
 		}
-		return nil, fmt.Errorf("request body required: pass --file, --set, or --set-str")
+		return nil, WithUsageDetail(fmt.Errorf("request body required"), "request body required: pass --file, --set, or --set-str")
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary

Two gaps left after #171: a required request body with no body input failed with a bare invalid-command-usage message, and the catalog discovery commands hid their failures — `commands show <unknown path>` returned a generic command-failed error with a misleading local-configuration hint (exit 1), and an empty `search` query exited 0 with no output, indistinguishable from zero matches.

- `resolveOperationBody` required-body errors now carry a typed usage detail naming the accepted body inputs (`--file`, `--set`, `--set-str`, and body flags when present).
- `commands show` with an unknown path is a usage error (exit 2) whose detail points at the `commands` listing without echoing the requested path.
- A blank `search` query fails as a usage error stating the query must not be empty.

All details are static or spec-derived text under the existing `error.detail` contract (docs/contracts.md); no user input is echoed and no contract text changes.

## Verification

- `go test ./pkg/runtime/ -run TestBuild_RequiredBodyUsageErrorDetail` and `go test ./pkg/lathe/ -run 'TestCommandsShowUnknownPathUsageError|TestSearchEmptyQueryUsageError'` — red before the fix, green after.
- `make check` and `go test -race -count=1 ./...` pass.
- Real-CLI probe: tokener built with a local replace shows `Detail: request body required: pass --file, --set, --set-str, or a body flag` for bare `keys create`, `Detail: no generated command at that path; run \`tokener commands\` to list paths` (exit 2) for `commands show keys nope`, and `Detail: search query must not be empty` for `search ""`.

## Compatibility

`commands show` with an unknown path changes from exit 1 (`command failed`) to exit 2 (usage), and a blank `search` query changes from exit 0 to exit 2. Error envelope shape, catalog schema, and the detail contract are unchanged.

## Checklist

- [x] Tests or focused verification cover the changed surface.
- [x] User-facing behavior changes are documented.
- [x] Generated output under `internal/generated/`, `.cache/`, and ad-hoc `skills/<cli-name>/` directories is not committed.
- [x] Commits are signed off when this is ready to merge.